### PR TITLE
Fix RTU response framing for Read FIFO Queue

### DIFF
--- a/src/tmodbus/pdu/fifo.py
+++ b/src/tmodbus/pdu/fifo.py
@@ -37,6 +37,26 @@ class ReadFifoQueuePDU(BasePDU[list[int]]):
         return struct.pack(">BH", self.function_code, self.address)
 
     @classmethod
+    def get_expected_response_data_length(cls, data: bytes) -> int | None:
+        """Determine the response data length (after the function code) for RTU framing.
+
+        Unlike most PDUs, the FIFO response starts with a two-byte byte count that
+        covers the FIFO count field and the register values that follow it, so the
+        default single-byte length logic does not apply here.
+
+        Args:
+            data: Response PDU data following the function code.
+
+        Returns:
+            Expected length of the data part, or None if it cannot be determined yet.
+
+        """
+        if len(data) < 2:
+            return None  # need the full byte count field first
+        byte_count = int.from_bytes(data[:2], "big")
+        return 2 + byte_count
+
+    @classmethod
     def decode_request(cls, data: bytes) -> Self:
         """Decode Read FIFO Queue request PDU.
 

--- a/tests/pdu/test_fifo.py
+++ b/tests/pdu/test_fifo.py
@@ -314,3 +314,17 @@ class TestReadFifoQueuePDU:
         decoded_response = original_pdu.decode_response(response)
 
         assert decoded_response == values
+
+    def test_expected_response_data_length(self) -> None:
+        """The RTU response length must account for the two-byte byte count."""
+        # Spec V1.1b3 example response: byte count 0x0006, FIFO count, two values.
+        response_pdu = bytes.fromhex("1800060002 01B8 1234".replace(" ", ""))
+        data_after_function_code = response_pdu[1:]
+        # Expected: everything after the function code (byte count + FIFO count + values).
+        assert ReadFifoQueuePDU.get_expected_response_data_length(data_after_function_code) == len(
+            data_after_function_code
+        )
+
+    def test_expected_response_data_length_needs_byte_count(self) -> None:
+        """Returns None until the full two-byte byte count is available."""
+        assert ReadFifoQueuePDU.get_expected_response_data_length(b"\x00") is None

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -176,6 +176,42 @@ async def test_send_and_receive_success(
     assert result[0] == "decoded"
 
 
+async def test_send_and_receive_fifo_queue_framing(
+    mock_transport: MagicMock,
+) -> None:
+    """Regression: FIFO responses use a two-byte byte count for RTU framing.
+
+    The FIFO response (function code 0x18) does not carry its length in a single
+    byte, so the transport must use the PDU's own length logic. With the wrong
+    length the frame would be cut short and fail its CRC check.
+    """
+    from tmodbus.pdu import ReadFifoQueuePDU  # noqa: PLC0415
+
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = ReadFifoQueuePDU(address=0x04DE)
+    unit_id = 1
+    # Spec V1.1b3 example response: byte count 0x0006, FIFO count 0x0002, values 0x01B8, 0x1234.
+    response_pdu = bytes.fromhex("1800060002 01B8 1234".replace(" ", ""))
+    payload = bytes([unit_id]) + response_pdu
+    response_adu = payload + calculate_crc16(payload)
+
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    async def simulate_response() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(response_adu)
+
+    result_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    response_task = asyncio.create_task(simulate_response())
+
+    result = await result_task
+    await response_task
+
+    assert result == [0x01B8, 0x1234]
+
+
 async def test_send_and_receive_not_connected() -> None:
     """Test that send_and_receive raises ModbusConnectionError when not connected."""
     t = AsyncRtuTransport("/dev/ttyUSB0", baudrate=9600)


### PR DESCRIPTION
# Proposed Changes

`ReadFifoQueuePDU` (function code `0x18`) did not override `get_expected_response_data_length`. The RTU and RTU-over-TCP transports use that method to work out how many bytes a response frame contains, and the default implementation assumes the data part begins with a single byte that holds the length.

The FIFO response does not follow that pattern: it starts with a two-byte byte count covering the FIFO count field and the register values. With the default logic the transport computed a data length of 1, framed the response to 5 bytes instead of its real length, and the frame then failed its CRC check (or the read timed out waiting for bytes it had already discarded). `base.py` even calls out `0x18` as the example that needs to override this method, but the override was missing.

This adds the override, reading the two-byte byte count that the PDU already encodes and decodes everywhere else.

The bug only affects the serial framing path; the PDU's own `encode`/`decode` were already correct, which is why it slipped through. Regression tests cover the length calculation directly and end to end through the RTU transport using the specification's example FIFO response (both fail without this fix).

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
