### PR TITLE
Allow device identification object id 0xFF

### DIFF
--- a/src/tmodbus/pdu/device.py
+++ b/src/tmodbus/pdu/device.py
@@ -74,7 +74,7 @@ class ReadDeviceIdentificationPDU(BaseSubFunctionClientPDU[ReadDeviceIdentificat
 
     def __post_init__(self) -> None:
         """Validate ReadDeviceIdentificationPDU."""
-        if not (0x00 <= self.object_id < 0xFF):
+        if not (0x00 <= self.object_id <= 0xFF):
             msg = "Object ID must be between 0x00 and 0xFF."
             raise ValueError(msg)
 

--- a/tests/pdu/test_device.py
+++ b/tests/pdu/test_device.py
@@ -26,9 +26,16 @@ class TestReadDeviceIdentificationPDU:
             ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=-1)
 
     def test_init_invalid_object_id_too_high(self) -> None:
-        """Test creating ReadDeviceIdentificationPDU with object_id >= 0xFF."""
+        """Test creating ReadDeviceIdentificationPDU with object_id above 0xFF."""
         with pytest.raises(ValueError, match=r"Object ID must be between 0x00 and 0xFF\."):
-            ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0xFF)
+            ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x100)
+
+    def test_init_object_id_max_value(self) -> None:
+        """Object ID 0xFF is valid (the top of the extended object range)."""
+        pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0xFF)
+        assert pdu.object_id == 0xFF
+        # And it encodes into the request unchanged.
+        assert pdu.encode_request()[-1] == 0xFF
 
     def test_encode_request(self) -> None:
         """Test encoding request."""


### PR DESCRIPTION
# Proposed Changes

`ReadDeviceIdentificationPDU.__post_init__` validated the object id with `0x00 <= object_id < 0xFF`, so object id `0xFF` was rejected. Both the Modbus spec and the client docstring (`read_device_identification`) describe the object id range as `0x00` to `0xFF`, and `0xFF` is the top of the extended (manufacturer specific) object range, so an individual read of object `0xFF` could not be sent.

This makes the upper bound inclusive (`<= 0xFF`). The boundary test that previously asserted `0xFF` is rejected now uses `0x100`, and a new test confirms `0xFF` is accepted and encoded unchanged.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
