### PR TITLE
Enforce Modbus byte-count limits on File Record requests

### DIFF
--- a/src/tmodbus/pdu/file.py
+++ b/src/tmodbus/pdu/file.py
@@ -10,6 +10,12 @@ from .base import BasePDU
 
 FILE_RECORD_REFERENCE_TYPE = 0x06  # reference type for file records
 
+# Modbus caps the request byte count of these function codes at a single byte. The
+# specification limits Read File Record (0x14) to 0xF5 and Write File Record (0x15)
+# to 0xFB bytes.
+MAX_READ_FILE_RECORD_BYTE_COUNT = 0xF5
+MAX_WRITE_FILE_RECORD_BYTE_COUNT = 0xFB
+
 
 @dataclass(frozen=True)
 class FileRecordRequest:
@@ -51,6 +57,18 @@ class ReadFileRecordPDU(BasePDU[list[bytes]]):
             if not (1 <= request.record_length <= 0xFFFF):
                 msg = "Record length must be between 1 and 65535."
                 raise InvalidRequestError(msg)
+
+        if not requests:
+            msg = "At least one file record request is required."
+            raise InvalidRequestError(msg)
+
+        byte_count = len(requests) * SUB_REQUEST_STRUCT.size
+        if byte_count > MAX_READ_FILE_RECORD_BYTE_COUNT:
+            msg = (
+                f"Read File Record request byte count {byte_count} exceeds the "
+                f"maximum of {MAX_READ_FILE_RECORD_BYTE_COUNT}."
+            )
+            raise InvalidRequestError(msg)
 
         self.requests = requests
 
@@ -231,6 +249,21 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
             if not (0 <= len(record.data) <= 0xFFFF):
                 msg = "Record data length must be between 0 and 65535 bytes."
                 raise InvalidRequestError(msg)
+
+        if not self.file_records:
+            msg = "At least one file record is required."
+            raise InvalidRequestError(msg)
+
+        # Each record is a 7-byte header plus its data, padded up to an even length.
+        byte_count = sum(
+            SUB_REQUEST_STRUCT.size + len(record.data) + (len(record.data) % 2) for record in self.file_records
+        )
+        if byte_count > MAX_WRITE_FILE_RECORD_BYTE_COUNT:
+            msg = (
+                f"Write File Record request byte count {byte_count} exceeds the "
+                f"maximum of {MAX_WRITE_FILE_RECORD_BYTE_COUNT}."
+            )
+            raise InvalidRequestError(msg)
 
     @classmethod
     def _encode(cls, file_records: list[FileRecord]) -> bytes:

--- a/tests/pdu/test_file.py
+++ b/tests/pdu/test_file.py
@@ -109,6 +109,19 @@ class TestReadFileRecordPDU:
         with pytest.raises(InvalidRequestError, match="Record length must be between 1 and 65535"):
             ReadFileRecordPDU([FileRecordRequest(file_number=0, record_number=0, record_length=0x10000)])
 
+    def test_validation_empty_requests(self) -> None:
+        """An empty request list is rejected."""
+        with pytest.raises(InvalidRequestError, match="At least one file record request"):
+            ReadFileRecordPDU([])
+
+    def test_validation_too_many_requests(self) -> None:
+        """More sub-requests than fit in the one-byte byte count are rejected."""
+        # 36 requests is 252 bytes, over the 0xF5 (245) maximum; 35 is the limit.
+        requests = [FileRecordRequest(file_number=0, record_number=0, record_length=1)] * 36
+        with pytest.raises(InvalidRequestError, match="exceeds the maximum"):
+            ReadFileRecordPDU(requests)
+        ReadFileRecordPDU(requests[:35])  # the maximum is accepted
+
     def test_decode_response_valid_single_record(self) -> None:
         """Test decoding a valid response with a single record."""
         requests = [FileRecordRequest(file_number=4, record_number=1, record_length=2)]
@@ -407,6 +420,19 @@ class TestWriteFileRecordPDU:
         # Data length must not exceed 65535 bytes
         with pytest.raises(InvalidRequestError, match="Record data length must be between 0 and 65535 bytes"):
             WriteFileRecordPDU(file_records=[FileRecord(file_number=0, record_number=0, data=b"\x00" * 65536)])
+
+    def test_validation_empty_records(self) -> None:
+        """An empty record list is rejected."""
+        with pytest.raises(InvalidRequestError, match="At least one file record"):
+            WriteFileRecordPDU(file_records=[])
+
+    def test_validation_byte_count_too_large(self) -> None:
+        """A record whose total byte count exceeds the one-byte field is rejected."""
+        # 7-byte header + 246 data bytes = 253, over the 0xFB (251) maximum.
+        with pytest.raises(InvalidRequestError, match="exceeds the maximum"):
+            WriteFileRecordPDU(file_records=[FileRecord(file_number=0, record_number=0, data=b"\x00" * 246)])
+        # 244 data bytes (7 + 244 = 251) is the limit and is accepted.
+        WriteFileRecordPDU(file_records=[FileRecord(file_number=0, record_number=0, data=b"\x00" * 244)])
 
     def test_decode_response_valid_single_record(self) -> None:
         """Test decoding a valid response with a single record."""


### PR DESCRIPTION
# Proposed Changes

The request byte count of Read File Record (`0x14`) and Write File Record (`0x15`) is encoded as a single byte, but neither PDU validated it:

- `ReadFileRecordPDU` builds the byte count from `len(requests) * 7`. With enough sub-requests this overflowed the one-byte field and failed late with a `struct.error` at `encode_request` time (or produced an invalid frame). An empty request list produced a malformed PDU with a byte count of 0.
- `WriteFileRecordPDU` builds the byte count from the (padded) record data. Too much data overflowed the same way.

This validates the request byte count against the specification limits at construction time: `0xF5` (245) for Read File Record and `0xFB` (251) for Write File Record, and rejects an empty request list. The error is now raised early as `InvalidRequestError` rather than as a late `struct.error`.

Regression tests cover the empty case, the maximum that is still accepted, and one over the maximum, for both PDUs.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
