### PR TITLE
Raise InvalidResponseError for malformed device identification responses

### DIFF
--- a/src/tmodbus/pdu/device.py
+++ b/src/tmodbus/pdu/device.py
@@ -91,34 +91,42 @@ class ReadDeviceIdentificationPDU(BaseSubFunctionClientPDU[ReadDeviceIdentificat
     def decode_response(self, response: bytes) -> ReadDeviceIdentificationResponse:
         """Decode Device Identifier PDU response."""
         response_header_struct = struct.Struct(">BBBBBBB")
-        (
-            function_code,
-            sub_function_code,
-            device_id_code,
-            conformity_level,
-            more,
-            next_object_id,
-            number_of_objects,
-        ) = response_header_struct.unpack_from(response, 0)
+        try:
+            (
+                function_code,
+                sub_function_code,
+                device_id_code,
+                conformity_level,
+                more,
+                next_object_id,
+                number_of_objects,
+            ) = response_header_struct.unpack_from(response, 0)
+        except struct.error as e:
+            msg = "Response too short for a Read Device Identification header"
+            raise InvalidResponseError(msg, response_bytes=response) from e
 
         if function_code != self.function_code:
             msg = f"Invalid function code: expected {self.function_code:#04x}, received {function_code:#04x}"
-            raise ValueError(msg)
+            raise InvalidResponseError(msg, response_bytes=response)
 
         if sub_function_code != self.sub_function_code:
             msg = (
                 f"Invalid sub function code: expected {self.sub_function_code:#04x}, received {sub_function_code:#04x}"
             )
-            raise ValueError(msg)
+            raise InvalidResponseError(msg, response_bytes=response)
 
         if more not in (0x00, 0xFF):
             msg = f"Invalid 'more' value: {more:#04x}"
-            raise ValueError(msg)
+            raise InvalidResponseError(msg, response_bytes=response)
 
         objects: dict[int, bytes] = {}
         offset = response_header_struct.size
         while offset < len(response):
-            obj_id, obj_length = struct.unpack_from(">BB", response, offset)
+            try:
+                obj_id, obj_length = struct.unpack_from(">BB", response, offset)
+            except struct.error as e:
+                msg = "Truncated object header in Read Device Identification response"
+                raise InvalidResponseError(msg, response_bytes=response) from e
             offset += 2
             objects[obj_id] = response[offset : offset + obj_length]
             offset += obj_length

--- a/tests/pdu/test_device.py
+++ b/tests/pdu/test_device.py
@@ -4,6 +4,7 @@ import logging
 import struct
 
 import pytest
+from tmodbus.exceptions import InvalidResponseError
 from tmodbus.pdu.device import (
     ConformityLevel,
     ReadDeviceIdentificationPDU,
@@ -110,7 +111,7 @@ class TestReadDeviceIdentificationPDU:
             0x00,
         )
 
-        with pytest.raises(ValueError, match=r"Invalid function code: expected 0x2b, received 0x03"):
+        with pytest.raises(InvalidResponseError, match=r"Invalid function code: expected 0x2b, received 0x03"):
             pdu.decode_response(response)
 
     def test_decode_response_invalid_sub_function_code(self) -> None:
@@ -128,7 +129,7 @@ class TestReadDeviceIdentificationPDU:
             0x00,
         )
 
-        with pytest.raises(ValueError, match=r"Invalid sub function code: expected 0x0e, received 0x0f"):
+        with pytest.raises(InvalidResponseError, match=r"Invalid sub function code: expected 0x0e, received 0x0f"):
             pdu.decode_response(response)
 
     def test_decode_response_invalid_more_value(self) -> None:
@@ -146,7 +147,21 @@ class TestReadDeviceIdentificationPDU:
             0x00,
         )
 
-        with pytest.raises(ValueError, match=r"Invalid 'more' value: 0x01"):
+        with pytest.raises(InvalidResponseError, match=r"Invalid 'more' value: 0x01"):
+            pdu.decode_response(response)
+
+    def test_decode_response_truncated_header(self) -> None:
+        """A response shorter than the header raises InvalidResponseError, not struct.error."""
+        pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)
+        with pytest.raises(InvalidResponseError, match=r"Response too short"):
+            pdu.decode_response(bytes.fromhex("2B0E0101"))
+
+    def test_decode_response_truncated_object_header(self) -> None:
+        """A response that ends mid-object header raises InvalidResponseError."""
+        pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)
+        # Valid 7-byte header claiming one object, then a single dangling object id byte.
+        response = bytes.fromhex("2B0E01010000 01".replace(" ", "")) + b"\x00"
+        with pytest.raises(InvalidResponseError, match=r"Truncated object header"):
             pdu.decode_response(response)
 
     def test_decode_response_empty_objects(self) -> None:


### PR DESCRIPTION
# Proposed Changes

`ReadDeviceIdentificationPDU.decode_response` unpacked the 7-byte response header and each object header with `struct.unpack_from` and no guard. A truncated response therefore raised a raw `struct.error` (for example `unpack_from requires a buffer of at least 7 bytes ...`) instead of the `InvalidResponseError` that every other PDU raises for a malformed response. This wraps both unpack calls so a short or truncated frame raises `InvalidResponseError` with the offending bytes attached.

While here, the function code, sub-function code, and `more` validation in the same method are changed from `ValueError` to `InvalidResponseError`, matching the rest of the codebase and this PDU's own `get_expected_response_data_length` (which already raises `InvalidResponseError`).

> Note: that last part is a small behaviour change. Callers that catch `ValueError` from `decode_response` will need to catch `InvalidResponseError` (a `TModbusError`) instead. This is the documented contract for response decoding, so it brings this PDU in line, but flagging it explicitly.

The lenient handling of an object whose declared length runs past the end of the response is intentionally left unchanged (it is covered by an existing test).

New tests cover the truncated header and truncated object header paths.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
