### PR TITLE
Add missing client functions

### DIFF
--- a/src/tmodbus/client/async_client.py
+++ b/src/tmodbus/client/async_client.py
@@ -9,14 +9,18 @@ from typing import Literal, Self, TypeVar
 
 from tmodbus.pdu import (
     BaseClientPDU,
+    FileRecord,
+    FileRecordRequest,
     MaskWriteRegisterPDU,
     ReadCoilsPDU,
     ReadDeviceIdentificationPDU,
     ReadDiscreteInputsPDU,
     ReadExceptionStatusPDU,
+    ReadFileRecordPDU,
     ReadHoldingRegistersPDU,
     ReadInputRegistersPDU,
     ReadWriteMultipleRegistersPDU,
+    WriteFileRecordPDU,
     WriteMultipleCoilsPDU,
     WriteMultipleRegistersPDU,
     WriteSingleCoilPDU,
@@ -319,6 +323,48 @@ class AsyncModbusClient(HoldingRegisterReadMixin, HoldingRegisterWriteMixin):
 
         """
         return await self.execute(ReportServerIdPDU())
+
+    async def read_file_record(
+        self,
+        requests: list[FileRecordRequest],
+    ) -> list[bytes]:
+        """Read File Record (Function Code 0x14).
+
+        Args:
+            requests: List of file record requests to read.
+
+        Returns:
+            List of raw record payloads in the same order as the input requests.
+
+        Example:
+            >>> from tmodbus.pdu import FileRecordRequest
+            >>> payloads = await client.read_file_record([
+            ...     FileRecordRequest(file_number=4, record_number=0, record_length=2),
+            ... ])
+
+        """
+        return await self.execute(ReadFileRecordPDU(requests=requests))
+
+    async def write_file_record(
+        self,
+        file_records: list[FileRecord],
+    ) -> list[FileRecord]:
+        r"""Write File Record (Function Code 0x15).
+
+        Args:
+            file_records: List of file records to write.
+
+        Returns:
+            Echoed file records from the server.
+
+        Example:
+            >>> from tmodbus.pdu import FileRecord
+            >>> written = await client.write_file_record([
+            ...     FileRecord(file_number=4, record_number=0, data=b"\x12\x34"),
+            ... ])
+
+        """
+        return await self.execute(WriteFileRecordPDU(file_records=file_records))
 
     async def mask_write_register(
         self,

--- a/src/tmodbus/client/async_client.py
+++ b/src/tmodbus/client/async_client.py
@@ -324,7 +324,7 @@ class AsyncModbusClient(HoldingRegisterReadMixin, HoldingRegisterWriteMixin):
         """
         return await self.execute(ReportServerIdPDU())
 
-    async def read_file_record(
+    async def read_file_records(
         self,
         requests: list[FileRecordRequest],
     ) -> list[bytes]:
@@ -338,14 +338,38 @@ class AsyncModbusClient(HoldingRegisterReadMixin, HoldingRegisterWriteMixin):
 
         Example:
             >>> from tmodbus.pdu import FileRecordRequest
-            >>> payloads = await client.read_file_record([
+            >>> payloads = await client.read_file_records([
             ...     FileRecordRequest(file_number=4, record_number=0, record_length=2),
             ... ])
 
         """
         return await self.execute(ReadFileRecordPDU(requests=requests))
 
-    async def write_file_record(
+    async def read_file_record(self, file_number: int, record_number: int, record_length: int) -> bytes:
+        """Read a single File Record (Function Code 0x14).
+
+        Args:
+            file_number: File number to read from
+            record_number: Record number to read from
+            record_length: Length of the record to read (in 16-bit words)
+
+        Example:
+            >>> from tmodbus.pdu import FileRecordRequest
+            >>> payloads = await client.read_file_record(4, 0, 2)
+
+        """
+        payloads = await self.read_file_records(
+            [
+                FileRecordRequest(
+                    file_number=file_number,
+                    record_number=record_number,
+                    record_length=record_length,
+                )
+            ]
+        )
+        return payloads[0]
+
+    async def write_file_records(
         self,
         file_records: list[FileRecord],
     ) -> list[FileRecord]:
@@ -359,12 +383,44 @@ class AsyncModbusClient(HoldingRegisterReadMixin, HoldingRegisterWriteMixin):
 
         Example:
             >>> from tmodbus.pdu import FileRecord
-            >>> written = await client.write_file_record([
+            >>> written = await client.write_file_records([
             ...     FileRecord(file_number=4, record_number=0, data=b"\x12\x34"),
             ... ])
 
         """
         return await self.execute(WriteFileRecordPDU(file_records=file_records))
+
+    async def write_file_record(
+        self,
+        file_number: int,
+        record_number: int,
+        data: bytes,
+    ) -> FileRecord:
+        r"""Write a single File Record (Function Code 0x15).
+
+        Args:
+            file_number: File number to write to
+            record_number: Record number to write to
+            data: Raw bytes to write (length must be even, as each register is 2 bytes)
+
+        Returns:
+            Echoed file record from the server.
+
+        Example:
+            >>> from tmodbus.pdu import FileRecord
+            >>> written = await client.write_file_record(4, 0, b"\x12\x34")
+
+        """
+        records = await self.write_file_records(
+            [
+                FileRecord(
+                    file_number=file_number,
+                    record_number=record_number,
+                    data=data,
+                )
+            ]
+        )
+        return records[0]
 
     async def mask_write_register(
         self,

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -509,20 +509,43 @@ async def test_read_exception_status(dummy_client: AsyncModbusClient) -> None:
     assert ["send_and_receive", 1, "ReadExceptionStatusPDU"] in dummy_client.transport.performed_actions
 
 
-async def test_read_file_record(dummy_client: AsyncModbusClient) -> None:
-    """Test read_file_record method."""
+async def test_read_file_records(dummy_client: AsyncModbusClient) -> None:
+    """Test read_file_records method."""
     assert isinstance(dummy_client.transport, DummyAsyncTransport)
 
     requests = [
         FileRecordRequest(file_number=1, record_number=0, record_length=2),
         FileRecordRequest(file_number=2, record_number=1, record_length=4),
     ]
-    result = await dummy_client.read_file_record(requests)
+    result = await dummy_client.read_file_records(requests)
     assert result == DUMMY_RESPONSE
     assert ["send_and_receive", 1, "ReadFileRecordPDU"] in dummy_client.transport.performed_actions
 
 
-async def test_write_file_record(dummy_client: AsyncModbusClient) -> None:
+async def test_read_file_record(dummy_client: AsyncModbusClient) -> None:
+    """Test read_file_record method."""
+    assert isinstance(dummy_client.transport, DummyAsyncTransport)
+
+    calls: dict[str, Any] = {}
+    expected_payload = b"\x12\x34"
+
+    async def fake_read_file_records(requests: list[FileRecordRequest]) -> list[bytes]:
+        calls["requests"] = requests
+        return [expected_payload]
+
+    dummy_client.read_file_records = fake_read_file_records  # type: ignore[method-assign]
+
+    result = await dummy_client.read_file_record(1, 0, 2)
+
+    assert result == expected_payload
+    requests = calls["requests"]
+    assert len(requests) == 1
+    assert requests[0].file_number == 1
+    assert requests[0].record_number == 0
+    assert requests[0].record_length == 2
+
+
+async def test_write_file_records(dummy_client: AsyncModbusClient) -> None:
     """Test write_file_record method."""
     assert isinstance(dummy_client.transport, DummyAsyncTransport)
 
@@ -530,6 +553,32 @@ async def test_write_file_record(dummy_client: AsyncModbusClient) -> None:
         FileRecord(file_number=1, record_number=0, data=b"\x12\x34"),
         FileRecord(file_number=2, record_number=1, data=b"\xab\xcd\xef\x01"),
     ]
-    result = await dummy_client.write_file_record(file_records)
+    result = await dummy_client.write_file_records(file_records)
     assert result == DUMMY_RESPONSE
     assert ["send_and_receive", 1, "WriteFileRecordPDU"] in dummy_client.transport.performed_actions
+
+
+async def test_write_file_record(
+    dummy_client: AsyncModbusClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test write_file_record method."""
+    assert isinstance(dummy_client.transport, DummyAsyncTransport)
+
+    calls: dict[str, Any] = {}
+    expected_record = FileRecord(file_number=1, record_number=0, data=b"\x12\x34")
+
+    async def fake_write_file_records(file_records: list[FileRecord]) -> list[FileRecord]:
+        calls["file_records"] = file_records
+        return [expected_record]
+
+    monkeypatch.setattr(dummy_client, "write_file_records", fake_write_file_records)
+
+    result = await dummy_client.write_file_record(1, 0, b"\x12\x34")
+    assert result == expected_record
+
+    file_records = calls["file_records"]
+    assert len(file_records) == 1
+    assert file_records[0].file_number == 1
+    assert file_records[0].record_number == 0
+    assert file_records[0].data == b"\x12\x34"

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -5,7 +5,14 @@ from unittest.mock import MagicMock
 
 import pytest
 from tmodbus.client.async_client import AsyncModbusClient
-from tmodbus.pdu import BasePDU, ReadCoilsPDU, ReadDeviceIdentificationPDU, ReadDeviceIdentificationResponse
+from tmodbus.pdu import (
+    BasePDU,
+    FileRecord,
+    FileRecordRequest,
+    ReadCoilsPDU,
+    ReadDeviceIdentificationPDU,
+    ReadDeviceIdentificationResponse,
+)
 from tmodbus.pdu.device import ConformityLevel
 from tmodbus.transport.async_base import AsyncBaseTransport
 
@@ -500,3 +507,29 @@ async def test_read_exception_status(dummy_client: AsyncModbusClient) -> None:
 
     # Verify that send_and_receive was called with the correct PDU type
     assert ["send_and_receive", 1, "ReadExceptionStatusPDU"] in dummy_client.transport.performed_actions
+
+
+async def test_read_file_record(dummy_client: AsyncModbusClient) -> None:
+    """Test read_file_record method."""
+    assert isinstance(dummy_client.transport, DummyAsyncTransport)
+
+    requests = [
+        FileRecordRequest(file_number=1, record_number=0, record_length=2),
+        FileRecordRequest(file_number=2, record_number=1, record_length=4),
+    ]
+    result = await dummy_client.read_file_record(requests)
+    assert result == DUMMY_RESPONSE
+    assert ["send_and_receive", 1, "ReadFileRecordPDU"] in dummy_client.transport.performed_actions
+
+
+async def test_write_file_record(dummy_client: AsyncModbusClient) -> None:
+    """Test write_file_record method."""
+    assert isinstance(dummy_client.transport, DummyAsyncTransport)
+
+    file_records = [
+        FileRecord(file_number=1, record_number=0, data=b"\x12\x34"),
+        FileRecord(file_number=2, record_number=1, data=b"\xab\xcd\xef\x01"),
+    ]
+    result = await dummy_client.write_file_record(file_records)
+    assert result == DUMMY_RESPONSE
+    assert ["send_and_receive", 1, "WriteFileRecordPDU"] in dummy_client.transport.performed_actions


### PR DESCRIPTION
# Proposed Changes

This PR adds the missing helper functions for FC15 in `AsyncModbusClient`.

It adds:
- `read_file_records` 
- `read_file_record` 
- `write_file_records`
- `write_file_record`

## Related Issues

None