### PR TITLE
Use delay between bytes sent over serial connection

### DIFF
--- a/src/tmodbus/exceptions.py
+++ b/src/tmodbus/exceptions.py
@@ -29,12 +29,12 @@ class InvalidResponseError(TModbusError):
     Raised when received response format is incorrect or unexpected.
     """
 
-    bytes_read: bytes
+    response_bytes: bytes
 
-    def __init__(self, *args: Any, bytes_read: bytes, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, response_bytes: bytes, **kwargs: Any) -> None:
         """Initialize RTUFrameError."""
         super().__init__(*args, **kwargs)
-        self.bytes_read = bytes_read
+        self.response_bytes = response_bytes
 
 
 class RTUFrameError(InvalidResponseError):

--- a/src/tmodbus/exceptions.py
+++ b/src/tmodbus/exceptions.py
@@ -1,30 +1,53 @@
 """Exceptions."""
 
+from typing import Any
+
 from .const import ExceptionCode
 
 
-class ModbusLinkError(Exception):
+class TModbusError(Exception):
     """Base exception class for ModbusLink library."""
 
 
-class ModbusConnectionError(ModbusLinkError):
+class ModbusConnectionError(TModbusError):
     """Connection error exception.
 
     Raised when unable to establish or maintain connection with Modbus device.
     """
 
+    bytes_read: bytes
 
-class CRCError(ModbusLinkError):
-    """CRC validation error exception.
+    def __init__(self, *args: Any, bytes_read: bytes | None = None, **kwargs: Any) -> None:
+        """Initialize RTUFrameError."""
+        super().__init__(*args, **kwargs)
+        self.bytes_read = bytes_read or b""
 
-    Raised when CRC validation of received data frame fails.
-    """
 
-
-class InvalidResponseError(ModbusLinkError):
+class InvalidResponseError(TModbusError):
     """Invalid response error exception.
 
     Raised when received response format is incorrect or unexpected.
+    """
+
+    bytes_read: bytes
+
+    def __init__(self, *args: Any, bytes_read: bytes, **kwargs: Any) -> None:
+        """Initialize RTUFrameError."""
+        super().__init__(*args, **kwargs)
+        self.bytes_read = bytes_read
+
+
+class RTUFrameError(InvalidResponseError):
+    """RTU frame error exception.
+
+    Raised when there is a framing error in the received RTU frame.
+    """
+
+
+class CRCError(InvalidResponseError):
+    """CRC validation error exception.
+
+    Raised when CRC validation of received data frame fails.
     """
 
 
@@ -42,7 +65,7 @@ class FunctionCodeError(InvalidResponseError):
     """
 
 
-class ModbusResponseError(ModbusLinkError):
+class ModbusResponseError(TModbusError):
     """Base class for all Modbus exception response."""
 
     error_code: int

--- a/src/tmodbus/pdu/coils.py
+++ b/src/tmodbus/pdu/coils.py
@@ -59,19 +59,19 @@ class ReadCoilsPDU(BaseModbusPDU):
             function_code, byte_count = struct.unpack_from(">BB", response)
         except struct.error as e:
             msg = "Expected response to start with function code and byte count"
-            raise InvalidResponseError(msg) from e
+            raise InvalidResponseError(msg, response_bytes=response) from e
 
         if function_code != self.function_code:
             msg = f"Invalid function code: expected {self.function_code:02x}, received {function_code:02x}"
-            raise InvalidResponseError(msg)
+            raise InvalidResponseError(msg, response_bytes=response)
 
         if len(response) != 2 + byte_count:
             msg = f"Invalid response PDU length: expected {2 + byte_count}, got {len(response)}"
-            raise InvalidResponseError(msg)
+            raise InvalidResponseError(msg, response_bytes=response)
 
         if byte_count != (self.quantity + 7) // 8:
             msg = f"Invalid byte count: expected {(self.quantity + 7) // 8}, got {byte_count}"
-            raise InvalidResponseError(msg)
+            raise InvalidResponseError(msg, response_bytes=response)
 
         coils: list[bool] = []
         for byte in response[2:]:
@@ -126,7 +126,7 @@ class WriteSingleCoilPDU(BaseModbusPDU):
         """
         if response != self.encode_request():
             msg = "Expected response to match request"
-            raise InvalidResponseError(msg)
+            raise InvalidResponseError(msg, response_bytes=response)
 
 
 class WriteMultipleCoilsPDU(BaseModbusPDU):
@@ -199,4 +199,4 @@ class WriteMultipleCoilsPDU(BaseModbusPDU):
 
         if response != expected_response:
             msg = "Device response does not match request"
-            raise InvalidResponseError(msg)
+            raise InvalidResponseError(msg, response_bytes=response)

--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -59,19 +59,19 @@ class RawReadHoldingRegistersPDU(BaseModbusPDU):
             function_code, byte_count = struct.unpack_from(">BB", response)
         except struct.error as e:
             msg = "Expected response to start with function code and byte count"
-            raise InvalidResponseError(msg) from e
+            raise InvalidResponseError(msg, response_bytes=response) from e
 
         if function_code != self.function_code:
             msg = f"Invalid function code: expected {self.function_code:02x}, received {function_code:02x}"
-            raise InvalidResponseError(msg)
+            raise InvalidResponseError(msg, response_bytes=response)
 
         if len(response) != 2 + byte_count:
             msg = f"Invalid response PDU length: expected {2 + byte_count}, got {len(response)}"
-            raise InvalidResponseError(msg)
+            raise InvalidResponseError(msg, response_bytes=response)
 
         if byte_count // 2 != self.quantity:
             msg = f"Invalid register count: expected {self.quantity}, got {byte_count // 2}"
-            raise InvalidResponseError(msg)
+            raise InvalidResponseError(msg, response_bytes=response)
 
         return response[2:]  # Return the data part of the response
 
@@ -178,7 +178,7 @@ class WriteSingleRegisterPDU(BaseModbusPDU):
         """
         if response != self.encode_request():
             msg = "Expected response to match request"
-            raise InvalidResponseError(msg)
+            raise InvalidResponseError(msg, response_bytes=response)
 
 
 class RawWriteMultipleRegistersPDU(BaseModbusPDU):
@@ -256,7 +256,7 @@ class RawWriteMultipleRegistersPDU(BaseModbusPDU):
 
         if response != expected_response:
             msg = "Device response does not match request"
-            raise InvalidResponseError(msg)
+            raise InvalidResponseError(msg, response_bytes=response)
 
 
 class WriteMultipleRegistersPDU(BaseModbusPDU):

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -15,6 +15,7 @@ from tmodbus.exceptions import (
     InvalidResponseError,
     ModbusConnectionError,
     ModbusResponseError,
+    RTUFrameError,
     error_code_to_exception_map,
 )
 from tmodbus.pdu import BaseModbusPDU, get_pdu_class
@@ -49,16 +50,18 @@ MAX_RTU_FRAME_SIZE = 256  # Maximum RTU frame size in bytes
 
 MIN_RTU_RESPONSE_LENGTH = 4  # a minimal response is: address + function code + CRC
 
-def compute_interframe_delay(baudrate: int) -> float:
-    """
-    Compute the Modbus RTU 3.5 character times (inter-frame delay) in seconds.
+BITS_PER_CHAR = 11  # start + 8 data + parity/stop
+
+
+def compute_interframe_delay(one_char_send_duration: float) -> float:
+    """Compute the Modbus RTU 3.5 character times (inter-frame delay) in seconds.
+
     For baudrate >= 19200, use 1.75ms.
     For baudrate < 19200, use 3.5 * (11 bits / baudrate).
     """
-    if baudrate >= 19200:
-        return 0.00175  # 1.75 ms
-    bits_per_char = 11  # start + 8 data + parity/stop
-    return 3.5 * bits_per_char / baudrate
+    interframe_delay = 3.5 * one_char_send_duration
+
+    return max(interframe_delay, 0.00175)  # Ensure at least 1.75 ms for faster baud rates
 
 
 class AsyncRtuTransport(AsyncBaseTransport):
@@ -73,9 +76,8 @@ class AsyncRtuTransport(AsyncBaseTransport):
 
     _reader: asyncio.StreamReader | None = None
     _writer: asyncio.StreamWriter | None = None
-    _next_transaction_id: int = 1
-
-    _communication_lock = asyncio.Lock()  # Prevents concurrent access to the transport layer
+    _last_frame_end: float = 0.0
+    _communication_lock: asyncio.Lock  # Prevents concurrent access to the transport layer
 
     pyserial_options: PySerialOptions
 
@@ -100,8 +102,10 @@ class AsyncRtuTransport(AsyncBaseTransport):
         self.pyserial_options = pyserial_options
         self.timeout = pyserial_options.get("timeout", DEFAULT_TIMEOUT)
         self._baudrate = pyserial_options.get("baudrate", 9600)
-        self._interframe_delay = compute_interframe_delay(self._baudrate)
-        self._last_frame_end: float = 0.0
+        self._one_char_send_duration = BITS_PER_CHAR / self._baudrate
+        self._interframe_delay = compute_interframe_delay(self._one_char_send_duration)
+
+        self._communication_lock = asyncio.Lock()
 
     async def open(self) -> None:
         """Establish Serial connection."""
@@ -175,8 +179,7 @@ class AsyncRtuTransport(AsyncBaseTransport):
             raw_traffic_logger.debug("RTU Send: %s", _format_bytes(request_adu))
 
             # 2. Wait for 3.5 character times since last frame (inter-frame delay)
-            now = time.monotonic()
-            time_since_last_frame = now - self._last_frame_end
+            time_since_last_frame = time.monotonic() - self._last_frame_end
             if time_since_last_frame < self._interframe_delay:
                 to_wait = self._interframe_delay - time_since_last_frame
                 logger.debug("Waiting for inter-frame delay: %.4fs", to_wait)
@@ -188,20 +191,24 @@ class AsyncRtuTransport(AsyncBaseTransport):
                 raise ModbusConnectionError(msg)
             self._writer.write(request_adu)
             await asyncio.wait_for(self._writer.drain(), timeout=self.timeout)
-
             # 4. Receive response
-            response_adu = await self._receive_response()
 
-            raw_traffic_logger.debug("RTU Receive: %s", _format_bytes(response_adu))
+            try:
+                response_adu = await self._receive_response()
+            except (RTUFrameError, ModbusConnectionError) as e:
+                raw_traffic_logger.debug("RTU Receive: %s [!]", _format_bytes(e.bytes_read))
+                raise
+            else:
+                raw_traffic_logger.debug("RTU Receive: %s", _format_bytes(response_adu))
 
             # 5. Validate CRC
             if not CRC16Modbus.validate(response_adu):
-                raise CRCError
+                raise CRCError(bytes_read=response_adu)
 
             # 6. Validate slave address
             if response_adu[0] != unit_id:
                 msg = f"Slave address mismatch: expected {unit_id}, received {response_adu[0]}"
-                raise InvalidResponseError(msg)
+                raise InvalidResponseError(msg, bytes_read=response_adu)
 
             response_pdu = response_adu[1:-2]  # remove address and CRC
 
@@ -216,13 +223,51 @@ class AsyncRtuTransport(AsyncBaseTransport):
 
             if response_function_code != pdu.function_code:
                 msg = f"Function code mismatch: expected {pdu.function_code}, received {response_function_code}"
-                raise InvalidResponseError(msg)
+                raise InvalidResponseError(msg, bytes_read=response_adu)
 
             # 8. Mark the end of this frame
             self._last_frame_end = time.monotonic()
 
             # 9. Return PDU part (remove address and CRC)
             return pdu.decode_response(response_pdu)
+
+    async def _read_with_interframe_timeout(self, bytes_to_read: int) -> bytes:
+        """Read the rest of an RTU frame.
+
+        We assume that this function has been called after the initial header of the RTU frame
+        has been received and processed.
+        """
+        if not self._reader:
+            msg = "Cannot read as connection is closed."
+            raise ModbusConnectionError(msg)
+
+        buf = bytearray()
+
+        # Read the rest of the bytes to read
+        while len(buf) < bytes_to_read:
+            try:
+                chunk = await asyncio.wait_for(self._reader.read(1), timeout=self._interframe_delay)
+            except TimeoutError:
+                msg = (
+                    "Saw an RTU interframe delay while we were waiting to read the complete frame. "
+                    f"Missing {bytes_to_read - len(buf)} bytes."
+                )
+                raise RTUFrameError(msg, bytes_read=buf) from None
+            else:
+                if not chunk:
+                    msg = "Serial port closed unexpectedly during response read."
+                    raise ModbusConnectionError(msg, bytes_read=buf)
+                buf.extend(chunk)
+
+        # If we have read more data than expected, it indicates a framing or out-of-sync error.
+        if len(buf) > bytes_to_read:
+            msg = (
+                "Received more data than expected while reading RTU frame. "
+                f"Got {len(buf) - bytes_to_read} bytes more than expected."
+            )
+            raise RTUFrameError(msg, bytes_read=buf)
+
+        return bytes(buf)
 
     async def _receive_response(self) -> bytes:
         """Receive complete response frame, using 3.5 character time as end-of-frame marker."""
@@ -236,50 +281,32 @@ class AsyncRtuTransport(AsyncBaseTransport):
                 self._reader.readexactly(MIN_RTU_RESPONSE_LENGTH),
                 timeout=self.timeout,
             )
-
-            # Step 2: Check if it's an exception response
-            if response_begin[1] & 0x80:  # Exception response
-                # Exception response format: address + exception function code + exception code + CRC (total 5 bytes)
-                return response_begin + await asyncio.wait_for(
-                    self._reader.readexactly(5 - MIN_RTU_RESPONSE_LENGTH),  # we need only 1 more byte
-                    timeout=self.timeout,
-                )  # Exception code + CRC
-
-            # Step 3: Normal response format: address + function code + data + CRC
-            expected_data_length = get_pdu_class(response_begin[1]).get_expected_data_length(response_begin[2:])
-
-            # Step 4: Read the remaining data and CRC
-            remaining = await asyncio.wait_for(
-                self._reader.readexactly(expected_data_length),
-                timeout=self.timeout,
-            )
-            full_response = response_begin + remaining
-
-            # Step 5: Wait for 3.5 character times to ensure no more data is incoming ("end of frame")
-            await self._wait_interframe_silence()
-
-            # If more data is available after inter-frame delay, it may indicate a framing or out-of-sync error.
-            # Optionally, drain extra data here or log a warning.
-
-            self._last_frame_end = time.monotonic()
-            return full_response
-
         except asyncio.IncompleteReadError as e:
-            msg = "Received incomplete data"
-            raise ModbusConnectionError(msg) from e
+            msg = "Received incomplete data while reading first part of RTU frame."
+            raise RTUFrameError(msg, bytes_read=e.partial) from e
         except TimeoutError:
             raise
         except Exception as e:
             msg = "Failed to read Modbus response"
             raise ModbusConnectionError(msg) from e
 
-    async def _wait_interframe_silence(self) -> None:
-        """
-        Wait for 3.5 character times of silence on the serial line.
-        This is used to detect the end of a Modbus RTU frame.
-        """
-        # For most asyncio serial implementations, we cannot directly check for "silence", so we sleep for the interval,
-        # then check if any data is available (if so, log or handle as appropriate).
-        await asyncio.sleep(self._interframe_delay)
-        # Optionally, we could try to read without blocking, but StreamReader has no non-blocking .read().
-        # If you have access to the underlying transport, you could check if data is waiting.
+        # Step 2: Determine the total expected data length for this frame
+        if response_begin[1] & 0x80:  # Exception response
+            # Exception response format: address + exception function code + exception code + CRC (total 5 bytes)
+            expected_data_length = 5
+        else:
+            expected_data_length = 5 + get_pdu_class(response_begin[1]).get_expected_data_length(response_begin[2:])
+
+        # Step 3: Read the remaining data and CRC
+        try:
+            remaining_response_bytes = await self._read_with_interframe_timeout(expected_data_length)
+        except RTUFrameError as e:
+            # make sure to also pass the bytes we read at the beginning of the response in the error
+            raise RTUFrameError(str(e), bytes_read=response_begin + e.bytes_read) from e
+        except ModbusConnectionError as e:
+            # make sure to also pass the bytes we read at the beginning of the response in the error
+            raise ModbusConnectionError(str(e), bytes_read=response_begin + e.bytes_read) from e
+
+        # log the current time to allow us to determine the 3.5 character gap before the next frame
+        self._last_frame_end = time.monotonic()
+        return response_begin + remaining_response_bytes

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -5,6 +5,7 @@ Implements async Modbus TCP protocol transport based on asyncio, including MBAP 
 
 import asyncio
 import logging
+import time
 from typing import TypedDict, TypeVar, Unpack
 
 import serial_asyncio
@@ -48,6 +49,17 @@ MAX_RTU_FRAME_SIZE = 256  # Maximum RTU frame size in bytes
 
 MIN_RTU_RESPONSE_LENGTH = 4  # a minimal response is: address + function code + CRC
 
+def compute_interframe_delay(baudrate: int) -> float:
+    """
+    Compute the Modbus RTU 3.5 character times (inter-frame delay) in seconds.
+    For baudrate >= 19200, use 1.75ms.
+    For baudrate < 19200, use 3.5 * (11 bits / baudrate).
+    """
+    if baudrate >= 19200:
+        return 0.00175  # 1.75 ms
+    bits_per_char = 11  # start + 8 data + parity/stop
+    return 3.5 * bits_per_char / baudrate
+
 
 class AsyncRtuTransport(AsyncBaseTransport):
     """Async Modbus Serial Transport Layer Implementation.
@@ -87,6 +99,9 @@ class AsyncRtuTransport(AsyncBaseTransport):
         self.port = port
         self.pyserial_options = pyserial_options
         self.timeout = pyserial_options.get("timeout", DEFAULT_TIMEOUT)
+        self._baudrate = pyserial_options.get("baudrate", 9600)
+        self._interframe_delay = compute_interframe_delay(self._baudrate)
+        self._last_frame_end: float = 0.0
 
     async def open(self) -> None:
         """Establish Serial connection."""
@@ -140,10 +155,11 @@ class AsyncRtuTransport(AsyncBaseTransport):
 
         Implements complete RTU protocol communication flow:
         1. Build ADU (Address + PDU + CRC)
-        2. Send request
-        3. Receive response
-        4. Validate CRC
-        5. Return response PDU
+        2. Wait for inter-frame delay
+        3. Send request
+        4. Receive response
+        5. Validate CRC
+        6. Return response PDU
         """
         async with self._communication_lock:
             if not self.is_open():
@@ -158,31 +174,39 @@ class AsyncRtuTransport(AsyncBaseTransport):
 
             raw_traffic_logger.debug("RTU Send: %s", _format_bytes(request_adu))
 
-            # 2. Clear receive buffer and send request
+            # 2. Wait for 3.5 character times since last frame (inter-frame delay)
+            now = time.monotonic()
+            time_since_last_frame = now - self._last_frame_end
+            if time_since_last_frame < self._interframe_delay:
+                to_wait = self._interframe_delay - time_since_last_frame
+                logger.debug("Waiting for inter-frame delay: %.4fs", to_wait)
+                await asyncio.sleep(to_wait)
+
+            # 3. Clear receive buffer and send request
             if not self._writer:
                 msg = "Connection not established."
                 raise ModbusConnectionError(msg)
             self._writer.write(request_adu)
             await asyncio.wait_for(self._writer.drain(), timeout=self.timeout)
 
-            # 3. Receive response
+            # 4. Receive response
             response_adu = await self._receive_response()
 
             raw_traffic_logger.debug("RTU Receive: %s", _format_bytes(response_adu))
 
-            # 4. Validate CRC
+            # 5. Validate CRC
             if not CRC16Modbus.validate(response_adu):
                 raise CRCError
 
-            # 5. Validate slave address
+            # 6. Validate slave address
             if response_adu[0] != unit_id:
                 msg = f"Slave address mismatch: expected {unit_id}, received {response_adu[0]}"
                 raise InvalidResponseError(msg)
 
             response_pdu = response_adu[1:-2]  # remove address and CRC
 
-            # 6. Check if it's an exception response
-            response_function_code = response_adu[0]
+            # 7. Check if it's an exception response
+            response_function_code = response_adu[1]
             if response_function_code & 0x80:  # Exception response
                 function_code = response_function_code & 0x7F  # Remove exception flag bit
                 exception_code = response_pdu[1] if len(response_pdu) > 1 else 0
@@ -194,42 +218,51 @@ class AsyncRtuTransport(AsyncBaseTransport):
                 msg = f"Function code mismatch: expected {pdu.function_code}, received {response_function_code}"
                 raise InvalidResponseError(msg)
 
-            # 7. Return PDU part (remove address and CRC)
+            # 8. Mark the end of this frame
+            self._last_frame_end = time.monotonic()
+
+            # 9. Return PDU part (remove address and CRC)
             return pdu.decode_response(response_pdu)
 
     async def _receive_response(self) -> bytes:
-        """Receive complete response frame."""
+        """Receive complete response frame, using 3.5 character time as end-of-frame marker."""
         if not self._reader:
             msg = "Serial connection not established."
             raise ModbusConnectionError(msg)
 
         try:
+            # Step 1: Read minimal header
             response_begin: bytes = await asyncio.wait_for(
                 self._reader.readexactly(MIN_RTU_RESPONSE_LENGTH),
                 timeout=self.timeout,
             )
 
-            #  Check if it's an exception response
-            if response_begin[1] & 0x80:  #  Exception response
+            # Step 2: Check if it's an exception response
+            if response_begin[1] & 0x80:  # Exception response
                 # Exception response format: address + exception function code + exception code + CRC (total 5 bytes)
-
                 return response_begin + await asyncio.wait_for(
                     self._reader.readexactly(5 - MIN_RTU_RESPONSE_LENGTH),  # we need only 1 more byte
                     timeout=self.timeout,
                 )  # Exception code + CRC
 
-            # Normal response format: address + function code + data + CRC
-
-            # figure out how many more bytes to read
+            # Step 3: Normal response format: address + function code + data + CRC
             expected_data_length = get_pdu_class(response_begin[1]).get_expected_data_length(response_begin[2:])
 
-            # we already read the minimal response length (taking into account address, function code, and CRC)
-            # now we only need to read the length of the data part too
-
-            return response_begin + await asyncio.wait_for(
+            # Step 4: Read the remaining data and CRC
+            remaining = await asyncio.wait_for(
                 self._reader.readexactly(expected_data_length),
                 timeout=self.timeout,
             )
+            full_response = response_begin + remaining
+
+            # Step 5: Wait for 3.5 character times to ensure no more data is incoming ("end of frame")
+            await self._wait_interframe_silence()
+
+            # If more data is available after inter-frame delay, it may indicate a framing or out-of-sync error.
+            # Optionally, drain extra data here or log a warning.
+
+            self._last_frame_end = time.monotonic()
+            return full_response
 
         except asyncio.IncompleteReadError as e:
             msg = "Received incomplete data"
@@ -239,3 +272,14 @@ class AsyncRtuTransport(AsyncBaseTransport):
         except Exception as e:
             msg = "Failed to read Modbus response"
             raise ModbusConnectionError(msg) from e
+
+    async def _wait_interframe_silence(self) -> None:
+        """
+        Wait for 3.5 character times of silence on the serial line.
+        This is used to detect the end of a Modbus RTU frame.
+        """
+        # For most asyncio serial implementations, we cannot directly check for "silence", so we sleep for the interval,
+        # then check if any data is available (if so, log or handle as appropriate).
+        await asyncio.sleep(self._interframe_delay)
+        # Optionally, we could try to read without blocking, but StreamReader has no non-blocking .read().
+        # If you have access to the underlying transport, you could check if data is waiting.

--- a/src/tmodbus/transport/async_tcp.py
+++ b/src/tmodbus/transport/async_tcp.py
@@ -184,21 +184,21 @@ class AsyncTcpTransport(AsyncBaseTransport):
                     f" Transaction ID mismatch: expected {current_transaction_id:02x}, "
                     f"received {response_transaction_id:02x}"
                 )
-                raise InvalidResponseError(msg, bytes_read=response_mbap)
+                raise InvalidResponseError(msg, response_bytes=response_mbap)
 
             if response_protocol_id != 0x0000:
                 msg = f"Invalid Protocol ID: expected 0x0000, received 0x{response_protocol_id:04x}"
-                raise InvalidResponseError(msg, bytes_read=response_mbap)
+                raise InvalidResponseError(msg, response_bytes=response_mbap)
 
             if response_unit_id != unit_id:
                 msg = f"Unit ID mismatch: expected {unit_id:02x}, received {response_unit_id:02x}"
-                raise InvalidResponseError(msg, bytes_read=response_mbap)
+                raise InvalidResponseError(msg, response_bytes=response_mbap)
 
             # 7. Async receive response PDU
             pdu_length = response_length - 1  # Subtract 1 byte for Unit ID
             if pdu_length <= 0:
                 msg = f"Invalid PDU length: {pdu_length}"
-                raise InvalidResponseError(msg, bytes_read=response_mbap)
+                raise InvalidResponseError(msg, response_bytes=response_mbap)
 
             try:
                 response_pdu_bytes = await self._receive_exact(pdu_length)


### PR DESCRIPTION
Properly account for 3.5 characters delay between RTU frames and a maximum of 1.5 character delay when receiving a response.