### PR TITLE
Remove unused _on_con_lost future from ModbusTcpProtocol

### DIFF
--- a/src/tmodbus/transport/async_tcp.py
+++ b/src/tmodbus/transport/async_tcp.py
@@ -169,7 +169,6 @@ class ModbusTcpProtocol(asyncio.Protocol):
     on_connection_lost: Callable[[Exception | None], None]
     timeout: float
 
-    _on_con_lost: asyncio.Future[Exception | None]
     _buffer: bytearray
     _next_transaction_id: int
     _transaction_id_lock: asyncio.Lock
@@ -188,7 +187,6 @@ class ModbusTcpProtocol(asyncio.Protocol):
         self.on_connection_lost = on_connection_lost
         self.timeout = timeout
 
-        self._on_con_lost = asyncio.get_event_loop().create_future()
         self._buffer = bytearray()
         self._next_transaction_id = 1
         self._transaction_id_lock = asyncio.Lock()


### PR DESCRIPTION
# Proposed Changes

`ModbusTcpProtocol` created a `_on_con_lost` future for every connection, but it was never awaited, resolved, or read anywhere. Connection loss is handled through the `on_connection_lost` callback (see `connection_lost`). This removes the dead attribute.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
