### PR TITLE
Reject odd register byte counts in read responses

### DIFF
--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -74,7 +74,7 @@ class RawReadHoldingRegistersPDU(BasePDU[bytes]):
             msg = f"Invalid response PDU length: expected {2 + byte_count}, got {len(response)}"
             raise InvalidResponseError(msg, response_bytes=response)
 
-        if byte_count // 2 != self.quantity:
+        if byte_count % 2 != 0 or byte_count // 2 != self.quantity:
             msg = f"Invalid register count: expected {self.quantity}, got {byte_count // 2}"
             raise InvalidResponseError(msg, response_bytes=response)
 

--- a/tests/pdu/test_holding_registers.py
+++ b/tests/pdu/test_holding_registers.py
@@ -136,6 +136,14 @@ class TestRawReadHoldingRegistersPDU:
         with pytest.raises(InvalidResponseError, match="Invalid register count"):
             pdu.decode_response(response)
 
+    def test_decode_response_odd_byte_count(self) -> None:
+        """An odd byte count raises InvalidResponseError instead of leaking struct.error."""
+        pdu = RawReadHoldingRegistersPDU(start_address=100, quantity=2)
+        # byte_count 5 is odd; with floor division it would have matched quantity 2.
+        response = b"\x03\x05\x00\x01\x00\x02\x03"
+        with pytest.raises(InvalidResponseError, match="Invalid register count"):
+            pdu.decode_response(response)
+
     def test_decode_response_too_short(self) -> None:
         """Test decoding response that is too short."""
         pdu = RawReadHoldingRegistersPDU(start_address=100, quantity=3)


### PR DESCRIPTION
# Proposed Changes

`RawReadHoldingRegistersPDU.decode_response` validated the register count with `byte_count // 2 != self.quantity`. Because of the floor division, an odd byte count whose halved value happened to match the requested quantity passed the check. For example a 2-register read with `byte_count` 5 (`5 // 2 == 2`) was accepted, and the typed decoder then unpacked the odd-length data and leaked a raw `struct.error` instead of `InvalidResponseError`.

This requires the byte count to be even as well, matching the check `ReadWriteMultipleRegistersPDU` already uses. It covers `ReadHoldingRegistersPDU`, `ReadInputRegistersPDU`, and their raw variants, which all decode through this method. A regression test feeds an odd byte count and asserts `InvalidResponseError`.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
