### PR TITLE
Make errors thrown for invalid requests consistent

### DIFF
--- a/src/tmodbus/pdu/coils.py
+++ b/src/tmodbus/pdu/coils.py
@@ -110,7 +110,10 @@ class ReadCoilsPDU(BasePDU[list[bool]]):
             msg = f"Invalid function code: expected {cls.function_code:#04x}, received {function_code:#04x}"
             raise InvalidRequestError(msg, request_bytes=request)
 
-        return cls(address, quantity)
+        try:
+            return cls(address, quantity)
+        except ValueError as e:
+            raise InvalidRequestError(str(e), request_bytes=request) from e
 
     def encode_response(self, value: list[bool]) -> bytes:
         """Convert PDU to bytes.
@@ -160,6 +163,9 @@ class WriteSingleCoilPDU(BasePDU[bool]):
 
         """
         super().__init__()
+        if not (0 <= address < 65536):
+            msg = "Address must be between 0 and 65535."
+            raise ValueError(msg)
         self.address = address
         self.value = value
 
@@ -213,7 +219,10 @@ class WriteSingleCoilPDU(BasePDU[bool]):
             msg = f"Invalid coil value: {coil_value:#06x}"
             raise InvalidRequestError(msg, request_bytes=request)
 
-        return cls(address, coil_value == 0xFF00)
+        try:
+            return cls(address, coil_value == 0xFF00)
+        except ValueError as e:
+            raise InvalidRequestError(str(e), request_bytes=request) from e
 
     def encode_response(self, value: bool) -> bytes:  # noqa: FBT001
         """Encode the response PDU.
@@ -349,7 +358,10 @@ class WriteMultipleCoilsPDU(BasePDU[int]):
         for byte in data:
             values += _BIT_TABLE[byte]
 
-        return cls(start_address, values[:quantity])
+        try:
+            return cls(start_address, values[:quantity])
+        except ValueError as e:
+            raise InvalidRequestError(str(e), request_bytes=request) from e
 
     def encode_response(self, value: int) -> bytes:
         """Encode the response PDU.

--- a/src/tmodbus/pdu/file.py
+++ b/src/tmodbus/pdu/file.py
@@ -44,23 +44,23 @@ class ReadFileRecordPDU(BasePDU[list[bytes]]):
             requests: List of FileRecordRequest instances to request.
 
         Raises:
-            InvalidRequestError: If any record is invalid.
+            ValueError: If any record is invalid.
 
         """
         for request in requests:
             if not (0 <= request.file_number <= 0xFFFF):
                 msg = "File number must be between 0 and 65535."
-                raise InvalidRequestError(msg)
+                raise ValueError(msg)
             if not (0 <= request.record_number <= 9999):
                 msg = "Record number must be between 0 and 9999."
-                raise InvalidRequestError(msg)
+                raise ValueError(msg)
             if not (1 <= request.record_length <= 0xFFFF):
                 msg = "Record length must be between 1 and 65535."
-                raise InvalidRequestError(msg)
+                raise ValueError(msg)
 
         if not requests:
             msg = "At least one file record request is required."
-            raise InvalidRequestError(msg)
+            raise ValueError(msg)
 
         byte_count = len(requests) * SUB_REQUEST_STRUCT.size
         if byte_count > MAX_READ_FILE_RECORD_BYTE_COUNT:
@@ -68,7 +68,7 @@ class ReadFileRecordPDU(BasePDU[list[bytes]]):
                 f"Read File Record request byte count {byte_count} exceeds the "
                 f"maximum of {MAX_READ_FILE_RECORD_BYTE_COUNT}."
             )
-            raise InvalidRequestError(msg)
+            raise ValueError(msg)
 
         self.requests = requests
 
@@ -217,7 +217,10 @@ class ReadFileRecordPDU(BasePDU[list[bytes]]):
 
             offset += SUB_REQUEST_STRUCT.size
 
-        return cls(requests)
+        try:
+            return cls(requests)
+        except ValueError as e:
+            raise InvalidRequestError(str(e), request_bytes=request) from e
 
 
 @dataclass(frozen=True)
@@ -242,17 +245,17 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
         for record in self.file_records:
             if not (0 <= record.file_number <= 0xFFFF):
                 msg = "File number must be between 0 and 65535."
-                raise InvalidRequestError(msg)
+                raise ValueError(msg)
             if not (0 <= record.record_number <= 9999):
                 msg = "Record number must be between 0 and 9999."
-                raise InvalidRequestError(msg)
+                raise ValueError(msg)
             if not (0 <= len(record.data) <= 0xFFFF):
                 msg = "Record data length must be between 0 and 65535 bytes."
-                raise InvalidRequestError(msg)
+                raise ValueError(msg)
 
         if not self.file_records:
             msg = "At least one file record is required."
-            raise InvalidRequestError(msg)
+            raise ValueError(msg)
 
         # Each record is a 7-byte header plus its data, padded up to an even length.
         byte_count = sum(
@@ -263,7 +266,7 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
                 f"Write File Record request byte count {byte_count} exceeds the "
                 f"maximum of {MAX_WRITE_FILE_RECORD_BYTE_COUNT}."
             )
-            raise InvalidRequestError(msg)
+            raise ValueError(msg)
 
     @classmethod
     def _encode(cls, file_records: list[FileRecord]) -> bytes:
@@ -403,4 +406,52 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
             InvalidRequestError: If the request is invalid.
 
         """
-        return cls(WriteFileRecordPDU._decode(request))
+        try:
+            function_code, byte_count = struct.unpack_from(">BB", request, 0)
+        except struct.error as e:
+            msg = "Expected request to start with function code and byte count"
+            raise InvalidRequestError(msg, request_bytes=request) from e
+
+        if function_code != cls.function_code:
+            msg = f"Invalid function code: expected {cls.function_code:#04x}, received {function_code:#04x}"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        if len(request) - 2 != byte_count:
+            msg = f"Request length {len(request)} is not equal to expected {2 + byte_count}"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        records: list[FileRecord] = []
+        offset = 2
+        end_offset = 2 + byte_count
+
+        while offset < end_offset:
+            try:
+                reference_type, file_number, record_number, record_length = SUB_REQUEST_STRUCT.unpack_from(
+                    request, offset
+                )
+            except struct.error as e:
+                msg = "Failed to unpack file record header"
+                raise InvalidRequestError(msg, request_bytes=request) from e
+
+            if reference_type != FILE_RECORD_REFERENCE_TYPE:
+                msg = (
+                    f"Invalid reference type: expected {FILE_RECORD_REFERENCE_TYPE:#04x}, "
+                    f"received {reference_type:#04x}"
+                )
+                raise InvalidRequestError(msg, request_bytes=request)
+
+            data_start = offset + SUB_REQUEST_STRUCT.size
+            data_end = data_start + record_length * 2
+
+            if data_end > len(request):
+                msg = "Not enough data for the specified record length"
+                raise InvalidRequestError(msg, request_bytes=request)
+
+            record_data = request[data_start:data_end]
+            records.append(FileRecord(file_number, record_number, record_data))
+            offset = data_end
+
+        try:
+            return cls(records)
+        except ValueError as e:
+            raise InvalidRequestError(str(e), request_bytes=request) from e

--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -101,7 +101,10 @@ class RawReadHoldingRegistersPDU(BasePDU[bytes]):
             msg = f"Invalid function code: expected {cls.function_code:#04x}, received {function_code:#04x}"
             raise InvalidRequestError(msg, request_bytes=request)
 
-        return cls(address, quantity)
+        try:
+            return cls(address, quantity)
+        except ValueError as e:
+            raise InvalidRequestError(str(e), request_bytes=request) from e
 
     def encode_response(self, value: bytes) -> bytes:
         """Encode the response PDU with raw bytes.
@@ -181,7 +184,10 @@ class ReadHoldingRegistersPDU(BasePDU[list[int]]):
             msg = f"Invalid function code: expected {cls.function_code:#04x}, received {function_code:#04x}"
             raise InvalidRequestError(msg, request_bytes=request)
 
-        return cls(address, quantity)
+        try:
+            return cls(address, quantity)
+        except ValueError as e:
+            raise InvalidRequestError(str(e), request_bytes=request) from e
 
     def encode_response(self, value: list[int]) -> bytes:
         """Encode the response PDU with register values.
@@ -308,7 +314,10 @@ class WriteSingleRegisterPDU(BasePDU[int]):
             msg = f"Invalid function code: expected {cls.function_code:#04x}, received {function_code:#04x}"
             raise InvalidRequestError(msg, request_bytes=request)
 
-        return cls(address, value)
+        try:
+            return cls(address, value)
+        except ValueError as e:
+            raise InvalidRequestError(str(e), request_bytes=request) from e
 
     def encode_response(self, value: int) -> bytes:
         """Encode the response PDU.
@@ -436,7 +445,10 @@ class RawWriteMultipleRegistersPDU(BasePDU[int]):
         if len(content) != byte_count:
             msg = f"Invalid data length: expected {byte_count}, got {len(content)}"
             raise InvalidRequestError(msg, request_bytes=request)
-        return cls(start_address, content)
+        try:
+            return cls(start_address, content)
+        except ValueError as e:
+            raise InvalidRequestError(str(e), request_bytes=request) from e
 
     def encode_response(self, value: int) -> bytes:
         """Encode the response PDU.
@@ -529,7 +541,10 @@ class WriteMultipleRegistersPDU(BasePDU[int]):
         raw = RawWriteMultipleRegistersPDU.decode_request(request)
         # Convert content bytes to list of ints
         values = list(struct.unpack(f">{'H' * (len(raw.content) // 2)}", raw.content))
-        return cls(raw.start_address, values)
+        try:
+            return cls(raw.start_address, values)
+        except ValueError as e:
+            raise InvalidRequestError(str(e), request_bytes=request) from e
 
     def encode_response(self, value: int) -> bytes:
         """Encode the response PDU.
@@ -643,7 +658,10 @@ class MaskWriteRegisterPDU(BasePDU[tuple[int, int]]):
             msg = f"Invalid function code: expected {cls.function_code:#04x}, received {function_code:#04x}"
             raise InvalidRequestError(msg, request_bytes=request)
 
-        return cls(address, and_mask, or_mask)
+        try:
+            return cls(address, and_mask, or_mask)
+        except ValueError as e:
+            raise InvalidRequestError(str(e), request_bytes=request) from e
 
     def encode_response(self, value: tuple[int, int]) -> bytes:
         """Encode the response PDU.
@@ -797,12 +815,15 @@ class ReadWriteMultipleRegistersPDU(BasePDU[list[int]]):
             raise InvalidRequestError(msg, request_bytes=request)
 
         write_values = list(struct.unpack(f">{'H' * (write_quantity)}", content))
-        return cls(
-            read_start_address=read_start_address,
-            read_quantity=read_quantity,
-            write_start_address=write_start_address,
-            write_values=write_values,
-        )
+        try:
+            return cls(
+                read_start_address=read_start_address,
+                read_quantity=read_quantity,
+                write_start_address=write_start_address,
+                write_values=write_values,
+            )
+        except ValueError as e:
+            raise InvalidRequestError(str(e), request_bytes=request) from e
 
     def encode_response(self, value: list[int]) -> bytes:
         """Encode the response PDU with register values.

--- a/tests/pdu/test_coils.py
+++ b/tests/pdu/test_coils.py
@@ -107,6 +107,12 @@ class TestReadCoilsPDU:
         with pytest.raises(InvalidRequestError, match=r"Invalid function code: expected 0x01, received 0x02"):
             ReadCoilsPDU.decode_request(request)
 
+    def test_decode_request_invalid_quantity(self) -> None:
+        """A server-side request with an invalid quantity raises InvalidRequestError."""
+        request = struct.pack(">BHH", 0x01, 100, 0)
+        with pytest.raises(InvalidRequestError, match=r"Quantity must be between 1 and 2000\."):
+            ReadCoilsPDU.decode_request(request)
+
     def test_encode_response_single_byte(self) -> None:
         """Test encoding response with single byte of coils."""
         pdu = ReadCoilsPDU(start_address=0, quantity=5)
@@ -134,6 +140,24 @@ class TestReadCoilsPDU:
 
 class TestWriteSingleCoilPDU:
     """Test class for WriteSingleCoilPDU decode_request and encode_response methods."""
+
+    def test_write_single_coil_address_validation(self) -> None:
+        """Client-side validation raises ValueError for an invalid coil address."""
+        with pytest.raises(ValueError, match=r"Address must be between 0 and 65535\."):
+            WriteSingleCoilPDU(address=-1, value=True)
+
+    def test_decode_request_value_error_is_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A constructor ValueError is converted to InvalidRequestError for server-side decoding."""
+
+        def fake_init(_self: WriteSingleCoilPDU, _address: int, _value: bool) -> None:  # noqa: FBT001
+            msg = "boom"
+            raise ValueError(msg)
+
+        monkeypatch.setattr(WriteSingleCoilPDU, "__init__", fake_init)
+
+        request = struct.pack(">BHH", 0x05, 100, 0xFF00)
+        with pytest.raises(InvalidRequestError, match="boom"):
+            WriteSingleCoilPDU.decode_request(request)
 
     def test_write_single_coil_pdu(self) -> None:
         """Test Write Single Coil PDU."""
@@ -314,6 +338,19 @@ class TestWriteMultipleCoilsPDU:
         """Test decode_request with invalid byte count."""
         request = struct.pack(">BHHB", 0x0F, 100, 5, 2) + b"\x15\x00"  # Wrong byte count
         with pytest.raises(InvalidRequestError, match=r"Invalid byte count: expected 1, got 2"):
+            WriteMultipleCoilsPDU.decode_request(request)
+
+    def test_decode_request_value_error_is_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A constructor ValueError is converted to InvalidRequestError for server-side decoding."""
+
+        def fake_init(_self: WriteMultipleCoilsPDU, _start_address: int, _values: list[bool]) -> None:
+            msg = "boom"
+            raise ValueError(msg)
+
+        monkeypatch.setattr(WriteMultipleCoilsPDU, "__init__", fake_init)
+
+        request = struct.pack(">BHHB", 0x0F, 100, 1, 1) + b"\x01"
+        with pytest.raises(InvalidRequestError, match="boom"):
             WriteMultipleCoilsPDU.decode_request(request)
 
     def test_encode_response(self) -> None:

--- a/tests/pdu/test_file.py
+++ b/tests/pdu/test_file.py
@@ -86,41 +86,55 @@ class TestReadFileRecordPDU:
         assert encoded[1] == 21  # byte count
 
     def test_validation_file_number_invalid(self) -> None:
-        """Test that invalid file numbers raise InvalidRequestError."""
-        with pytest.raises(InvalidRequestError, match="File number must be between 0 and 65535"):
+        """Test that invalid file numbers raise ValueError."""
+        with pytest.raises(ValueError, match="File number must be between 0 and 65535"):
             ReadFileRecordPDU([FileRecordRequest(file_number=-1, record_number=0, record_length=1)])
 
-        with pytest.raises(InvalidRequestError, match="File number must be between 0 and 65535"):
+        with pytest.raises(ValueError, match="File number must be between 0 and 65535"):
             ReadFileRecordPDU([FileRecordRequest(file_number=0x10000, record_number=0, record_length=1)])
 
     def test_validation_record_number_invalid(self) -> None:
-        """Test that invalid record numbers raise InvalidRequestError."""
-        with pytest.raises(InvalidRequestError, match="Record number must be between 0 and 9999"):
+        """Test that invalid record numbers raise ValueError."""
+        with pytest.raises(ValueError, match="Record number must be between 0 and 9999"):
             ReadFileRecordPDU([FileRecordRequest(file_number=0, record_number=-1, record_length=1)])
 
-        with pytest.raises(InvalidRequestError, match="Record number must be between 0 and 9999"):
+        with pytest.raises(ValueError, match="Record number must be between 0 and 9999"):
             ReadFileRecordPDU([FileRecordRequest(file_number=0, record_number=10000, record_length=1)])
 
     def test_validation_record_length_invalid(self) -> None:
-        """Test that invalid record lengths raise InvalidRequestError."""
-        with pytest.raises(InvalidRequestError, match="Record length must be between 1 and 65535"):
+        """Test that invalid record lengths raise ValueError."""
+        with pytest.raises(ValueError, match="Record length must be between 1 and 65535"):
             ReadFileRecordPDU([FileRecordRequest(file_number=0, record_number=0, record_length=0)])
 
-        with pytest.raises(InvalidRequestError, match="Record length must be between 1 and 65535"):
+        with pytest.raises(ValueError, match="Record length must be between 1 and 65535"):
             ReadFileRecordPDU([FileRecordRequest(file_number=0, record_number=0, record_length=0x10000)])
 
     def test_validation_empty_requests(self) -> None:
         """An empty request list is rejected."""
-        with pytest.raises(InvalidRequestError, match="At least one file record request"):
+        with pytest.raises(ValueError, match="At least one file record request"):
             ReadFileRecordPDU([])
 
     def test_validation_too_many_requests(self) -> None:
         """More sub-requests than fit in the one-byte byte count are rejected."""
         # 36 requests is 252 bytes, over the 0xF5 (245) maximum; 35 is the limit.
         requests = [FileRecordRequest(file_number=0, record_number=0, record_length=1)] * 36
-        with pytest.raises(InvalidRequestError, match="exceeds the maximum"):
+        with pytest.raises(ValueError, match="exceeds the maximum"):
             ReadFileRecordPDU(requests)
         ReadFileRecordPDU(requests[:35])  # the maximum is accepted
+
+    def test_decode_request_invalid_record_number(self) -> None:
+        """A malformed request is rejected with InvalidRequestError, even when constructor validation fails."""
+        # Server-side request: record_number=10000 is outside the allowed range.
+        request = b"\x14\x07\x06\x00\x04\x27\x10\x00\x02"
+        with pytest.raises(InvalidRequestError, match="Record number must be between 0 and 9999"):
+            ReadFileRecordPDU.decode_request(request)
+
+    def test_decode_request_invalid_record_length(self) -> None:
+        """A malformed request is rejected with InvalidRequestError, even when constructor validation fails."""
+        # Server-side request: record_length=0 is invalid for Read File Record.
+        request = b"\x14\x07\x06\x00\x04\x00\x01\x00\x00"
+        with pytest.raises(InvalidRequestError, match="Record length must be between 1 and 65535"):
+            ReadFileRecordPDU.decode_request(request)
 
     def test_decode_response_valid_single_record(self) -> None:
         """Test decoding a valid response with a single record."""
@@ -396,36 +410,36 @@ class TestWriteFileRecordPDU:
             pdu.encode_request()
 
     def test_validation_file_number_invalid(self) -> None:
-        """Test that invalid file numbers raise InvalidRequestError."""
-        with pytest.raises(InvalidRequestError, match="File number must be between 0 and 65535"):
+        """Test that invalid file numbers raise ValueError."""
+        with pytest.raises(ValueError, match="File number must be between 0 and 65535"):
             WriteFileRecordPDU(file_records=[FileRecord(file_number=-1, record_number=0, data=b"\x00\x01")])
 
-        with pytest.raises(InvalidRequestError, match="File number must be between 0 and 65535"):
+        with pytest.raises(ValueError, match="File number must be between 0 and 65535"):
             WriteFileRecordPDU(file_records=[FileRecord(file_number=0x10000, record_number=0, data=b"\x00\x01")])
 
     def test_validation_record_number_invalid(self) -> None:
-        """Test that invalid record numbers raise InvalidRequestError."""
-        with pytest.raises(InvalidRequestError, match="Record number must be between 0 and 9999"):
+        """Test that invalid record numbers raise ValueError."""
+        with pytest.raises(ValueError, match="Record number must be between 0 and 9999"):
             WriteFileRecordPDU(file_records=[FileRecord(file_number=0, record_number=-1, data=b"\x00\x01")])
 
-        with pytest.raises(InvalidRequestError, match="Record number must be between 0 and 9999"):
+        with pytest.raises(ValueError, match="Record number must be between 0 and 9999"):
             WriteFileRecordPDU(file_records=[FileRecord(file_number=0, record_number=10000, data=b"\x00\x01")])
 
     def test_validation_data_length_invalid(self) -> None:
-        """Test that invalid data lengths raise InvalidRequestError."""
+        """Test that invalid data lengths raise ValueError."""
         # Data length must not exceed 65535 bytes
-        with pytest.raises(InvalidRequestError, match="Record data length must be between 0 and 65535 bytes"):
+        with pytest.raises(ValueError, match="Record data length must be between 0 and 65535 bytes"):
             WriteFileRecordPDU(file_records=[FileRecord(file_number=0, record_number=0, data=b"\x00" * 65536)])
 
     def test_validation_empty_records(self) -> None:
         """An empty record list is rejected."""
-        with pytest.raises(InvalidRequestError, match="At least one file record"):
+        with pytest.raises(ValueError, match="At least one file record"):
             WriteFileRecordPDU(file_records=[])
 
     def test_validation_byte_count_too_large(self) -> None:
         """A record whose total byte count exceeds the one-byte field is rejected."""
         # 7-byte header + 246 data bytes = 253, over the 0xFB (251) maximum.
-        with pytest.raises(InvalidRequestError, match="exceeds the maximum"):
+        with pytest.raises(ValueError, match="exceeds the maximum"):
             WriteFileRecordPDU(file_records=[FileRecord(file_number=0, record_number=0, data=b"\x00" * 246)])
         # 244 data bytes (7 + 244 = 251) is the limit and is accepted.
         WriteFileRecordPDU(file_records=[FileRecord(file_number=0, record_number=0, data=b"\x00" * 244)])
@@ -562,3 +576,45 @@ class TestWriteFileRecordPDU:
         assert pdu.file_records[0].file_number == 4
         assert pdu.file_records[0].record_number == 7
         assert pdu.file_records[0].data == b"\x06\xaf\x04\xbe"
+
+    def test_decode_request_invalid_record_number(self) -> None:
+        """A server-side request with an out-of-range record number raises InvalidRequestError."""
+        # record_number=10000 is outside the allowed range and should be rejected on decode.
+        request = b"\x15\x0b\x06\x00\x04\x27\x10\x00\x02\x06\xaf\x04\xbe"
+        with pytest.raises(InvalidRequestError, match="Record number must be between 0 and 9999"):
+            WriteFileRecordPDU.decode_request(request)
+
+    def test_decode_request_too_short(self) -> None:
+        """A truncated server-side request raises InvalidRequestError."""
+        with pytest.raises(InvalidRequestError, match="Expected request to start with function code and byte count"):
+            WriteFileRecordPDU.decode_request(b"\x15")
+
+    def test_decode_request_invalid_function_code(self) -> None:
+        """A server-side request with the wrong function code raises InvalidRequestError."""
+        request = b"\x14\x0b\x06\x00\x04\x00\x07\x00\x02\x06\xaf\x04\xbe"
+        with pytest.raises(InvalidRequestError, match="Invalid function code"):
+            WriteFileRecordPDU.decode_request(request)
+
+    def test_decode_request_invalid_byte_count(self) -> None:
+        """A server-side request with a mismatched byte count raises InvalidRequestError."""
+        request = b"\x15\x0c\x06\x00\x04\x00\x07\x00\x02\x06\xaf\x04\xbe"
+        with pytest.raises(InvalidRequestError, match="Request length"):
+            WriteFileRecordPDU.decode_request(request)
+
+    def test_decode_request_truncated_subrequest_header(self) -> None:
+        """A truncated sub-request header raises InvalidRequestError."""
+        request = b"\x15\x01\x06"
+        with pytest.raises(InvalidRequestError, match="Failed to unpack file record header"):
+            WriteFileRecordPDU.decode_request(request)
+
+    def test_decode_request_invalid_reference_type(self) -> None:
+        """A wrong reference type in a server-side request raises InvalidRequestError."""
+        request = b"\x15\x0b\x07\x00\x04\x00\x07\x00\x02\x06\xaf\x04\xbe"
+        with pytest.raises(InvalidRequestError, match="Invalid reference type"):
+            WriteFileRecordPDU.decode_request(request)
+
+    def test_decode_request_not_enough_data(self) -> None:
+        """A server-side request with a truncated record payload raises InvalidRequestError."""
+        request = b"\x15\x09\x06\x00\x04\x00\x07\x00\x02\x06\xaf"
+        with pytest.raises(InvalidRequestError, match="Not enough data for the specified record length"):
+            WriteFileRecordPDU.decode_request(request)

--- a/tests/pdu/test_holding_registers.py
+++ b/tests/pdu/test_holding_registers.py
@@ -73,6 +73,19 @@ class TestReadHoldingRegistersPDU:
         with pytest.raises(InvalidRequestError, match=r"Invalid function code"):
             ReadHoldingRegistersPDU.decode_request(request)
 
+    def test_decode_request_value_error_is_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A constructor ValueError is converted to InvalidRequestError for server-side decoding."""
+
+        def fake_init(_self: ReadHoldingRegistersPDU, _start_address: int, _quantity: int) -> None:
+            msg = "boom"
+            raise ValueError(msg)
+
+        monkeypatch.setattr(ReadHoldingRegistersPDU, "__init__", fake_init)
+
+        request = b"\x03\x12\x34\x00\x0a"
+        with pytest.raises(InvalidRequestError, match="boom"):
+            ReadHoldingRegistersPDU.decode_request(request)
+
 
 # ============================================================================
 # RawReadHoldingRegistersPDU Tests
@@ -172,6 +185,25 @@ class TestRawReadHoldingRegistersPDU:
         ):
             RawReadHoldingRegistersPDU.decode_request(request)
 
+    def test_decode_request_invalid_quantity(self) -> None:
+        """A server-side request with an invalid quantity raises InvalidRequestError."""
+        request = b"\x03\x12\x34\x00\x00"
+        with pytest.raises(InvalidRequestError, match="Quantity must be between 1 and 125"):
+            RawReadHoldingRegistersPDU.decode_request(request)
+
+    def test_decode_request_value_error_is_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A constructor ValueError is converted to InvalidRequestError for server-side decoding."""
+
+        def fake_init(_self: RawReadHoldingRegistersPDU, _start_address: int, _quantity: int) -> None:
+            msg = "boom"
+            raise ValueError(msg)
+
+        monkeypatch.setattr(RawReadHoldingRegistersPDU, "__init__", fake_init)
+
+        request = b"\x03\x12\x34\x00\x0a"
+        with pytest.raises(InvalidRequestError, match="boom"):
+            RawReadHoldingRegistersPDU.decode_request(request)
+
     def test_encode_response(self) -> None:
         """Test encoding response."""
         pdu = RawReadHoldingRegistersPDU(start_address=100, quantity=3)
@@ -206,6 +238,12 @@ class TestRawReadInputRegistersPDU:
         assert pdu.start_address == 0x1234
         assert pdu.quantity == 10
 
+    def test_decode_request_invalid_quantity(self) -> None:
+        """A server-side request with an invalid quantity raises InvalidRequestError."""
+        request = b"\x04\x12\x34\x00\x00"
+        with pytest.raises(InvalidRequestError, match="Quantity must be between 1 and 125"):
+            RawReadInputRegistersPDU.decode_request(request)
+
 
 # ============================================================================
 # ReadInputRegistersPDU Tests
@@ -239,6 +277,12 @@ class TestReadInputRegistersPDU:
         pdu = ReadInputRegistersPDU.decode_request(request)
         assert pdu.raw_pdu.start_address == 0x1234
         assert pdu.raw_pdu.quantity == 10
+
+    def test_decode_request_invalid_quantity(self) -> None:
+        """A server-side request with an invalid quantity raises InvalidRequestError."""
+        request = b"\x04\x12\x34\x00\x00"
+        with pytest.raises(InvalidRequestError, match="Quantity must be between 1 and 125"):
+            ReadInputRegistersPDU.decode_request(request)
 
     def test_encode_response(self) -> None:
         """Test encoding response."""
@@ -280,6 +324,19 @@ class TestWriteSingleRegisterPDU:
         """Test decoding request with invalid function code."""
         request = b"\x03\x12\x34\x56\x78"
         with pytest.raises(InvalidRequestError, match="Invalid function code"):
+            WriteSingleRegisterPDU.decode_request(request)
+
+    def test_decode_request_value_error_is_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A constructor ValueError is converted to InvalidRequestError for server-side decoding."""
+
+        def fake_init(_self: WriteSingleRegisterPDU, _address: int, _value: int) -> None:
+            msg = "boom"
+            raise ValueError(msg)
+
+        monkeypatch.setattr(WriteSingleRegisterPDU, "__init__", fake_init)
+
+        request = b"\x06\x12\x34\x56\x78"
+        with pytest.raises(InvalidRequestError, match="boom"):
             WriteSingleRegisterPDU.decode_request(request)
 
     def test_decode_request_too_short(self) -> None:
@@ -423,6 +480,19 @@ class TestRawWriteMultipleRegistersPDU:
         with pytest.raises(InvalidRequestError, match="Invalid data length"):
             RawWriteMultipleRegistersPDU.decode_request(request)
 
+    def test_decode_request_value_error_is_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A constructor ValueError is converted to InvalidRequestError for server-side decoding."""
+
+        def fake_init(_self: RawWriteMultipleRegistersPDU, _start_address: int, _content: bytes) -> None:
+            msg = "boom"
+            raise ValueError(msg)
+
+        monkeypatch.setattr(RawWriteMultipleRegistersPDU, "__init__", fake_init)
+
+        request = b"\x10\x10\x00\x00\x02\x04\x12\x34\x56\x78"
+        with pytest.raises(InvalidRequestError, match="boom"):
+            RawWriteMultipleRegistersPDU.decode_request(request)
+
     def test_encode_response(self) -> None:
         """Test encoding response."""
         content = b"\x12\x34\x56\x78"
@@ -514,6 +584,31 @@ class TestWriteMultipleRegistersPDU:
         pdu = WriteMultipleRegistersPDU.decode_request(request)
         assert pdu.raw_pdu.start_address == 0x1000
         assert pdu.values == [0x1234, 0x5678]
+
+    def test_decode_request_value_error_is_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A constructor ValueError is converted to InvalidRequestError for server-side decoding."""
+
+        def fake_raw_decode_request(
+            _cls: type[RawWriteMultipleRegistersPDU], _request: bytes
+        ) -> RawWriteMultipleRegistersPDU:
+            return RawWriteMultipleRegistersPDU(start_address=0x1000, content=b"\x12\x34")
+
+        def fake_init(_self: WriteMultipleRegistersPDU, _start_address: int, _values: list[int]) -> None:
+            msg = "boom"
+            raise ValueError(msg)
+
+        monkeypatch.setattr(RawWriteMultipleRegistersPDU, "decode_request", classmethod(fake_raw_decode_request))
+        monkeypatch.setattr(WriteMultipleRegistersPDU, "__init__", fake_init)
+
+        request = b"\x10\x10\x00\x00\x01\x02\x12\x34"
+        with pytest.raises(InvalidRequestError, match="boom"):
+            WriteMultipleRegistersPDU.decode_request(request)
+
+    def test_decode_request_invalid_quantity(self) -> None:
+        """A server-side request with an invalid quantity raises InvalidRequestError."""
+        request = b"\x10\x10\x00\x00\x00\x00"
+        with pytest.raises(InvalidRequestError, match="Content must not be empty"):
+            WriteMultipleRegistersPDU.decode_request(request)
 
     def test_encode_response(self) -> None:
         """Test encoding response."""
@@ -674,6 +769,19 @@ class TestMaskWriteRegisterPDU:
         with pytest.raises(
             InvalidRequestError, match=r"Expected request to start with function code, address, AND mask, and OR mask"
         ):
+            MaskWriteRegisterPDU.decode_request(request)
+
+    def test_decode_request_value_error_is_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A constructor ValueError is converted to InvalidRequestError for server-side decoding."""
+
+        def fake_init(_self: MaskWriteRegisterPDU, _address: int, _and_mask: int, _or_mask: int) -> None:
+            msg = "boom"
+            raise ValueError(msg)
+
+        monkeypatch.setattr(MaskWriteRegisterPDU, "__init__", fake_init)
+
+        request = b"\x16\x00\x04\xf2\xf2\x25\x25"
+        with pytest.raises(InvalidRequestError, match="boom"):
             MaskWriteRegisterPDU.decode_request(request)
 
     def test_encode_response(self) -> None:
@@ -893,6 +1001,12 @@ class TestReadWriteMultipleRegistersPDU:
         assert pdu.read_quantity == 1
         assert pdu.write_start_address == 0
         assert pdu.write_values == [0x1234]
+
+    def test_decode_request_invalid_empty_write_values(self) -> None:
+        """A server-side request with zero write registers raises InvalidRequestError."""
+        request = b"\x17\x00\x10\x00\x01\x00\x20\x00\x00\x00"
+        with pytest.raises(InvalidRequestError, match="Number of registers to write must be between 1 and 121"):
+            ReadWriteMultipleRegistersPDU.decode_request(request)
 
     def test_decode_request_too_short(self) -> None:
         """Test decode_request raises on request too short."""


### PR DESCRIPTION
# Proposed Changes

We distinguish between two cases: tModbus being used as a modbus client and tModbus being used as a server (future work).

When used as a client, tModbus will always throw a  when trying to make an invalid request.

When used as a server, tModbus will always throw an InvalidRequestError when it tries to decode an invalid request. This error-object contains an attribute  that allows you to inspect the bytes of the invalid request that was received.

## Related Issues

None