### PR TITLE
Raise Invalid*Error from FIFO and exception status decode paths

### DIFF
--- a/src/tmodbus/pdu/exception_status.py
+++ b/src/tmodbus/pdu/exception_status.py
@@ -1,6 +1,7 @@
 """Exception status PDU Module (serial line only)."""
 
 from tmodbus.const import FunctionCode
+from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
 from tmodbus.pdu.base import BasePDU
 
 
@@ -29,18 +30,18 @@ class ReadExceptionStatusPDU(BasePDU[int]):
             Decoded ReadExceptionStatus instance
 
         Raises:
-            ValueError: If data length is incorrect
+            InvalidRequestError: If data length or function code is incorrect
 
         """
         if len(data) != 1:
             msg = f"Invalid Read Exception Status request length: {len(data)}. Expected 1."
-            raise ValueError(msg)
+            raise InvalidRequestError(msg, request_bytes=data)
 
         function_code = data[0]
 
         if function_code != cls.function_code:
             msg = f"Invalid function code: {function_code:#04x}. Expected {cls.function_code:#04x}."
-            raise ValueError(msg)
+            raise InvalidRequestError(msg, request_bytes=data)
 
         return cls()
 
@@ -73,17 +74,17 @@ class ReadExceptionStatusPDU(BasePDU[int]):
             Decoded exception status (0-255)
 
         Raises:
-            ValueError: If data length is incorrect
+            InvalidResponseError: If data length or function code is incorrect
 
         """
         if len(data) != 2:
             msg = f"Invalid Read Exception Status response length: {len(data)}. Expected 2."
-            raise ValueError(msg)
+            raise InvalidResponseError(msg, response_bytes=data)
 
         function_code, status = data
 
         if function_code != self.function_code:
             msg = f"Invalid function code: {function_code:#04x}. Expected {self.function_code:#04x}."
-            raise ValueError(msg)
+            raise InvalidResponseError(msg, response_bytes=data)
 
         return status

--- a/src/tmodbus/pdu/fifo.py
+++ b/src/tmodbus/pdu/fifo.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Self
 
 from tmodbus.const import FunctionCode
+from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
 from tmodbus.pdu.base import BasePDU
 
 
@@ -67,18 +68,18 @@ class ReadFifoQueuePDU(BasePDU[list[int]]):
             Decoded ReadFifoQueuePDU instance
 
         Raises:
-            ValueError: If data length is incorrect
+            InvalidRequestError: If data length or function code is incorrect
 
         """
         if len(data) != 3:
             msg = f"Invalid Read FIFO Queue request length: {len(data)}. Expected 3."
-            raise ValueError(msg)
+            raise InvalidRequestError(msg, request_bytes=data)
 
         function_code, address = struct.unpack(">BH", data)
 
         if function_code != cls.function_code:
             msg = f"Invalid function code: {function_code:#04x}. Expected {cls.function_code:#04x}."
-            raise ValueError(msg)
+            raise InvalidRequestError(msg, request_bytes=data)
 
         return cls(address=address)
 
@@ -118,12 +119,12 @@ class ReadFifoQueuePDU(BasePDU[list[int]]):
             List of values from the FIFO queue
 
         Raises:
-            ValueError: If data length is incorrect or count doesn't match values
+            InvalidResponseError: If data length is incorrect or count doesn't match values
 
         """
         if len(data) < 5:
             msg = f"Invalid Read FIFO Queue response length: {len(data)}. Minimum expected is 5."
-            raise ValueError(msg)
+            raise InvalidResponseError(msg, response_bytes=data)
 
         response_header_struct = struct.Struct(">BHH")
 
@@ -131,11 +132,11 @@ class ReadFifoQueuePDU(BasePDU[list[int]]):
 
         if function_code != self.function_code:
             msg = f"Invalid function code: {function_code:#04x}. Expected {self.function_code:#04x}."
-            raise ValueError(msg)
+            raise InvalidResponseError(msg, response_bytes=data)
 
         if byte_count != len(data) - 3:
             msg = f"Byte count {byte_count} does not match actual data length {len(data) - 3}."
-            raise ValueError(msg)
+            raise InvalidResponseError(msg, response_bytes=data)
 
         values_count = (byte_count // 2) - 1
         values = list(struct.unpack(f">{values_count}H", data[response_header_struct.size :]))
@@ -143,6 +144,6 @@ class ReadFifoQueuePDU(BasePDU[list[int]]):
         # Validate that the FIFO count matches the number of values
         if fifo_count != len(values):
             msg = f"FIFO count {fifo_count} does not match number of values {len(values)}."
-            raise ValueError(msg)
+            raise InvalidResponseError(msg, response_bytes=data)
 
         return values

--- a/tests/pdu/test_exception_status.py
+++ b/tests/pdu/test_exception_status.py
@@ -2,6 +2,7 @@
 
 import pytest
 from tmodbus.const import FunctionCode
+from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
 from tmodbus.pdu.exception_status import ReadExceptionStatusPDU
 
 
@@ -31,19 +32,23 @@ class TestReadExceptionStatusPDU:
     def test_decode_request_invalid_length_too_short(self) -> None:
         """Test decoding fails when request is too short."""
         data = bytes([])
-        with pytest.raises(ValueError, match=r"Invalid Read Exception Status request length: 0\. Expected 1\."):
+        with pytest.raises(
+            InvalidRequestError, match=r"Invalid Read Exception Status request length: 0\. Expected 1\."
+        ):
             ReadExceptionStatusPDU.decode_request(data)
 
     def test_decode_request_invalid_length_too_long(self) -> None:
         """Test decoding fails when request is too long."""
         data = bytes([0x07, 0x00])
-        with pytest.raises(ValueError, match=r"Invalid Read Exception Status request length: 2\. Expected 1\."):
+        with pytest.raises(
+            InvalidRequestError, match=r"Invalid Read Exception Status request length: 2\. Expected 1\."
+        ):
             ReadExceptionStatusPDU.decode_request(data)
 
     def test_decode_request_invalid_function_code(self) -> None:
         """Test decoding fails when function code is incorrect."""
         data = bytes([0x03])
-        with pytest.raises(ValueError, match=r"Invalid function code: 0x03\. Expected 0x07\."):
+        with pytest.raises(InvalidRequestError, match=r"Invalid function code: 0x03\. Expected 0x07\."):
             ReadExceptionStatusPDU.decode_request(data)
 
     def test_encode_response_valid_min(self) -> None:
@@ -128,28 +133,34 @@ class TestReadExceptionStatusPDU:
         """Test decoding fails when response is too short."""
         pdu = ReadExceptionStatusPDU()
         data = bytes([0x07])
-        with pytest.raises(ValueError, match=r"Invalid Read Exception Status response length: 1\. Expected 2\."):
+        with pytest.raises(
+            InvalidResponseError, match=r"Invalid Read Exception Status response length: 1\. Expected 2\."
+        ):
             pdu.decode_response(data)
 
     def test_decode_response_invalid_length_empty(self) -> None:
         """Test decoding fails when response is empty."""
         pdu = ReadExceptionStatusPDU()
         data = bytes([])
-        with pytest.raises(ValueError, match=r"Invalid Read Exception Status response length: 0\. Expected 2\."):
+        with pytest.raises(
+            InvalidResponseError, match=r"Invalid Read Exception Status response length: 0\. Expected 2\."
+        ):
             pdu.decode_response(data)
 
     def test_decode_response_invalid_length_too_long(self) -> None:
         """Test decoding fails when response is too long."""
         pdu = ReadExceptionStatusPDU()
         data = bytes([0x07, 0x55, 0x00])
-        with pytest.raises(ValueError, match=r"Invalid Read Exception Status response length: 3\. Expected 2\."):
+        with pytest.raises(
+            InvalidResponseError, match=r"Invalid Read Exception Status response length: 3\. Expected 2\."
+        ):
             pdu.decode_response(data)
 
     def test_decode_response_invalid_function_code(self) -> None:
         """Test decoding fails when function code is incorrect."""
         pdu = ReadExceptionStatusPDU()
         data = bytes([0x03, 0x55])
-        with pytest.raises(ValueError, match=r"Invalid function code: 0x03\. Expected 0x07\."):
+        with pytest.raises(InvalidResponseError, match=r"Invalid function code: 0x03\. Expected 0x07\."):
             pdu.decode_response(data)
 
     def test_round_trip_encode_decode_request(self) -> None:

--- a/tests/pdu/test_fifo.py
+++ b/tests/pdu/test_fifo.py
@@ -3,6 +3,7 @@
 import struct
 
 import pytest
+from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
 from tmodbus.pdu.fifo import ReadFifoQueuePDU
 
 
@@ -68,19 +69,19 @@ class TestReadFifoQueuePDU:
     def test_decode_request_invalid_length_too_short(self) -> None:
         """Test decoding request with invalid length (too short)."""
         request = b"\x18\x04"
-        with pytest.raises(ValueError, match=r"Invalid Read FIFO Queue request length: 2. Expected 3"):
+        with pytest.raises(InvalidRequestError, match=r"Invalid Read FIFO Queue request length: 2. Expected 3"):
             ReadFifoQueuePDU.decode_request(request)
 
     def test_decode_request_invalid_length_too_long(self) -> None:
         """Test decoding request with invalid length (too long)."""
         request = b"\x18\x04\xde\x00"
-        with pytest.raises(ValueError, match=r"Invalid Read FIFO Queue request length: 4. Expected 3"):
+        with pytest.raises(InvalidRequestError, match=r"Invalid Read FIFO Queue request length: 4. Expected 3"):
             ReadFifoQueuePDU.decode_request(request)
 
     def test_decode_request_invalid_function_code(self) -> None:
         """Test decoding request with invalid function code."""
         request = b"\x03\x04\xde"
-        with pytest.raises(ValueError, match=r"Invalid function code: 0x03. Expected 0x18"):
+        with pytest.raises(InvalidRequestError, match=r"Invalid function code: 0x03. Expected 0x18"):
             ReadFifoQueuePDU.decode_request(request)
 
     def test_encode_response_valid(self) -> None:
@@ -187,14 +188,16 @@ class TestReadFifoQueuePDU:
         """Test decoding response that is too short."""
         pdu = ReadFifoQueuePDU(address=0x1000)
         response_data = b"\x18\x00"
-        with pytest.raises(ValueError, match=r"Invalid Read FIFO Queue response length: 2. Minimum expected is 5"):
+        with pytest.raises(
+            InvalidResponseError, match=r"Invalid Read FIFO Queue response length: 2. Minimum expected is 5"
+        ):
             pdu.decode_response(response_data)
 
     def test_decode_response_invalid_function_code(self) -> None:
         """Test decoding response with invalid function code."""
         pdu = ReadFifoQueuePDU(address=0x04DE)
         response_data = b"\x03\x00\x06\x00\x02\x01\xb8\x12\x84"
-        with pytest.raises(ValueError, match=r"Invalid function code: 0x03. Expected 0x18"):
+        with pytest.raises(InvalidResponseError, match=r"Invalid function code: 0x03. Expected 0x18"):
             pdu.decode_response(response_data)
 
     def test_decode_response_invalid_byte_count(self) -> None:
@@ -202,7 +205,7 @@ class TestReadFifoQueuePDU:
         pdu = ReadFifoQueuePDU(address=0x04DE)
         # Byte count says 8 but actual data is only 6 bytes (9 total - 3 header = 6)
         response_data = b"\x18\x00\x08\x00\x02\x01\xb8\x12\x84"
-        with pytest.raises(ValueError, match=r"Byte count 8 does not match actual data length 6"):
+        with pytest.raises(InvalidResponseError, match=r"Byte count 8 does not match actual data length 6"):
             pdu.decode_response(response_data)
 
     def test_decode_response_count_mismatch(self) -> None:
@@ -211,7 +214,7 @@ class TestReadFifoQueuePDU:
         # FIFO count says 3 but we only have 2 values
         # Byte count = 2 + 2*2 = 6, FIFO count = 3, but only 2 values follow
         response_data = b"\x18\x00\x06\x00\x03\x01\xb8\x12\x84"
-        with pytest.raises(ValueError, match=r"FIFO count 3 does not match number of values 2"):
+        with pytest.raises(InvalidResponseError, match=r"FIFO count 3 does not match number of values 2"):
             pdu.decode_response(response_data)
 
     def test_round_trip_encode_decode_request(self) -> None:


### PR DESCRIPTION
# Proposed Changes

`ReadFifoQueuePDU` and `ReadExceptionStatusPDU` raised a plain `ValueError` when decoding a malformed request or response, while every other PDU (and the `send_and_receive` contract documented in `async_base.py`) raises `InvalidResponseError` for a bad response and `InvalidRequestError` for a bad request. So a caller that catches `InvalidResponseError` (or `TModbusError`) to handle a hostile or corrupt response from a device would miss these two function codes and get a bare `ValueError` instead.

This brings both PDUs in line with the rest of the library: their `decode_response` paths now raise `InvalidResponseError` and their `decode_request` paths raise `InvalidRequestError`, carrying the same messages and the offending bytes. The `encode_response` value range checks are intentionally left as `ValueError`, since those validate user supplied values rather than data received from the wire, which matches the convention used elsewhere (for example the `write_uint16` range checks).

This is the same consistency fix that was applied to `ReadDeviceIdentificationPDU` in #14, now extended to the last two PDUs that were still raising `ValueError` from their decode paths.

Note: this is a small behaviour change. Callers that catch `ValueError` from `decode_request`/`decode_response` on these two PDUs will need to catch `InvalidRequestError`/`InvalidResponseError` (both subclasses of `TModbusError`) instead. That is the documented contract for decoding, so this aligns the two outliers with it.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
