### PR TITLE
Raise InvalidResponseError for an unknown device conformity level

### DIFF
--- a/src/tmodbus/pdu/device.py
+++ b/src/tmodbus/pdu/device.py
@@ -119,6 +119,12 @@ class ReadDeviceIdentificationPDU(BaseSubFunctionClientPDU[ReadDeviceIdentificat
             msg = f"Invalid 'more' value: {more:#04x}"
             raise InvalidResponseError(msg, response_bytes=response)
 
+        try:
+            conformity = ConformityLevel(conformity_level)
+        except ValueError as e:
+            msg = f"Invalid conformity level: {conformity_level:#04x}"
+            raise InvalidResponseError(msg, response_bytes=response) from e
+
         objects: dict[int, bytes] = {}
         offset = response_header_struct.size
         while offset < len(response):
@@ -136,7 +142,7 @@ class ReadDeviceIdentificationPDU(BaseSubFunctionClientPDU[ReadDeviceIdentificat
 
         return ReadDeviceIdentificationResponse(
             device_id_code=device_id_code,
-            conformity_level=ConformityLevel(conformity_level),
+            conformity_level=conformity,
             more=bool(more),
             next_object_id=next_object_id,
             number_of_objects=number_of_objects,

--- a/tests/pdu/test_device.py
+++ b/tests/pdu/test_device.py
@@ -150,6 +150,14 @@ class TestReadDeviceIdentificationPDU:
         with pytest.raises(InvalidResponseError, match=r"Invalid 'more' value: 0x01"):
             pdu.decode_response(response)
 
+    def test_decode_response_invalid_conformity_level(self) -> None:
+        """An unknown conformity level raises InvalidResponseError, not a raw ValueError."""
+        pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)
+        # Conformity level 0x04 is not a defined value.
+        response = struct.pack(">BBBBBBB", 0x2B, 0x0E, 0x01, 0x04, 0x00, 0x00, 0x00)
+        with pytest.raises(InvalidResponseError, match=r"Invalid conformity level: 0x04"):
+            pdu.decode_response(response)
+
     def test_decode_response_truncated_header(self) -> None:
         """A response shorter than the header raises InvalidResponseError, not struct.error."""
         pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)


### PR DESCRIPTION
# Proposed Changes

`ReadDeviceIdentificationPDU.decode_response` built the response with `ConformityLevel(conformity_level)`. For any conformity level byte outside the defined set (`0x01`, `0x02`, `0x03`, `0x81`, `0x82`, `0x83`) that raised a bare `ValueError` ("N is not a valid ConformityLevel"), so a caller catching `InvalidResponseError` to handle a malformed device response would miss it.

This converts the conformity level inside a guarded block and raises `InvalidResponseError` instead, matching the rest of the response validation in this PDU (function code, sub function code, `more`, header length). A regression test covers an unknown conformity level.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
