### PR TITLE
Speed up CRC16 with a precomputed lookup table

### DIFF
--- a/src/tmodbus/utils/crc.py
+++ b/src/tmodbus/utils/crc.py
@@ -6,6 +6,24 @@ Uses polynomial 0xA001 (reverse of 0x8005).
 """
 
 
+def _build_crc16_table() -> tuple[int, ...]:
+    """Precompute the CRC16 lookup table for polynomial 0xA001.
+
+    Each entry holds the CRC contribution of a single input byte, so the main
+    loop can process a byte at a time instead of bit by bit.
+    """
+    table = []
+    for byte in range(256):
+        crc = byte
+        for _ in range(8):
+            crc = (crc >> 1) ^ 0xA001 if crc & 0x0001 else crc >> 1
+        table.append(crc)
+    return tuple(table)
+
+
+_CRC16_TABLE = _build_crc16_table()
+
+
 def calculate_crc16(data: bytes) -> bytes:
     r"""Calculate CRC16 Checksum.
 
@@ -21,16 +39,11 @@ def calculate_crc16(data: bytes) -> bytes:
         '840a'
 
     """
-    crc = 0xFFFF  #  Initial value is 0xFFFF
+    crc = 0xFFFF  # Initial value is 0xFFFF
 
     for byte in data:
-        crc ^= byte  #  XOR operation
-        for _ in range(8):  #  Process 8 bits
-            if crc & 0x0001:  #  Check lowest bit
-                crc >>= 1  #  Right shift by one bit
-                crc ^= 0xA001  #  XOR with polynomial
-            else:
-                crc >>= 1  #  Right shift by one bit
+        # Table-driven: fold one byte at a time using the precomputed table.
+        crc = (crc >> 8) ^ _CRC16_TABLE[(crc ^ byte) & 0xFF]
 
     # Return 2-byte CRC in little-endian format
     return crc.to_bytes(2, byteorder="little")

--- a/tests/utils/test_crc.py
+++ b/tests/utils/test_crc.py
@@ -1,12 +1,39 @@
 """Tests for tmodbus/utils/crc.py ."""
 
+import pytest
 from tmodbus.utils.crc import calculate_crc16, validate_crc16
+
+
+def _reference_crc16(data: bytes) -> bytes:
+    """Independent bit-by-bit CRC16 reference for polynomial 0xA001."""
+    crc = 0xFFFF
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            crc = (crc >> 1) ^ 0xA001 if crc & 0x0001 else crc >> 1
+    return crc.to_bytes(2, byteorder="little")
 
 
 def test_calculate_crc() -> None:
     """Test combined compute/check CRC."""
     data = b"\x12\x34\x23\x45\x34\x56\x45\x67"
     assert calculate_crc16(data) == bytearray.fromhex("E2 DB")
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"",
+        b"\x00",
+        b"\xff",
+        b"\x01\x03\x00\x00\x00\x01",
+        bytes(range(256)),
+        b"\xff" * 256,
+    ],
+)
+def test_calculate_crc_matches_reference(data: bytes) -> None:
+    """The table-driven implementation must match a bit-by-bit reference."""
+    assert calculate_crc16(data) == _reference_crc16(data)
 
 
 def test_validate_crc() -> None:


### PR DESCRIPTION
# Proposed Changes

`calculate_crc16` computed the CRC with a bit-by-bit inner loop: for every byte it iterated 8 times doing a shift and a conditional xor. The CRC is computed on every RTU and RTU-over-TCP frame that is sent, and validated on every frame received, so for serial polling workloads this loop is squarely on the hot path.

This replaces the inner bit loop with a precomputed 256-entry lookup table (polynomial `0xA001`) that folds one byte at a time. The output is identical for every input, since the table is derived from the same polynomial, and a new test pins the table-driven result to an independent bit-by-bit reference across edge and full-range inputs.

## Performance

Measured with `timeit` on CPython 3.14 (microseconds per call, lower is better):

| Frame size | Before (bit loop) | After (table) | Speedup |
| ---------- | ----------------- | ------------- | ------- |
| 8 bytes    | 3.68 us           | 0.59 us       | 6.2x    |
| 64 bytes   | 29.67 us          | 3.56 us       | 8.3x    |
| 256 bytes  | 117.07 us         | 13.95 us      | 8.4x    |

Methodology: I profiled the test suite with both cProfile and py-spy first, which (as expected) showed the suite is dominated by pytest and asyncio overhead with effectively no time in library code. Switching to a microbenchmark of the actual hot path made the cost visible. The flamegraph below is a py-spy capture of a CRC-heavy loop on the old bit-by-bit implementation (12k samples), where the inner loop accounts for essentially all of the time. The lookup table removes that inner loop.

![CRC16 bit-by-bit flamegraph](https://gist.githubusercontent.com/frenck/34d7e0ad6eeeb80b44030df218719d7c/raw/crc16-bitwise-flamegraph.svg)

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
