### PR TITLE
Export ASCII and RTU-over-TCP transports and factories in __all__

### DIFF
--- a/src/tmodbus/__init__.py
+++ b/src/tmodbus/__init__.py
@@ -245,10 +245,14 @@ def create_async_rtu_over_tcp_client(  # noqa: PLR0913
 
 
 __all__ = [
+    "AsyncAsciiTransport",
     "AsyncModbusClient",
+    "AsyncRtuOverTcpTransport",
     "AsyncRtuTransport",
     "AsyncSmartTransport",
     "AsyncTcpTransport",
+    "create_async_ascii_client",
     "create_async_rtu_client",
+    "create_async_rtu_over_tcp_client",
     "create_async_tcp_client",
 ]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -140,3 +140,22 @@ async def test_create_async_rtu_over_tcp_client() -> None:
     assert client.transport.args[0].kwargs["timeout"] == 5.0
     assert client.transport.args[0].kwargs["connect_timeout"] == 2.0
     assert client.transport.args[0].kwargs["extra"] == 456
+
+
+def test_public_transports_and_factories_are_exported() -> None:
+    """Every public transport and client factory must be in __all__ and importable."""
+    expected = {
+        "AsyncAsciiTransport",
+        "AsyncModbusClient",
+        "AsyncRtuOverTcpTransport",
+        "AsyncRtuTransport",
+        "AsyncSmartTransport",
+        "AsyncTcpTransport",
+        "create_async_ascii_client",
+        "create_async_rtu_client",
+        "create_async_rtu_over_tcp_client",
+        "create_async_tcp_client",
+    }
+    assert expected <= set(tmodbus.__all__)
+    for name in tmodbus.__all__:
+        assert hasattr(tmodbus, name), name


### PR DESCRIPTION
# Proposed Changes

The package imports `AsyncAsciiTransport` and `AsyncRtuOverTcpTransport` and defines the `create_async_ascii_client` and `create_async_rtu_over_tcp_client` factory functions, but `__all__` listed only the TCP, RTU and smart variants. So `from tmodbus import *`, and tooling that relies on `__all__` (documentation, IDEs), hid four documented public APIs.

This adds the four missing names to `__all__` and a test that every public transport and client factory is exported and resolvable.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
