### PR TITLE
Fix RTU response framing for Read Exception Status

### DIFF
--- a/src/tmodbus/pdu/exception_status.py
+++ b/src/tmodbus/pdu/exception_status.py
@@ -8,6 +8,7 @@ class ReadExceptionStatusPDU(BasePDU[int]):
     """Read Exception Status PDU (Function Code 0x07)."""
 
     function_code: int = FunctionCode.READ_EXCEPTION_STATUS
+    rtu_response_data_length = 1  # a single status byte follows the function code
 
     def encode_request(self) -> bytes:
         """Encode Read Exception Status request PDU.

--- a/tests/pdu/test_exception_status.py
+++ b/tests/pdu/test_exception_status.py
@@ -219,3 +219,16 @@ class TestReadExceptionStatusPDU:
         pdu = ReadExceptionStatusPDU()
         encoded = pdu.encode_request()
         assert len(encoded) == 1
+
+    def test_rtu_response_data_length(self) -> None:
+        """The RTU response data part is a single status byte for any status value.
+
+        Without a fixed length the transport would read the status byte as a byte
+        count, framing a nonzero status (for example 0xFF) far too long.
+        """
+        assert ReadExceptionStatusPDU.rtu_response_data_length == 1
+
+        pdu = ReadExceptionStatusPDU()
+        for status in (0x00, 0x01, 0xFF):
+            response = pdu.encode_response(status)
+            assert pdu.get_expected_response_data_length(response[1:]) == len(response) - 1

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -212,6 +212,42 @@ async def test_send_and_receive_fifo_queue_framing(
     assert result == [0x01B8, 0x1234]
 
 
+async def test_send_and_receive_exception_status_framing(
+    mock_transport: MagicMock,
+) -> None:
+    """Regression: Read Exception Status frames as one status byte over RTU.
+
+    The status byte is not a byte count, so a nonzero status (0xFF) must not be
+    read as a length, which would otherwise frame the response far too long.
+    """
+    from tmodbus.pdu import ReadExceptionStatusPDU  # noqa: PLC0415
+
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = ReadExceptionStatusPDU()
+    unit_id = 1
+    # Response PDU: function code 0x07 followed by status 0xFF (the value that
+    # previously made framing wait for 256 extra bytes).
+    response_pdu = bytes([0x07, 0xFF])
+    payload = bytes([unit_id]) + response_pdu
+    response_adu = payload + calculate_crc16(payload)
+
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    async def simulate_response() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(response_adu)
+
+    result_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    response_task = asyncio.create_task(simulate_response())
+
+    result = await result_task
+    await response_task
+
+    assert result == 0xFF
+
+
 async def test_send_and_receive_not_connected() -> None:
     """Test that send_and_receive raises ModbusConnectionError when not connected."""
     t = AsyncRtuTransport("/dev/ttyUSB0", baudrate=9600)


### PR DESCRIPTION
# Proposed Changes

`ReadExceptionStatusPDU` (function code `0x07`) did not set `rtu_response_data_length`, so the RTU and RTU-over-TCP transports fell back to the default framing logic, which reads the length of the response data part from its first byte.

For this function code that first byte is the status value, not a byte count. A nonzero status therefore framed the response far too long: `0x01` made the transport expect one extra byte and `0xFF` made it expect 256 extra bytes, so the read hung until the timeout fired (or desynced). A status of `0x00` worked only by accident.

The response data part is always exactly one status byte, so this sets `rtu_response_data_length = 1`. This is the same kind of fix that #11 applied to Read FIFO Queue.

Regression tests cover the length calculation directly for several status values and exercise it end to end through the RTU transport with a `0xFF` status (both fail without this change).

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
