### PR TITLE
Drop misleading tenacity import guard in Smart Transport

### DIFF
--- a/src/tmodbus/transport/async_smart.py
+++ b/src/tmodbus/transport/async_smart.py
@@ -14,19 +14,16 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, TypeVar
 
-try:
-    from tenacity import (
-        AsyncRetrying,
-        RetryCallState,
-        RetryError,
-        retry_any,
-        retry_if_exception_type,
-        stop_after_delay,
-        wait_exponential,
-    )
-except ImportError as ex:  # pragma: no cover
-    msg = "tenacity is required for Smart Transport functionality.Install with 'pip install tmodbus[smart]'"
-    raise ImportError(msg) from ex
+# tenacity is a hard dependency of tmodbus, so it is always available.
+from tenacity import (
+    AsyncRetrying,
+    RetryCallState,
+    RetryError,
+    retry_any,
+    retry_if_exception_type,
+    stop_after_delay,
+    wait_exponential,
+)
 
 from tmodbus.exceptions import (
     ModbusConnectionError,


### PR DESCRIPTION
# Proposed Changes

The Smart Transport module wrapped the `tenacity` import in a `try`/`except ImportError` that raised a friendly error telling users to `pip install tmodbus[smart]`.

That message is wrong on two counts: `tenacity` is a mandatory dependency (`dependencies = ["tenacity>=9.1.2"]`), so the import cannot fail in a correctly installed `tmodbus`, and there is no `smart` extra (only `async-serial` is defined). The guard was dead code pointing users at an install target that does not exist.

This imports `tenacity` directly. If a real optional `smart` extra is wanted later, that is a separate packaging change (move `tenacity` to an extra and guard its use across the smart transport).

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
