### PR TITLE
Error on write of odd length payloads

### DIFF
--- a/src/tmodbus/pdu/file.py
+++ b/src/tmodbus/pdu/file.py
@@ -277,7 +277,8 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
         for record in file_records:
             record_data = record.data
             if len(record_data) % 2 != 0:
-                record_data += b"\x00"  # pad with zero byte if odd length
+                msg = "Record data length cannot be odd; each register is 2 bytes."
+                raise ValueError(msg)
 
             records_bytes += SUB_REQUEST_STRUCT.pack(
                 FILE_RECORD_REFERENCE_TYPE,

--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -351,7 +351,8 @@ class RawWriteMultipleRegistersPDU(BasePDU[int]):
             raise ValueError(msg)
 
         if len(content) % 2 != 0:
-            content += b"\x00"  # Pad with zero if odd length
+            msg = "Content length cannot be odd; each register is 2 bytes."
+            raise ValueError(msg)
 
         self.content = content
 

--- a/tests/pdu/test_file.py
+++ b/tests/pdu/test_file.py
@@ -389,15 +389,11 @@ class TestWriteFileRecordPDU:
         assert encoded[1] == 20  # byte count
 
     def test_encode_request_odd_length_data(self) -> None:
-        """Test encoding with odd-length data (should be padded)."""
+        """Odd-length payloads are rejected because registers are 2 bytes."""
         records = [FileRecord(file_number=1, record_number=0, data=b"\x00\x01\x02")]
         pdu = WriteFileRecordPDU(file_records=records)
-        encoded = pdu.encode_request()
-
-        # Odd length (3 bytes) should be padded to 4 bytes (2 registers)
-        # Header: 7 bytes, Data: 4 bytes (3 + 1 padding)
-        assert encoded[1] == 11  # byte count
-        assert struct.unpack(">H", encoded[7:9])[0] == 2  # record length is 2 registers
+        with pytest.raises(ValueError, match="Record data length cannot be odd"):
+            pdu.encode_request()
 
     def test_validation_file_number_invalid(self) -> None:
         """Test that invalid file numbers raise InvalidRequestError."""

--- a/tests/pdu/test_holding_registers.py
+++ b/tests/pdu/test_holding_registers.py
@@ -341,11 +341,11 @@ class TestRawWriteMultipleRegistersPDU:
         assert pdu.start_address == 100
         assert pdu.content == content
 
-    def test_initialization_pads_odd_length(self) -> None:
-        """Test that odd-length content is padded."""
+    def test_initialization_rejects_odd_length(self) -> None:
+        """Odd-length content is rejected because registers are 2 bytes."""
         content = b"\x12\x34\x56"
-        pdu = RawWriteMultipleRegistersPDU(start_address=100, content=content)
-        assert pdu.content == b"\x12\x34\x56\x00"
+        with pytest.raises(ValueError, match="Content length cannot be odd"):
+            RawWriteMultipleRegistersPDU(start_address=100, content=content)
 
     @pytest.mark.parametrize(
         ("start_address", "content", "expected_error"),


### PR DESCRIPTION
# Proposed Changes

Instead of silently padding odd-length values received in `RawWriteMultipleRegistersPDU` or `WriteFileRecordPDU`, which is undesirable because it most likely points to a bug in the user code, we now explicitly throw a `ValueError`.

## Related Issues

Fixes #38
