### PR TITLE
Fix stale references and examples in the documentation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -6,9 +6,9 @@ functions provided in the :mod:`tmodbus` module and use the functions of the ret
 :class:`~tmodbus.client.AsyncModbusClient` instance to interact with a Modbus server.
 
 If your Modbus device uses non-standard function codes or requires special handling, you
-can create a custom PDU class by inheriting from
-:class:`~tmodbus.pdu.pdu_modbus.ModbusClientPDU` and implementing the necessary methods.
-cfr. :doc:`Vendor functions <vendor_functions>` for more details.
+can create a custom PDU class by inheriting from :class:`~tmodbus.pdu.BaseClientPDU` and
+implementing the necessary methods. cfr. :doc:`Vendor functions <vendor_functions>` for
+more details.
 
 General
 -------
@@ -62,9 +62,9 @@ When the server responds with an error, tModbus will raise the corresponding sub
 - 0x01 Illegal function: :class:`~tmodbus.exceptions.IllegalFunctionError`
 - 0x02 Illegal data address: :class:`~tmodbus.exceptions.IllegalDataAddressError`
 - 0x03 Illegal data value: :class:`~tmodbus.exceptions.IllegalDataValueError`
-- 0x04 Slave device failure: :class:`~tmodbus.exceptions.SlaveDeviceFailureError`
+- 0x04 Server device failure: :class:`~tmodbus.exceptions.ServerDeviceFailureError`
 - 0x05 Acknowledge: :class:`~tmodbus.exceptions.AcknowledgeError`
-- 0x06 Slave device busy: :class:`~tmodbus.exceptions.SlaveDeviceBusyError`
+- 0x06 Server device busy: :class:`~tmodbus.exceptions.ServerDeviceBusyError`
 - 0x08 Memory parity error: :class:`~tmodbus.exceptions.MemoryParityError`
 - 0x0A Gateway path unavailable:
   :class:`~tmodbus.exceptions.GatewayPathUnavailableError`
@@ -75,7 +75,7 @@ If an unknown exception code is returned, a generic
 :class:`~tmodbus.exceptions.ModbusResponseError` will be raised.
 
 When the server responds with an invalid response, tModbus will raise the corresponding
-subclass of :class:`~tmodbus.exceptions.ModbusInvalidResponseError`:
+subclass of :class:`~tmodbus.exceptions.InvalidResponseError`:
 
 - RTU Frame Error: :class:`~tmodbus.exceptions.RTUFrameError`
 - Invalid CRC: :class:`~tmodbus.exceptions.CRCError`

--- a/docs/source/batch_reading.rst
+++ b/docs/source/batch_reading.rst
@@ -14,7 +14,7 @@ to define the data structure of the registers we want to read. You can pass any
 :meth:`~tmodbus.pdu.holding_registers_struct.HoldingRegisterReadMixin.read_struct_format`
 method.
 
-For example, if we want to read 10 consecutive holding registers starting from address
+For example, if we want to read 6 consecutive holding registers starting from address
 100, and interpret them as two 32-bit integers followed by a 32-bit float, we can do the
 following:
 

--- a/docs/source/vendor_function_example.py
+++ b/docs/source/vendor_function_example.py
@@ -19,7 +19,6 @@ class LoginRequestChallengePDU(BaseSubFunctionClientPDU[LoginChallenge]):
 
     function_code = 0x41
     sub_function_code = 0x24
-    rtu_byte_count_pos = 3
 
     def encode_request(self) -> bytes:
         """Encode LoginRequestChallengePDU."""
@@ -43,15 +42,17 @@ class LoginRequestChallengePDU(BaseSubFunctionClientPDU[LoginChallenge]):
             )
             raise ValueError(msg)
 
-        expected_response_content_length = 17
-        if expected_response_content_length != response_content_length:
+        inverter_challenge_length = 16
+        # The content length byte counts the bytes that follow it, which is the
+        # challenge itself. This is also what the default sub-function RTU framing
+        # (1 sub-function byte + 1 length byte + length) relies on.
+        if response_content_length != inverter_challenge_length:
             msg = (
-                f"Invalid response content length length: expected {expected_response_content_length}, "
+                f"Invalid response content length: expected {inverter_challenge_length}, "
                 f"received {response_content_length}"
             )
             raise ValueError(msg)
 
-        inverter_challenge_length = 16
         return LoginChallenge(
             challenge=response[response_header_struct.size : response_header_struct.size + inverter_challenge_length]
         )

--- a/src/tmodbus/client/async_client.py
+++ b/src/tmodbus/client/async_client.py
@@ -139,7 +139,7 @@ class AsyncModbusClient(HoldingRegisterReadMixin, HoldingRegisterWriteMixin):
             InvalidResponseError: If response is invalid or does not match request
 
         Example:
-            >>> coils = await client.read_coils(1, 0, 8)
+            >>> coils = await client.read_coils(0, 8)
             [True, False, True, False, False, False, True, False]
 
         """
@@ -160,7 +160,7 @@ class AsyncModbusClient(HoldingRegisterReadMixin, HoldingRegisterWriteMixin):
             List of coil status, True for ON, False for OFF
 
         Example:
-            >>> coils = await client.read_coils(1, 0, 8)
+            >>> inputs = await client.read_discrete_inputs(0, 8)
             [True, False, True, False, False, False, True, False]
 
         """
@@ -406,11 +406,14 @@ class AsyncModbusClient(HoldingRegisterReadMixin, HoldingRegisterWriteMixin):
 
 
         Returns:
-            A dictionary mapping object IDs to their corresponding string values.
+            A dictionary mapping object IDs to their raw byte values. Decode them
+            with the encoding the device documents (commonly ASCII).
 
         Example:
             >>> device_info = await client.read_device_identification(1, 0)
-            {0: 'VendorName', 1: 'ProductCode', ...}
+            {0: b'VendorName', 1: b'ProductCode', ...}
+            >>> device_info[0].decode("ascii")
+            'VendorName'
 
         """
         result: dict[int, bytes] = {}


### PR DESCRIPTION
# Proposed Changes

A batch of documentation fixes found while auditing the docs against the code.

- `api.rst` referenced classes and exceptions that do not exist. The custom PDU section now points at `BaseClientPDU`, and the exception list uses the real names `ServerDeviceFailureError`, `ServerDeviceBusyError`, and `InvalidResponseError` (previously `SlaveDeviceFailureError`, `SlaveDeviceBusyError`, `ModbusInvalidResponseError`).
- The client docstring examples called `read_coils` with three positional arguments and used `read_coils` for the discrete inputs example. They now match the real signatures (`read_coils(0, 8)`, `read_discrete_inputs(0, 8)`). `read_device_identification` returns `dict[int, bytes]`, not strings, so the example shows bytes and how to decode them.
- The vendor function example declared an unused `rtu_byte_count_pos` and validated a content length of `17` for a 16-byte challenge, which does not line up with the default sub-function RTU framing (`1 + 1 + length`). The length check now uses the challenge length, so the example frames consistently. Verified: `get_expected_response_data_length` returns the correct frame length and decode round-trips.
- `batch_reading.rst` said the example reads "10 consecutive holding registers" while the `>iif` struct and the very next sentence describe 6.

Documentation only, no behaviour change.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
