### PR TITLE
Reject trailing bytes in Report Server ID responses

### DIFF
--- a/src/tmodbus/pdu/serial_line.py
+++ b/src/tmodbus/pdu/serial_line.py
@@ -67,8 +67,8 @@ class ReportServerIdPDU(BasePDU[ServerIdResponse]):
             msg = f"Invalid function code: expected {self.function_code:#04x}, received {function_code:#04x}"
             raise InvalidResponseError(msg, response_bytes=response)
 
-        if len(response) < 2 + byte_count:
-            msg = f"Response length {len(response)} is less than expected {2 + byte_count}"
+        if len(response) != 2 + byte_count:
+            msg = f"Response length {len(response)} does not match expected {2 + byte_count}"
             raise InvalidResponseError(msg, response_bytes=response)
 
         # we can the data after the byte count for the status indicator byte to know

--- a/tests/pdu/test_serial_line.py
+++ b/tests/pdu/test_serial_line.py
@@ -57,6 +57,14 @@ def test_decode_response_invalid_function_code() -> None:
         pdu.decode_response(response)
 
 
+def test_decode_response_trailing_bytes() -> None:
+    """Trailing bytes beyond the declared byte count are rejected."""
+    pdu = ReportServerIdPDU()
+    response = make_response(pdu.function_code, b"abc", ID_ON, b"xyz") + b"\x00\x00"
+    with pytest.raises(InvalidResponseError, match="Response length"):
+        pdu.decode_response(response)
+
+
 def test_decode_response_invalid_length() -> None:
     """Test decode_response raises InvalidResponseError if the response is too short for the byte count."""
     pdu = ReportServerIdPDU()


### PR DESCRIPTION
# Proposed Changes

`ReportServerIdPDU.decode_response` validated the response with `len(response) < 2 + byte_count`, so a response longer than the declared byte count passed and the trailing bytes were silently ignored. A malformed or misframed response (extra bytes after the data) was accepted as valid, masking a framing or device problem.

This requires the response length to match `2 + byte_count` exactly. A regression test covers trailing bytes.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
