### PR TITLE
Fail fast on bad LRC responses

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -79,6 +79,7 @@ subclass of :class:`~tmodbus.exceptions.ModbusInvalidResponseError`:
 
 - RTU Frame Error: :class:`~tmodbus.exceptions.RTUFrameError`
 - Invalid CRC: :class:`~tmodbus.exceptions.CRCError`
+- Invalid LRC: :class:`~tmodbus.exceptions.LRCError`
 - Header mismatch: :class:`~tmodbus.exceptions.HeaderMismatchError`
 - Function code mismatch: :class:`~tmodbus.exceptions.FunctionCodeError`
 

--- a/src/tmodbus/transport/async_ascii.py
+++ b/src/tmodbus/transport/async_ascii.py
@@ -91,6 +91,10 @@ def decode_ascii_frame(frame: bytes) -> bytes:
 
 def validate_ascii_frame(raw: bytes) -> bool:
     """Validate Modbus ASCII frame for correct LRC."""
+    # We assume that the provided raw bytes were decoded by the `decode_ascii_frame` function,
+    # which already checks for frame structure and minimum length.
+    # Therefore, we only need to validate the LRC here.
+
     return validate_lrc(raw[:-1], raw[-1])
 
 
@@ -314,6 +318,15 @@ class ModbusAsciiProtocol(asyncio.Protocol):
                 continue
 
             if not validate_ascii_frame(raw):
+                # The unit id is also part of the raw frame, so in theory it is possible that the LRC is caused by
+                # a bit flip on the unit id.
+
+                # However, in most cases this corrupt unit id would not correspond with a pending request,
+                # and the frame would have been discarded already anyway.
+
+                # As we're trying to recover from a bad frame, we prefer to fail fast instead of letting pending
+                # requests wait for a timeout. Therefore, we set an exception on the pending future and continue.
+
                 pending_future.set_exception(LRCError(response_bytes=frame))
                 continue
 

--- a/src/tmodbus/transport/async_ascii.py
+++ b/src/tmodbus/transport/async_ascii.py
@@ -71,8 +71,8 @@ def build_ascii_frame(address: int, pdu: bytes) -> bytes:
     return ASCII_FRAME_START + ascii_encode(message_with_lrc) + ASCII_FRAME_END
 
 
-def parse_ascii_frame(frame: bytes) -> bytes:
-    """Parse Modbus ASCII frame (strip start/end, decode hex, check LRC)."""
+def decode_ascii_frame(frame: bytes) -> bytes:
+    """Decode Modbus ASCII frame without validating LRC."""
     if not frame.startswith(ASCII_FRAME_START) or not frame.endswith(ASCII_FRAME_END):
         msg = "Malformed ASCII frame: does not start with ':' and end with '\\r\\n'"
         raise ASCIIFrameError(msg, response_bytes=frame)
@@ -86,10 +86,12 @@ def parse_ascii_frame(frame: bytes) -> bytes:
     if len(raw) < 3:
         msg = "ASCII frame too short"
         raise ASCIIFrameError(msg, response_bytes=frame)
-    message, lrc = raw[:-1], raw[-1]
-    if not validate_lrc(message, lrc):
-        raise LRCError(response_bytes=frame)
     return raw  # address + pdu + lrc
+
+
+def validate_ascii_frame(raw: bytes) -> bool:
+    """Validate Modbus ASCII frame for correct LRC."""
+    return validate_lrc(raw[:-1], raw[-1])
 
 
 @dataclass(frozen=True)
@@ -291,19 +293,16 @@ class ModbusAsciiProtocol(asyncio.Protocol):
             frame = bytes(self._buffer[:frame_length])
             del self._buffer[:frame_length]
 
-            # Parse and validate the frame
+            # Parse framing and hex payload first, then attribute checksum failures by unit_id.
             try:
-                raw = parse_ascii_frame(frame)
-            except (ASCIIFrameError, LRCError) as e:
+                raw = decode_ascii_frame(frame)
+            except ASCIIFrameError as e:
                 logger.warning("Invalid frame received: %s", e)
                 # Continue to next frame
                 continue
 
             # Extract unit_id from frame
             unit_id = raw[0]
-            pdu_bytes = raw[1:-1]  # Remove address and LRC
-            lrc = raw[-1:]
-
             # Check if this unit_id has a pending request
             pending_future = self._pending_requests.get(unit_id)
             if pending_future is None or pending_future.done():
@@ -314,12 +313,16 @@ class ModbusAsciiProtocol(asyncio.Protocol):
                 )
                 continue
 
+            if not validate_ascii_frame(raw):
+                pending_future.set_exception(LRCError(response_bytes=frame))
+                continue
+
             # Deliver response to pending request
             pending_future.set_result(
                 _ModbusAsciiMessage(
                     unit_id=unit_id,
-                    pdu_bytes=pdu_bytes,
-                    lrc=lrc,
+                    pdu_bytes=raw[1:-1],  # Remove address and LRC
+                    lrc=raw[-1:],
                 )
             )
 

--- a/src/tmodbus/transport/async_base.py
+++ b/src/tmodbus/transport/async_base.py
@@ -69,6 +69,7 @@ class AsyncBaseTransport(ABC):
             ConnectionError: Connection error
             TimeoutError:  Operation timeout
             CRCError: CRC verification failed (RTU only)
+            LRCError: LRC verification failed (ASCII only)
             InvalidResponseError: Invalid response format
 
         """

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -546,6 +546,15 @@ class ModbusRtuProtocol(asyncio.Protocol):
                     )
                 )
             else:
+                # The unit id is also part of the raw frame, so in theory it is possible that the CRC is caused by
+                # a bit flip on the unit id.
+
+                # However, in most cases this corrupt unit id would not correspond with a pending request,
+                # and the frame would have been discarded already anyway.
+
+                # As we're trying to recover from a bad frame, we prefer to fail fast instead of letting pending
+                # requests wait for a timeout. Therefore, we set an exception on the pending future and continue.
+
                 pending_future.set_exception(CRCError(response_bytes=frame))
 
     def connection_lost(self, exc: Exception | None) -> None:

--- a/tests/transport/test_async_ascii.py
+++ b/tests/transport/test_async_ascii.py
@@ -27,7 +27,8 @@ from tmodbus.transport.async_ascii import (
     ascii_decode,
     ascii_encode,
     build_ascii_frame,
-    parse_ascii_frame,
+    decode_ascii_frame,
+    validate_ascii_frame,
 )
 from tmodbus.utils.lrc import calculate_lrc
 
@@ -142,49 +143,50 @@ def test_build_ascii_frame_broadcast() -> None:
     assert raw[0] == 0
 
 
-def test_parse_ascii_frame_valid() -> None:
-    """Test parsing valid ASCII frame."""
+def test_decode_ascii_frame_valid() -> None:
+    """Test decoding valid ASCII frame."""
     # Build a valid frame
     message = b"\x01\x03"
     lrc = calculate_lrc(message)
     hex_data = ascii_encode(message + bytes([lrc]))
     frame = b":" + hex_data + b"\r\n"
 
-    raw = parse_ascii_frame(frame)
+    raw = decode_ascii_frame(frame)
     assert raw[0] == 0x01  # address
     assert raw[1] == 0x03  # function code
     assert raw[-1] == lrc  # LRC
+    assert validate_ascii_frame(raw)
 
 
-def test_parse_ascii_frame_missing_start() -> None:
-    """Test parsing frame without start marker."""
+def test_decode_ascii_frame_missing_start() -> None:
+    """Test decoding frame without start marker."""
     with pytest.raises(ASCIIFrameError, match="does not start with ':'"):
-        parse_ascii_frame(b"0103FC\r\n")
+        decode_ascii_frame(b"0103FC\r\n")
 
 
-def test_parse_ascii_frame_missing_end() -> None:
-    """Test parsing frame without end marker."""
+def test_decode_ascii_frame_missing_end() -> None:
+    """Test decoding frame without end marker."""
     with pytest.raises(ASCIIFrameError, match="does not start with ':' and end with"):
-        parse_ascii_frame(b":0103FC")
+        decode_ascii_frame(b":0103FC")
 
 
-def test_parse_ascii_frame_invalid_hex() -> None:
-    """Test parsing frame with invalid hex."""
+def test_decode_ascii_frame_invalid_hex() -> None:
+    """Test decoding frame with invalid hex."""
     with pytest.raises(ASCIIFrameError, match="Invalid hex"):
-        parse_ascii_frame(b":GGZZ\r\n")
+        decode_ascii_frame(b":GGZZ\r\n")
 
 
-def test_parse_ascii_frame_too_short() -> None:
-    """Test parsing frame that's too short."""
+def test_decode_ascii_frame_too_short() -> None:
+    """Test decoding frame that's too short."""
     with pytest.raises(ASCIIFrameError, match="too short"):
-        parse_ascii_frame(b":01\r\n")
+        decode_ascii_frame(b":01\r\n")
 
 
-def test_parse_ascii_frame_invalid_lrc() -> None:
-    """Test parsing frame with invalid LRC."""
-    # Valid structure but wrong LRC
-    with pytest.raises(LRCError):
-        parse_ascii_frame(b":0103FF\r\n")  # FF is wrong LRC
+def test_decode_ascii_frame_invalid_lrc_is_detectable() -> None:
+    """Test that decode-only path keeps invalid LRC detectable."""
+    # Valid structure but wrong LRC.
+    raw = decode_ascii_frame(b":0103FF\r\n")
+    assert not validate_ascii_frame(raw)
 
 
 # Fixtures
@@ -592,7 +594,7 @@ async def test_protocol_partial_frame(mock_transport: MagicMock) -> None:
 
 
 async def test_protocol_invalid_frame(mock_transport: MagicMock) -> None:
-    """Test handling invalid frame (bad LRC)."""
+    """Test handling invalid frame (bad LRC) for pending request."""
     protocol = ModbusAsciiProtocol(
         on_connection_lost=lambda _exc: None,
         timeout=0.1,
@@ -607,7 +609,49 @@ async def test_protocol_invalid_frame(mock_transport: MagicMock) -> None:
     # Send frame with bad LRC
     protocol.data_received(b":0103FF\r\n")  # Invalid LRC
 
-    # Should timeout because frame was discarded
+    # Should fail fast because bad checksum matches pending unit_id.
+    with pytest.raises(LRCError):
+        await task
+
+
+async def test_protocol_invalid_frame_wrong_unit_id_is_discarded(mock_transport: MagicMock) -> None:
+    """Test bad-LRC frame for another unit does not fail the pending request."""
+    protocol = ModbusAsciiProtocol(
+        on_connection_lost=lambda _exc: None,
+        timeout=0.1,
+    )
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+
+    task = asyncio.create_task(protocol.send_and_receive(1, pdu))
+    await asyncio.sleep(0.01)
+
+    # Bad LRC frame for unit 2 while unit 1 is pending.
+    protocol.data_received(b":0203FF\r\n")
+
+    # Request for unit 1 should still timeout because frame is not attributable.
+    with pytest.raises(TimeoutError):
+        await task
+
+
+async def test_protocol_invalid_hex_frame_is_discarded(mock_transport: MagicMock) -> None:
+    """Test malformed ASCII frame (invalid hex) is logged and discarded."""
+    protocol = ModbusAsciiProtocol(
+        on_connection_lost=lambda _exc: None,
+        timeout=0.1,
+    )
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+
+    task = asyncio.create_task(protocol.send_and_receive(1, pdu))
+    await asyncio.sleep(0.01)
+
+    # Starts/ends like a frame but has invalid hex payload, exercising ASCIIFrameError path.
+    protocol.data_received(b":GGZZ\r\n")
+
+    # Request should still timeout because malformed frame is discarded.
     with pytest.raises(TimeoutError):
         await task
 


### PR DESCRIPTION
# Proposed Changes

* Align ASCII transport checksum handling with RTU by surfacing [LRCError](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the pending request instead of silently dropping invalid frames and timing out.
* Refactored ASCII frame parsing into decode vs checksum-validation stages
* Updated API/docs to mention ASCII LRC errors
* Refreshed transport tests to cover fail-fast behavior plus non-attributable bad-frame discard semantics.

## Related Issues

Fixes #17