### PR TITLE
Skip raw traffic formatting when debug logging is disabled

### DIFF
--- a/src/tmodbus/utils/raw_traffic_logger.py
+++ b/src/tmodbus/utils/raw_traffic_logger.py
@@ -1,6 +1,6 @@
 """Raw traffic logger."""
 
-from logging import getLogger
+from logging import DEBUG, getLogger
 from typing import Literal
 
 raw_traffic_logger = getLogger("tmodbus.raw_traffic")
@@ -13,13 +13,17 @@ def log_raw_traffic(
     *,
     is_error: bool = False,
 ) -> None:
-    """Log raw Modbus TCP traffic."""
-    formatted_data = _format_bytes(data)
+    """Log raw Modbus traffic when debug logging is enabled."""
+    # This runs on every frame in both directions, and formatting the bytes to
+    # hex is not free. Skip the work entirely when nobody is listening.
+    if not raw_traffic_logger.isEnabledFor(DEBUG):
+        return
+
     raw_traffic_logger.debug(
         "%6s %s: %s %s",
         transport_name,
         direction,
-        formatted_data,
+        _format_bytes(data),
         "[!]" if is_error else "",
     )
 

--- a/tests/utils/test_raw_traffic_logger.py
+++ b/tests/utils/test_raw_traffic_logger.py
@@ -7,8 +7,12 @@ from tmodbus.utils.raw_traffic_logger import _format_bytes, log_raw_traffic
 
 
 class _DummyLogger:
-    def __init__(self) -> None:
+    def __init__(self, *, enabled: bool = True) -> None:
         self.records: list[tuple[Any, dict[str, Any]]] = []
+        self._enabled = enabled
+
+    def isEnabledFor(self, _level: int) -> bool:  # noqa: N802 - matches logging.Logger
+        return self._enabled
 
     def debug(self, *args: Any, **kwargs: Any) -> None:
         self.records.append((args, kwargs))
@@ -45,3 +49,11 @@ def test_log_raw_traffic_recv_error() -> None:
     assert args[2] == "recv"
     assert args[3] == "FF"
     assert args[4] == "[!]"
+
+
+def test_log_raw_traffic_skipped_when_disabled() -> None:
+    """Nothing is logged (and no formatting happens) when debug logging is off."""
+    dummy = _DummyLogger(enabled=False)
+    with patch("tmodbus.utils.raw_traffic_logger.raw_traffic_logger", dummy):
+        log_raw_traffic("rtu", "sent", b"\x01\x02")
+    assert dummy.records == []


### PR DESCRIPTION
# Proposed Changes

`log_raw_traffic` formatted every frame to a hex string (`data.hex(" ").upper()`) before passing it to `logger.debug`. When raw traffic logging is not enabled, which is the common case in production, the logger drops the record, but the formatting has already run.

This is called on every frame in both directions (once on send, once on receive), so the wasted work scales with the payload size for no benefit.

Guard the formatting behind `isEnabledFor(DEBUG)`. With logging disabled the call becomes a constant, near-zero cost regardless of frame size; with logging enabled the behaviour is unchanged.

## Performance

`timeit` on CPython 3.14 with raw traffic logging disabled (the default), microseconds per call:

| Frame size | Before | After |
| ---------- | ------ | ----- |
| 8 bytes    | 0.30   | 0.15  |
| 64 bytes   | 0.44   | 0.15  |
| 256 bytes  | 0.98   | 0.15  |

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
