### PR TITLE
Speed up LRC with a single sum instead of a byte loop

### DIFF
--- a/src/tmodbus/utils/lrc.py
+++ b/src/tmodbus/utils/lrc.py
@@ -3,11 +3,9 @@
 
 def calculate_lrc(data: bytes) -> int:
     """Use to compute the longitudinal redundancy check against a string."""
-    lrc = 0
-    for byte in data:
-        lrc = (lrc + byte) & 0xFF
-
-    return ((lrc ^ 0xFF) + 1) & 0xFF
+    # The LRC is the two's complement of the 8-bit sum of all bytes. Letting the
+    # C-level sum() add everything up first is a lot faster than a Python loop.
+    return (-sum(data)) & 0xFF
 
 
 def validate_lrc(data: bytes, check: int) -> bool:

--- a/tests/utils/test_lrc.py
+++ b/tests/utils/test_lrc.py
@@ -1,6 +1,31 @@
 """Tests for tmodbus/utils/lrc.py."""
 
+import pytest
 from tmodbus.utils.lrc import calculate_lrc, validate_lrc
+
+
+def _reference_lrc(data: bytes) -> int:
+    """Independent accumulator-based LRC reference."""
+    lrc = 0
+    for byte in data:
+        lrc = (lrc + byte) & 0xFF
+    return ((lrc ^ 0xFF) + 1) & 0xFF
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"",
+        b"\x00",
+        b"\xff",
+        b"\x01\x03\x00\x00\x00\x64",
+        bytes(range(256)),
+        b"\xff" * 256,
+    ],
+)
+def test_calculate_lrc_matches_reference(data: bytes) -> None:
+    """The optimized implementation must match an accumulator-based reference."""
+    assert calculate_lrc(data) == _reference_lrc(data)
 
 
 def test_calculate_lrc_simple() -> None:


### PR DESCRIPTION
# Proposed Changes

The LRC is the two's complement of the 8-bit sum of all bytes in the message. The implementation computed it with a manual accumulator loop that masked to 8 bits on every byte. That is equivalent to `(-sum(data)) & 0xFF`, which lets the C-level `sum()` do the work in one pass.

The LRC is computed on every Modbus ASCII frame that is sent and verified on every frame received, so this is on the per-frame path for ASCII transports. The output is unchanged, and a new test pins the result to the accumulator-based reference.

## Performance

`timeit` on CPython 3.14 (microseconds per call):

| Frame size | Before | After | Speedup |
| ---------- | ------ | ----- | ------- |
| 8 bytes    | 0.29   | 0.12  | ~2.4x   |
| 64 bytes   | 1.68   | 0.31  | ~5.5x   |
| 256 bytes  | 6.80   | 0.85  | ~8.0x   |

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
