### PR TITLE
Verify echoed masks in Mask Write Register responses

### DIFF
--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -609,6 +609,13 @@ class MaskWriteRegisterPDU(BasePDU[tuple[int, int]]):
             msg = f"Invalid address: expected {self.address}, received {address}"
             raise InvalidResponseError(msg, response_bytes=response)
 
+        if and_mask != self.and_mask or or_mask != self.or_mask:
+            msg = (
+                f"Mask mismatch: expected AND {self.and_mask:#06x} OR {self.or_mask:#06x}, "
+                f"received AND {and_mask:#06x} OR {or_mask:#06x}"
+            )
+            raise InvalidResponseError(msg, response_bytes=response)
+
         return and_mask, or_mask
 
     @classmethod

--- a/tests/pdu/test_holding_registers.py
+++ b/tests/pdu/test_holding_registers.py
@@ -605,6 +605,14 @@ class TestMaskWriteRegisterPDU:
         with pytest.raises(InvalidResponseError, match=r"Invalid address: expected 4, received 5"):
             pdu.decode_response(response)
 
+    def test_decode_response_mask_mismatch(self) -> None:
+        """A response echoing different masks than requested raises InvalidResponseError."""
+        pdu = MaskWriteRegisterPDU(address=0x0004, and_mask=0xF2F2, or_mask=0x2525)
+        # Correct function code and address, but the OR mask differs from the request.
+        response = b"\x16\x00\x04\xf2\xf2\x99\x99"
+        with pytest.raises(InvalidResponseError, match=r"Mask mismatch"):
+            pdu.decode_response(response)
+
     def test_decode_response_too_short(self) -> None:
         """Test decoding response that is too short."""
         pdu = MaskWriteRegisterPDU(address=0x0004, and_mask=0xF2F2, or_mask=0x2525)


### PR DESCRIPTION
# Proposed Changes

The Mask Write Register response (function code `0x16`) echoes the request: function code, address, AND mask, and OR mask. `MaskWriteRegisterPDU.decode_response` validated the function code and the address but returned the received masks without comparing them to the request, so a device that echoed different masks was reported as success.

This rejects a response whose AND or OR mask differs from the request, matching how the other write PDUs validate their echo (`WriteSingleCoilPDU` and `WriteSingleRegisterPDU` compare the whole response to the request). A regression test covers a mismatched OR mask.

Note: this is a small behaviour change. A nonconforming device that previously returned mismatched masks (which the client then handed back to the caller) will now raise `InvalidResponseError`.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
