### PR TITLE
Drop the unnecessary transaction id lock in the TCP protocol

### DIFF
--- a/src/tmodbus/transport/async_tcp.py
+++ b/src/tmodbus/transport/async_tcp.py
@@ -175,7 +175,6 @@ class ModbusTcpProtocol(asyncio.Protocol):
 
     _buffer: bytearray
     _next_transaction_id: int
-    _transaction_id_lock: asyncio.Lock
     _last_request_finished_at: float = 0.0
     _pending_requests: dict[int, asyncio.Future[_ModbusMessage]]
 
@@ -193,14 +192,14 @@ class ModbusTcpProtocol(asyncio.Protocol):
 
         self._buffer = bytearray()
         self._next_transaction_id = 1
-        self._transaction_id_lock = asyncio.Lock()
         self._pending_requests = {}
 
-    async def _get_next_transaction_id(self) -> int:
-        async with self._transaction_id_lock:
-            current_id = self._next_transaction_id
-            self._next_transaction_id = (self._next_transaction_id + 1) % 0x10000  # 16-bit wraparound
-            return current_id
+    def _get_next_transaction_id(self) -> int:
+        # No lock needed: this runs to completion without an await, so concurrent
+        # callers on the single-threaded event loop cannot interleave here.
+        current_id = self._next_transaction_id
+        self._next_transaction_id = (self._next_transaction_id + 1) % 0x10000  # 16-bit wraparound
+        return current_id
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         """Handle connection made event."""
@@ -227,7 +226,7 @@ class ModbusTcpProtocol(asyncio.Protocol):
             raise ModbusConnectionError(msg)
 
         # 1. Generate transaction ID and build MBAP header
-        current_transaction_id = await self._get_next_transaction_id()
+        current_transaction_id = self._get_next_transaction_id()
 
         request_pdu_bytes = pdu.encode_request()  # Convert PDU to bytes
 

--- a/tests/transport/test_async_tcp.py
+++ b/tests/transport/test_async_tcp.py
@@ -122,8 +122,8 @@ async def test_protocol_transaction_id_wraparound() -> None:
     protocol = ModbusTcpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
 
     protocol._next_transaction_id = 0xFFFF
-    tid1 = await protocol._get_next_transaction_id()
-    tid2 = await protocol._get_next_transaction_id()
+    tid1 = protocol._get_next_transaction_id()
+    tid2 = protocol._get_next_transaction_id()
     assert tid1 == 0xFFFF
     assert tid2 == 0
 


### PR DESCRIPTION
# Proposed Changes

`ModbusTcpProtocol._get_next_transaction_id` acquired an `asyncio.Lock` around a read and increment of `_next_transaction_id`. There is no `await` between reading and writing the counter, so on the single-threaded event loop concurrent callers cannot interleave inside it. The lock only added acquire/release overhead on every TCP request.

This makes the helper synchronous and removes the lock and its field. The wraparound test is updated to call it without `await`.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
