### PR TITLE
Resync TCP parser on an out-of-range MBAP length

### DIFF
--- a/src/tmodbus/transport/async_tcp.py
+++ b/src/tmodbus/transport/async_tcp.py
@@ -27,6 +27,10 @@ RT = TypeVar("RT")
 logger = logging.getLogger(__name__)
 log_raw_traffic = partial(base_log_raw_traffic, "TCP")
 
+# Maximum value of the MBAP length field: unit id (1 byte) plus a 253-byte PDU,
+# which is the largest a Modbus TCP frame is allowed to be.
+MODBUS_TCP_MAX_LENGTH = 254
+
 
 class AsyncTcpTransport(AsyncBaseTransport):
     """Async Modbus TCP Transport Layer Implementation.
@@ -294,20 +298,24 @@ class ModbusTcpProtocol(asyncio.Protocol):
             # Unpack MBAP header
             transaction_id, protocol_id, length, unit_id = struct.unpack_from(">HHHB", self._buffer)
 
-            # Do some sanity checks on the contents of the header: can it be the start of a valid message?
-            if protocol_id != 0x0000:
-                # Unexpected contents: let's try to discard as much as needed to find a valid header
-                # We look for the next occurrence of 0x0000 in the buffer
-                next_protocol_id_pos = self._buffer.find(b"\x00\x00", 2)  # start searching after the first 2 bytes
+            # Do some sanity checks on the header: can it be the start of a valid message?
+            # A valid MBAP header has protocol id 0x0000 and a length within the Modbus TCP
+            # bounds. An out-of-range length is just as much a sign of a misaligned buffer as
+            # a bad protocol id, and trusting it would stall the parser forever waiting for
+            # bytes that never come, so resync in that case too.
+            if protocol_id != 0x0000 or not (1 <= length <= MODBUS_TCP_MAX_LENGTH):
+                # Look for the next occurrence of 0x0000 (a candidate protocol id), starting
+                # past the current position so a bogus length cannot loop on the same bytes.
+                next_protocol_id_pos = self._buffer.find(b"\x00\x00", 3)
                 if next_protocol_id_pos == -1:
                     # No occurrence found: discard everything except the last byte (in case it's part of a valid header)
                     logger.debug("Discarding garbage bytes: %s", self._buffer[:-1].hex(" ").upper())
                     del self._buffer[:-1]
                     return  # buffer is exhausted, wait for more data
 
-                # Discard bytes up to the potential start of the next message
-                logger.debug("Discarding garbage bytes: %s", self._buffer[:next_protocol_id_pos].hex(" ").upper())
-                # keep the 2 bytes before the found occurrence, as it contains the transaction ID
+                # Discard bytes up to the potential start of the next message,
+                # keeping the 2 bytes before the found occurrence as the transaction ID.
+                logger.debug("Discarding garbage bytes: %s", self._buffer[: next_protocol_id_pos - 2].hex(" ").upper())
                 del self._buffer[: next_protocol_id_pos - 2]
                 continue  # Re-evaluate the buffer from the start
 

--- a/tests/transport/test_async_tcp.py
+++ b/tests/transport/test_async_tcp.py
@@ -171,6 +171,31 @@ async def test_protocol_data_received_complete_frame() -> None:
     assert result.transaction_id == 1
 
 
+async def test_protocol_data_received_out_of_range_length_resyncs() -> None:
+    """A frame with an out-of-range length must not stall the parser.
+
+    Modbus TCP caps the MBAP length field at 254. A larger value means the buffer
+    is misaligned; the parser must discard it and recover instead of waiting
+    forever for bytes that never arrive, which would desync the connection.
+    """
+    protocol = ModbusTcpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
+    protocol.connection_made(MagicMock(spec=asyncio.WriteTransport))
+
+    future: asyncio.Future[_ModbusMessage] = asyncio.get_event_loop().create_future()
+    protocol._pending_requests[1] = future
+
+    # Header with protocol id 0 but an absurd length (5000), followed by some bytes.
+    protocol.data_received(struct.pack(">HHHB", 1, 0x0000, 5000, 1) + b"\x03\x02\x00\x0a")
+    assert not future.done()  # bogus frame is not delivered
+
+    # A real response for the same transaction id must still be parsed.
+    protocol.data_received(struct.pack(">HHHB", 1, 0x0000, 3, 1) + b"\x03\x99")
+    await asyncio.sleep(0.01)
+
+    assert future.done()
+    assert future.result().pdu_bytes == b"\x03\x99"
+
+
 async def test_protocol_data_received_unexpected_transaction_id() -> None:
     """Test protocol handles unexpected transaction ID gracefully."""
     protocol = ModbusTcpProtocol(on_connection_lost=lambda _: None, timeout=10.0)


### PR DESCRIPTION
# Proposed Changes

The Modbus TCP frame parser in `ModbusTcpProtocol.data_received` only sanity-checked the protocol id of each MBAP header. It trusted the length field unconditionally.

A frame with protocol id `0x0000` but a length above the Modbus TCP maximum (unit id plus a 253-byte PDU, so 254) made the parser wait for `7 + length - 1` bytes that never arrive. The buffer was never cleared, so the parser stayed stuck on the bogus frame and every subsequent valid response on that connection was silently dropped (its future never resolved, the request timed out). In other words, a single bad length field desynced the connection until it was reconnected.

This is not purely theoretical: the parser already has resync logic to recover from a misaligned buffer (the protocol id check), and that recovery path can itself land on a coincidental `0x0000` followed by bytes that read as a large length.

The fix treats an out-of-range length the same way as a bad protocol id: discard and resync to the next candidate header. Two supporting details:

- The resync search now starts one byte further into the buffer (index 3 instead of 2). This is equivalent for the original protocol-id case (a `0x0000` cannot sit at index 2 when the protocol id is non-zero) and is required for the new case, where the bad frame's protocol id genuinely is `0x0000` at index 2 and must be skipped to avoid looping on the same bytes.
- The "discarding garbage bytes" debug log now logs the bytes that are actually dropped (`[:next_pos - 2]`); it previously logged `[:next_pos]`, overstating the discard by 2 bytes.

A regression test feeds an out-of-range-length frame followed by a valid response and asserts the valid response is still delivered. It fails without this change (the future never resolves) and passes with it.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
