### PR TITLE
Fix OrderAwareStruct.unpack_from for nonzero offsets

### DIFF
--- a/src/tmodbus/utils/order_aware_struct.py
+++ b/src/tmodbus/utils/order_aware_struct.py
@@ -217,6 +217,19 @@ class OrderAwareStruct(struct.Struct):
 
     def unpack_from(self, buffer: "ReadableBuffer", offset: int = 0) -> tuple[Any, ...]:
         """Unpack from buffer with word order consideration."""
+        # Handle negative offsets correctly
+        if offset < 0:
+            buf_len = len(memoryview(buffer))
+            if offset + self.size > 0:
+                msg = f"not enough data to unpack {self.size} bytes at offset {offset}"
+                raise struct.error(msg)
+
+            if offset + buf_len < 0:
+                msg = f"offset {offset} out of range for {buf_len}-byte buffer"
+                raise struct.error(msg)
+
+            offset += buf_len
+
         # Reorder only the struct-sized region at `offset`. Transforming the whole
         # buffer first and unpacking at `offset` afterwards would reorder the wrong
         # bytes (the region starting at 0) for any nonzero offset.

--- a/src/tmodbus/utils/order_aware_struct.py
+++ b/src/tmodbus/utils/order_aware_struct.py
@@ -217,7 +217,11 @@ class OrderAwareStruct(struct.Struct):
 
     def unpack_from(self, buffer: "ReadableBuffer", offset: int = 0) -> tuple[Any, ...]:
         """Unpack from buffer with word order consideration."""
-        return super().unpack_from(self._swap_word_order(buffer), offset)
+        # Reorder only the struct-sized region at `offset`. Transforming the whole
+        # buffer first and unpacking at `offset` afterwards would reorder the wrong
+        # bytes (the region starting at 0) for any nonzero offset.
+        region = memoryview(buffer)[offset : offset + self.size]
+        return super().unpack(self._swap_word_order(region))
 
     def pack(self, *args: Any) -> bytes:
         """Pack values into bytes with word order consideration."""

--- a/tests/utils/test_order_aware_struct.py
+++ b/tests/utils/test_order_aware_struct.py
@@ -143,6 +143,30 @@ def test_unpack_from() -> None:
     assert result == (0x0A0B0C0D,)
 
 
+def test_unpack_from_negative_offset_success() -> None:
+    """Test unpack_from resolves valid negative offsets from buffer end."""
+    s = OrderAwareStruct(">I", word_order="big")
+    data = b"\xaa\xbb" + s.pack(0x0A0B0C0D)
+    result = s.unpack_from(data, offset=-4)
+    assert result == (0x0A0B0C0D,)
+
+
+def test_unpack_from_negative_offset_not_enough_data() -> None:
+    """Test unpack_from raises when negative offset points into trailing partial value."""
+    s = OrderAwareStruct(">I", word_order="big")
+    data = b"\x00\x01\x02\x03"
+    with pytest.raises(struct.error, match="not enough data to unpack 4 bytes at offset -2"):
+        s.unpack_from(data, offset=-2)
+
+
+def test_unpack_from_negative_offset_out_of_range() -> None:
+    """Test unpack_from raises when negative offset exceeds buffer start."""
+    s = OrderAwareStruct(">I", word_order="big")
+    data = b"\x00\x01\x02\x03"
+    with pytest.raises(struct.error, match="offset -5 out of range for 4-byte buffer"):
+        s.unpack_from(data, offset=-5)
+
+
 @pytest.mark.parametrize(
     ("word_order", "byte_order"),
     [("big", "big"), ("little", "big"), ("big", "little"), ("little", "little")],

--- a/tests/utils/test_order_aware_struct.py
+++ b/tests/utils/test_order_aware_struct.py
@@ -143,6 +143,23 @@ def test_unpack_from() -> None:
     assert result == (0x0A0B0C0D,)
 
 
+@pytest.mark.parametrize(
+    ("word_order", "byte_order"),
+    [("big", "big"), ("little", "big"), ("big", "little"), ("little", "little")],
+)
+@pytest.mark.parametrize("offset", [0, 1, 2, 5])
+def test_unpack_from_with_offset_and_order(
+    word_order: Literal["big", "little"],
+    byte_order: Literal["big", "little"],
+    offset: int,
+) -> None:
+    """unpack_from must reorder the region at the offset, not the start of the buffer."""
+    value = 0x0A0B0C0D
+    s = OrderAwareStruct(">I", word_order=word_order, byte_order=byte_order)
+    buffer = b"\xaa" * offset + s.pack(value) + b"\xbb" * 4
+    assert s.unpack_from(buffer, offset) == (value,)
+
+
 def test_pack_into() -> None:
     """Test pack_into with buffer and offset."""
     s = OrderAwareStruct(">I", word_order="little")


### PR DESCRIPTION
# Proposed Changes

`OrderAwareStruct.unpack_from(buffer, offset)` reordered the whole buffer with `_swap_word_order(buffer)` and then called `struct`'s `unpack_from` at `offset`. The reordering always operates on the region starting at byte 0 (the value lengths it walks sum to `self.size` starting from index 0), so for any nonzero `offset` combined with a non-standard word or byte order it reordered the wrong bytes and returned a wrong value.

For example, with `OrderAwareStruct(">I", word_order="little", byte_order="big")` and the packed value placed at offset 2, `unpack_from(buffer, 2)` returned `0x00000a0b` instead of `0x0a0b0c0d`.

The fix slices the struct-sized region at the offset first, reorders just that region, and unpacks it. As a side benefit it no longer transforms more of the buffer than necessary. `unpack_from` at offset 0, and all offsets under the standard big/big order, are unchanged.

The library itself only uses `unpack` (offset 0) internally, so this is a latent bug on the public `unpack_from` method rather than a regression in the high level client. New tests cover every word/byte order combination at several offsets.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
