### PR TITLE
Stop read_device_identification looping on a non-advancing device

### DIFF
--- a/src/tmodbus/client/async_client.py
+++ b/src/tmodbus/client/async_client.py
@@ -416,7 +416,20 @@ class AsyncModbusClient(HoldingRegisterReadMixin, HoldingRegisterWriteMixin):
         result: dict[int, bytes] = {}
         more = True
         number_of_objects: int | None = None
+        requested_object_ids: set[int] = set()
         while more:
+            if object_id in requested_object_ids:
+                # The device says there is more to read but points back at an object we
+                # already requested. Stop here instead of looping forever on a device that
+                # never advances its next object id.
+                logger.warning(
+                    "Device repeated object id %#04x while streaming device identification; "
+                    "stopping with the objects collected so far.",
+                    object_id,
+                )
+                break
+            requested_object_ids.add(object_id)
+
             response = await self.execute(ReadDeviceIdentificationPDU(device_code, object_id))
             result.update(response.objects)
             more = response.more

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -366,6 +366,36 @@ async def test_read_device_identification_warns_on_number_of_objects_change(
     assert any("Number of objects changed between requests" in r for r in caplog.text.splitlines())
 
 
+async def test_read_device_identification_stops_on_non_advancing_object_id(
+    monkeypatch: pytest.MonkeyPatch,
+    dummy_client: AsyncModbusClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A device that keeps saying 'more' without advancing must not loop forever."""
+    call_count = {"count": 0}
+
+    async def fake_execute(_self: None, _pdu: ReadDeviceIdentificationPDU) -> ReadDeviceIdentificationResponse:
+        call_count["count"] += 1
+        # Always claims more, always points back at object id 0.
+        return ReadDeviceIdentificationResponse(
+            device_id_code=1,
+            conformity_level=ConformityLevel.BASIC,
+            objects={0: b"vendor"},
+            more=True,
+            next_object_id=0,
+            number_of_objects=1,
+        )
+
+    monkeypatch.setattr(AsyncModbusClient, "execute", fake_execute)
+    with caplog.at_level("WARNING"):
+        result = await dummy_client.read_device_identification(1, 0)
+
+    # It requested object 0 once, then detected the repeat and stopped.
+    assert call_count["count"] == 1
+    assert result == {0: b"vendor"}
+    assert any("repeated object id" in line for line in caplog.text.splitlines())
+
+
 def test_for_unit_id_creates_new_instance_with_different_unit_id() -> None:
     """Test that for_unit_id creates a new client instance with the specified unit_id."""
     transport = DummyAsyncTransport()


### PR DESCRIPTION
# Proposed Changes

`read_device_identification` walks the device identification stream by following the response's `more` flag and `next_object_id`. It trusted both unconditionally, so a device that keeps setting `more` to true while pointing `next_object_id` back at an object that was already requested made the loop run forever (the call hangs).

This tracks the object ids that have been requested and stops when the device points back at one already requested. It returns the objects collected so far and logs a warning, rather than looping. Object ids are a single byte, so this also bounds the loop to at most 256 requests in any case.

Normal streaming, where each response advances `next_object_id`, is unchanged. A regression test simulates a device that always reports `more` with the same `next_object_id`; it hangs without this change and completes with it.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
