### PR TITLE
Fail RTU request on unsupported function code instead of crashing

### DIFF
--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -454,15 +454,22 @@ class ModbusRtuProtocol(asyncio.Protocol):
             expected_total_frame_length = 5  # address + exception FC + exception code + CRC
         else:
             # check if we can already determine the expected length with the available data
-            if not is_function_code_for_subfunction_pdu(function_code):
-                pdu_class = get_pdu_class(function_code)
-            else:
-                # It's a sub-function PDU, we need at least 6 bytes to determine the length
-                # 6 = address + function code + sub-function code + at least 1 byte of data + CRC
-                if len(self._buffer) < 6:
-                    return None  # Wait for more data
-                sub_function_code = self._buffer[2]
-                pdu_class = get_subfunction_pdu_class(function_code, sub_function_code)
+            try:
+                if not is_function_code_for_subfunction_pdu(function_code):
+                    pdu_class = get_pdu_class(function_code)
+                else:
+                    # It's a sub-function PDU, we need at least 6 bytes to determine the length
+                    # 6 = address + function code + sub-function code + at least 1 byte of data + CRC
+                    if len(self._buffer) < 6:
+                        return None  # Wait for more data
+                    sub_function_code = self._buffer[2]
+                    pdu_class = get_subfunction_pdu_class(function_code, sub_function_code)
+            except ValueError as e:
+                # Unknown or unsupported (sub-)function code, for example a bit flip on the
+                # line. We cannot determine where the frame ends, so fail the pending request
+                # with a frame error rather than letting the exception crash the protocol.
+                msg = f"Cannot frame response with unsupported function code {function_code:#04x}"
+                raise RTUFrameError(msg, response_bytes=bytes(self._buffer)) from e
 
             expected_response_data_length = pdu_class.get_expected_response_data_length(self._buffer[2:])
 

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -227,6 +227,39 @@ async def test_send_and_receive_crc_error(
     await response_task
 
 
+async def test_send_and_receive_unsupported_function_code(
+    mock_transport: MagicMock,
+) -> None:
+    """An unknown function code in a response must not crash the parser.
+
+    A bit flip on the line can turn the function code into one this library does
+    not know. The frame length cannot be determined, so the request should fail
+    with an RTUFrameError instead of letting a ValueError escape data_received.
+    """
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()  # function code 0x03
+    unit_id = 1
+    # Response carries an unsupported function code (0x65) for the pending unit.
+    payload = bytes([unit_id, 0x65, 0x00, 0x00])
+    response_adu = payload + calculate_crc16(payload)
+
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    async def simulate_response() -> None:
+        await asyncio.sleep(0.01)
+        # This must not raise out of data_received.
+        protocol.data_received(response_adu)
+
+    result_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    response_task = asyncio.create_task(simulate_response())
+
+    with pytest.raises(RTUFrameError):
+        await result_task
+    await response_task
+
+
 async def test_send_and_receive_address_mismatch(
     mock_transport: MagicMock,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
# Proposed Changes

`ModbusRtuProtocol._determine_expected_frame_length` looks up the PDU class for the received function code in order to work out how long the response frame should be. `get_pdu_class` (and `get_subfunction_pdu_class`) raise `ValueError` for a function code that is unknown, unsupported, or simply not implemented by this library (for example `0x08` diagnostics).

`data_received` only catches `RTUFrameError`, so that `ValueError` escaped into the asyncio protocol callback and tore the parser down before the CRC was ever validated. The whole point of RTU framing plus CRC is to tolerate line noise, but a single bit flip in the function code byte (for a response that matches a pending unit) was enough to crash the parser instead of being rejected as a bad frame.

This catches the `ValueError` and raises `RTUFrameError`, which `data_received` already handles by failing the pending request. The caller receives a frame error it can retry or reconnect on, and the protocol stays alive.

A regression test feeds a response with an unsupported function code for a pending request and asserts it surfaces as `RTUFrameError` rather than escaping `data_received`. It fails without this change (a raw `ValueError` propagates) and passes with it.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
