### PR TITLE
Apply connect_timeout when opening TCP connections

### DIFF
--- a/src/tmodbus/transport/async_rtu_over_tcp.py
+++ b/src/tmodbus/transport/async_rtu_over_tcp.py
@@ -91,11 +91,14 @@ class AsyncRtuOverTcpTransport(AsyncBaseTransport):
             return
 
         try:
-            self._transport, self._protocol = await loop.create_connection(
-                lambda: ModbusRtuProtocol(on_connection_lost=self._on_connection_lost, timeout=self.timeout),
-                host=self.host,
-                port=self.port,
-                **self.connection_kwargs,
+            self._transport, self._protocol = await asyncio.wait_for(
+                loop.create_connection(
+                    lambda: ModbusRtuProtocol(on_connection_lost=self._on_connection_lost, timeout=self.timeout),
+                    host=self.host,
+                    port=self.port,
+                    **self.connection_kwargs,
+                ),
+                timeout=self.connect_timeout,
             )
 
             logger.info("Async RTU/TCP connection established: %s:%d", self.host, self.port)

--- a/src/tmodbus/transport/async_tcp.py
+++ b/src/tmodbus/transport/async_tcp.py
@@ -93,11 +93,14 @@ class AsyncTcpTransport(AsyncBaseTransport):
             return
 
         try:
-            self._transport, self._protocol = await loop.create_connection(
-                lambda: ModbusTcpProtocol(on_connection_lost=self._on_connection_lost, timeout=self.timeout),
-                host=self.host,
-                port=self.port,
-                **self.connection_kwargs,
+            self._transport, self._protocol = await asyncio.wait_for(
+                loop.create_connection(
+                    lambda: ModbusTcpProtocol(on_connection_lost=self._on_connection_lost, timeout=self.timeout),
+                    host=self.host,
+                    port=self.port,
+                    **self.connection_kwargs,
+                ),
+                timeout=self.connect_timeout,
             )
 
             logger.info("Async TCP connection established: %s:%d", self.host, self.port)

--- a/tests/transport/test_async_tcp.py
+++ b/tests/transport/test_async_tcp.py
@@ -45,6 +45,22 @@ async def test_open_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
         await t.open()
 
 
+async def test_open_respects_connect_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """open() must give up after connect_timeout when the connection never completes."""
+
+    async def never_connects(*_args: object, **_kwargs: object) -> tuple[None, None]:
+        await asyncio.sleep(10)
+        return None, None
+
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "create_connection", never_connects)
+
+    t = AsyncTcpTransport("host", port=1234, connect_timeout=0.05)
+    with pytest.raises(TimeoutError):
+        await t.open()
+    assert not t.is_open()
+
+
 async def test_is_open_false_when_not_connected() -> None:
     """Test is_open returns False when not connected."""
     t = AsyncTcpTransport("host", port=1234)


### PR DESCRIPTION
# Proposed Changes

`AsyncTcpTransport` and `AsyncRtuOverTcpTransport` accept a `connect_timeout` argument, validate it in `__init__`, and store it, but `open()` called `loop.create_connection()` directly and never used it. So a configured `connect_timeout` had no effect and a connection attempt could block until the operating system or network timed out.

This wraps `create_connection()` in `asyncio.wait_for(..., timeout=self.connect_timeout)`. On timeout the existing `except TimeoutError` handler re-raises, and because `wait_for` cancels the inner coroutine before the result is assigned, `_transport`/`_protocol` are never set and the transport stays closed (`is_open()` returns `False`).

A regression test points `create_connection` at a coroutine that never completes and asserts `open()` raises `TimeoutError` within the configured `connect_timeout`. Without the change the test hangs.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
