### PR TITLE
Fix: make serialization lock per connection

### DIFF
--- a/src/tmodbus/transport/async_smart.py
+++ b/src/tmodbus/transport/async_smart.py
@@ -67,9 +67,9 @@ class AsyncSmartTransport(AsyncBaseTransport):
     and automatic reconnection on connection loss.
     """
 
-    _communication_lock: asyncio.Lock = asyncio.Lock()
-    _should_be_connected: bool = False
-    _must_reconnect: bool = False
+    _communication_lock: asyncio.Lock
+    _should_be_connected: bool
+    _must_reconnect: bool
 
     auto_reconnect: AsyncRetrying | None = None
     response_retry_strategy: AsyncRetrying
@@ -103,6 +103,10 @@ class AsyncSmartTransport(AsyncBaseTransport):
 
         """
         self.base_transport = base_transport
+        self._communication_lock = asyncio.Lock()
+        self._should_be_connected = False
+        self._must_reconnect = False
+
         if wait_between_requests < 0:
             msg = "wait_between_requests must be a positive value"
             raise ValueError(msg)

--- a/tests/transport/test_async_smart.py
+++ b/tests/transport/test_async_smart.py
@@ -50,12 +50,20 @@ def test_on_reconnected_requires_auto_reconnect(base_transport_mock: AsyncBaseTr
         AsyncSmartTransport(base_transport_mock, auto_reconnect=False, on_reconnected=lambda: None)
 
 
-def test_init_creates_instance_communication_lock(base_transport_mock: AsyncBaseTransport) -> None:
-    """Test that each transport instance has its own communication lock."""
+def test_init_creates_instance_communication_state(base_transport_mock: AsyncBaseTransport) -> None:
+    """Test that each transport instance has its own communication state."""
     t1 = AsyncSmartTransport(base_transport_mock)
     t2 = AsyncSmartTransport(base_transport_mock)
 
     assert t1._communication_lock is not t2._communication_lock
+    assert "_communication_lock" in t1.__dict__
+    assert "_should_be_connected" in t1.__dict__
+    assert "_must_reconnect" in t1.__dict__
+
+    t1._should_be_connected = True
+    t1._must_reconnect = True
+    assert not t2._should_be_connected
+    assert not t2._must_reconnect
 
 
 async def test_open_waits_after_connect(base_transport_mock: MagicMock) -> None:

--- a/tests/transport/test_async_smart.py
+++ b/tests/transport/test_async_smart.py
@@ -50,6 +50,14 @@ def test_on_reconnected_requires_auto_reconnect(base_transport_mock: AsyncBaseTr
         AsyncSmartTransport(base_transport_mock, auto_reconnect=False, on_reconnected=lambda: None)
 
 
+def test_init_creates_instance_communication_lock(base_transport_mock: AsyncBaseTransport) -> None:
+    """Test that each transport instance has its own communication lock."""
+    t1 = AsyncSmartTransport(base_transport_mock)
+    t2 = AsyncSmartTransport(base_transport_mock)
+
+    assert t1._communication_lock is not t2._communication_lock
+
+
 async def test_open_waits_after_connect(base_transport_mock: MagicMock) -> None:
     """Test that open waits after connecting if configured."""
     t = AsyncSmartTransport(base_transport_mock, wait_after_connect=0.05)


### PR DESCRIPTION
# Proposed Changes

We now limit to 1 command per connection, instead of 1 command per any instance of the connection class.

## Related Issues

Fixes https://github.com/wlcrs/tmodbus/issues/2