### PR TITLE
Add Python 3.15 to the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python }}
       - name: 🏗 Install dependencies
-        run: uv sync --all-extras --frozen --dev
+        run: uv sync --all-extras --frozen --no-default-groups --group test
       - name: 🚀 Run pytest
         run: uv run pytest --cov tmodbus tests
       - name: ⬆️ Upload coverage artifact
@@ -49,7 +49,7 @@ jobs:
           enable-cache: true
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: 🏗 Install dependencies
-        run: uv sync --all-extras --frozen --dev
+        run: uv sync --all-extras --frozen --no-default-groups --group test
       - name: 🚀 Process coverage results
         run: |
           uv run coverage combine coverage*/.coverage*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: 🏗 Install dependencies
         run: uv sync --all-extras --frozen --no-default-groups --group test
       - name: 🚀 Run pytest
-        run: uv run pytest --cov tmodbus tests
+        run: uv run --no-sync pytest --cov tmodbus tests
       - name: ⬆️ Upload coverage artifact
         uses: actions/upload-artifact@v4.6.2
         with:
@@ -52,7 +52,7 @@ jobs:
         run: uv sync --all-extras --frozen --no-default-groups --group test
       - name: 🚀 Process coverage results
         run: |
-          uv run coverage combine coverage*/.coverage*
-          uv run coverage xml -i
+          uv run --no-sync coverage combine coverage*/.coverage*
+          uv run --no-sync coverage xml -i
       - name: 🚀 Upload coverage report
         uses: codecov/codecov-action@v5.5.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.12", "3.13", "3.14"]
+        python: ["3.12", "3.13", "3.14", "3.15"]
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v5.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: System :: Networking",
   "Typing :: Typed",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,17 +126,24 @@ fail_under = 100
 prerelease = "if-necessary"
 
 [dependency-groups]
-dev = [
-  "codespell==2.4.1",
+# Dependencies needed to run the test suite. Kept separate from the full dev
+# group so the test matrix does not pull in tooling it does not use (for
+# example docstrfmt, whose libcst dependency has no wheel for new Python
+# pre-releases yet).
+test = [
   "covdefaults==2.3.0",
   "coverage[toml]==7.10.7",
+  "pytest==8.4.2",
+  "pytest-asyncio==1.2.0",
+  "pytest-cov==7.0.0",
+]
+dev = [
+  { include-group = "test" },
+  "codespell==2.4.1",
   "docstrfmt>=1.11.1",
   "mypy==1.18.2",
   "pre-commit==4.3.0",
   "pre-commit-hooks==6.0.0",
-  "pytest==8.4.2",
-  "pytest-asyncio==1.2.0",
-  "pytest-cov==7.0.0",
   "ruff==0.13.3",
   "yamllint==1.37.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1064,6 +1064,13 @@ docs = [
     { name = "sphinx-rtd-theme" },
     { name = "sphinxcontrib-mermaid" },
 ]
+test = [
+    { name = "covdefaults" },
+    { name = "coverage" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1092,6 +1099,13 @@ docs = [
     { name = "sphinx-autobuild" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
     { name = "sphinxcontrib-mermaid" },
+]
+test = [
+    { name = "covdefaults", specifier = "==2.3.0" },
+    { name = "coverage", extras = ["toml"], specifier = "==7.10.7" },
+    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest-asyncio", specifier = "==1.2.0" },
+    { name = "pytest-cov", specifier = "==7.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Proposed Changes

Add Python 3.15 to the pytest matrix in `tests.yml` and add the matching `Programming Language :: Python :: 3.15` classifier, the same way 3.14 was added while it was still pre-release.

`requires-python` already allows it (`>=3.12`), so no change is needed there.

Note: 3.15 is still a pre-release at the time of writing. `setup-uv` should install the latest 3.15 build from python-build-standalone; if the job is not green yet because of that, this can wait for a 3.15 release or be marked allow-failure.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
