### PR TITLE
Fix RTU response length for RawWriteMultipleRegistersPDU

### DIFF
--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -324,7 +324,7 @@ class RawWriteMultipleRegistersPDU(BasePDU[int]):
     """Write Multiple Registers PDU."""
 
     function_code = FunctionCode.WRITE_MULTIPLE_REGISTERS
-    rtu_response_data_length = 5
+    rtu_response_data_length = 4  # address (2) + quantity (2)
 
     def __init__(self, start_address: int, content: bytes) -> None:
         """Initialize Write Multiple Registers PDU.

--- a/tests/pdu/test_holding_registers.py
+++ b/tests/pdu/test_holding_registers.py
@@ -424,7 +424,15 @@ class TestRawWriteMultipleRegistersPDU:
 
     def test_rtu_response_data_length(self) -> None:
         """Test RTU response data length constant."""
-        assert RawWriteMultipleRegistersPDU.rtu_response_data_length == 5
+        # Response data part is start address (2) + quantity (2) = 4 bytes,
+        # matching the response format produced by encode_response.
+        assert RawWriteMultipleRegistersPDU.rtu_response_data_length == 4
+
+        # The constant must match the actual response length so the RTU transport
+        # frames the response correctly (everything after the function code, minus CRC).
+        pdu = RawWriteMultipleRegistersPDU(start_address=0x1000, content=b"\x12\x34\x56\x78")
+        response = pdu.encode_response(2)
+        assert pdu.get_expected_response_data_length(response[1:]) == len(response) - 1
 
 
 # ============================================================================


### PR DESCRIPTION
# Proposed Changes

The Write Multiple Registers response (function code `0x10`) has a data part of start address (2 bytes) plus quantity written (2 bytes), so `rtu_response_data_length` should be `4`. `RawWriteMultipleRegistersPDU` set it to `5`.

Over RTU and RTU-over-TCP the transport derives the expected frame length from this constant. With `5` it expected `1 + 1 + 5 + 2 = 9` bytes for a response that is only `8` bytes long, so it kept waiting for a byte that never arrived and eventually failed with a timeout.

`RawWriteMultipleRegistersPDU` is the PDU used by all typed struct write helpers (`write_uint32`, `write_float`, `write_string`, `write_struct_format`), so those writes were broken on the serial RTU transport. The sibling `WriteMultipleRegistersPDU` already used the correct value `4`.

This corrects the constant, updates the test that asserted the wrong value, and adds an assertion tying the constant to the actual length returned by `encode_response`.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
