### PR TITLE
Clean up half-open serial transport when open() times out

### DIFF
--- a/src/tmodbus/transport/async_ascii.py
+++ b/src/tmodbus/transport/async_ascii.py
@@ -412,10 +412,19 @@ class AsyncAsciiTransport(AsyncBaseTransport):
 
         except TimeoutError:
             logger.warning("Async Serial connection timeout: %s", self.port, exc_info=True)
+            self._abort_failed_open()
             raise
         except Exception as e:
             logger.exception("Async Serial connection error: %s", self.port)
+            self._abort_failed_open()
             raise ModbusConnectionError from e
+
+    def _abort_failed_open(self) -> None:
+        """Close and clear a partially opened transport after a failed open."""
+        if self._transport is not None:
+            self._transport.close()
+        self._transport = None
+        self._protocol = None
 
     async def close(self) -> None:
         """Close Serial connection."""

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -208,10 +208,19 @@ class AsyncRtuTransport(AsyncBaseTransport):
 
         except TimeoutError:
             logger.warning("Async serial connection timeout: %s", self.port, exc_info=True)
+            self._abort_failed_open()
             raise
         except Exception as e:
             logger.exception("Async serial connection error: %s", self.port)
+            self._abort_failed_open()
             raise ModbusConnectionError from e
+
+    def _abort_failed_open(self) -> None:
+        """Close and clear a partially opened transport after a failed open."""
+        if self._transport is not None:
+            self._transport.close()
+        self._transport = None
+        self._protocol = None
 
     async def close(self) -> None:
         """Close Serial connection."""

--- a/tests/transport/test_async_ascii.py
+++ b/tests/transport/test_async_ascii.py
@@ -255,6 +255,27 @@ async def test_open_already_open() -> None:
         assert t.is_open()
 
 
+async def test_open_timeout_waiting_for_connection_made(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If connection_made never fires, open() times out and leaves no half-open transport."""
+    mock_transport = MagicMock(spec=asyncio.WriteTransport)
+    mock_transport.is_closing.return_value = False
+
+    async def fake_create_serial_connection(
+        _loop: Any, protocol_factory: Callable[[], ModbusAsciiProtocol], **_kwargs: Any
+    ) -> tuple[asyncio.Transport, asyncio.Protocol]:
+        # Return a transport/protocol but never call connection_made.
+        return mock_transport, protocol_factory()
+
+    monkeypatch.setattr(serialx, "create_serial_connection", fake_create_serial_connection)
+
+    t = AsyncAsciiTransport("/dev/ttyUSB0", baudrate=9600, timeout=0.05)
+    with pytest.raises(TimeoutError):
+        await t.open()
+
+    assert not t.is_open()
+    mock_transport.close.assert_called_once()
+
+
 async def test_open_and_close(
     mock_serial_connection: tuple[MagicMock, Callable[[], ModbusAsciiProtocol | None]],
 ) -> None:

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -120,6 +120,27 @@ async def test_open_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
         await t.open()
 
 
+async def test_open_timeout_waiting_for_connection_made(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If connection_made never fires, open() times out and leaves no half-open transport."""
+    mock_transport = MagicMock(spec=asyncio.WriteTransport)
+    mock_transport.is_closing.return_value = False
+
+    async def fake_create_serial_connection(
+        _loop: Any, protocol_factory: Callable[[], ModbusRtuProtocol], **_kwargs: Any
+    ) -> tuple[asyncio.Transport, asyncio.Protocol]:
+        # Return a transport/protocol but never call connection_made.
+        return mock_transport, protocol_factory()
+
+    monkeypatch.setattr(serialx, "create_serial_connection", fake_create_serial_connection)
+
+    t = AsyncRtuTransport("/dev/ttyUSB0", baudrate=9600, timeout=0.05)
+    with pytest.raises(TimeoutError):
+        await t.open()
+
+    assert not t.is_open()
+    mock_transport.close.assert_called_once()
+
+
 @pytest.mark.usefixtures("mock_serial_connection")
 async def test_open_close_is_open() -> None:
     """Test open, close, and is_open functionality."""


### PR DESCRIPTION
# Proposed Changes

`AsyncRtuTransport.open` and `AsyncAsciiTransport.open` assign `self._transport` and `self._protocol` as soon as `serialx.create_serial_connection` returns, and then wait for `connection_made_event` (serialx can be slow to call `connection_made`).

If that second wait timed out, or any later error occurred, `open()` raised but `_transport`/`_protocol` were left set. `is_open()` then returned `True` even though the connection was never fully established, and the underlying transport was leaked (never closed).

This adds an `_abort_failed_open` helper that closes the transport and resets `_transport`/`_protocol` to `None`, called from both failure handlers. A failed open now leaves the transport cleanly closed and `is_open()` returns `False`.

Regression tests (RTU and ASCII) simulate a connection where `connection_made` never fires, and assert `open()` raises `TimeoutError`, `is_open()` is `False`, and the transport was closed. Both fail without this change.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
