### PR TITLE
Add on_connection_lost callback to detect socket drops immediately

### DIFF
--- a/src/tmodbus/__init__.py
+++ b/src/tmodbus/__init__.py
@@ -33,6 +33,7 @@ def create_async_tcp_client(  # noqa: PLR0913
     wait_after_connect: float = 0.0,
     auto_reconnect: "bool | AsyncRetrying" = True,
     on_reconnected: Callable[[], Awaitable[None] | None] | None = None,
+    on_connection_lost: Callable[[Exception | None], None] | None = None,
     response_retry_strategy: "AsyncRetrying | None" = None,
     retry_on_device_busy: bool = True,
     retry_on_device_failure: bool = False,
@@ -51,6 +52,8 @@ def create_async_tcp_client(  # noqa: PLR0913
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).
                         Can be a custom AsyncRetrying instance when more control is needed.
         on_reconnected: Callback to be called after a successful reconnection.
+        on_connection_lost: Callback invoked the moment the connection is lost, receiving the causing
+                            exception (or None on a clean close). Fires even when auto_reconnect is disabled.
         response_retry_strategy: Retry strategy for handling failed requests (default: None).
         retry_on_device_busy: Whether to retry on device busy errors (default: True).
                               Can be a custom AsyncRetrying instance when more control is needed.
@@ -74,6 +77,7 @@ def create_async_tcp_client(  # noqa: PLR0913
         wait_after_connect=wait_after_connect,
         auto_reconnect=auto_reconnect,
         on_reconnected=on_reconnected,
+        on_connection_lost=on_connection_lost,
         response_retry_strategy=response_retry_strategy,
         retry_on_device_busy=retry_on_device_busy,
         retry_on_device_failure=retry_on_device_failure,
@@ -89,6 +93,7 @@ def create_async_rtu_client(  # noqa: PLR0913
     wait_after_connect: float = 0.0,
     auto_reconnect: "bool | AsyncRetrying" = True,
     on_reconnected: Callable[[], Awaitable[None] | None] | None = None,
+    on_connection_lost: Callable[[Exception | None], None] | None = None,
     response_retry_strategy: "AsyncRetrying | None" = None,
     retry_on_device_busy: bool = True,
     retry_on_device_failure: bool = False,
@@ -106,6 +111,8 @@ def create_async_rtu_client(  # noqa: PLR0913
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).
                         Can be a custom AsyncRetrying instance when more control is needed.
         on_reconnected: Callback to be called after a successful reconnection.
+        on_connection_lost: Callback invoked the moment the connection is lost, receiving the causing
+                            exception (or None on a clean close). Fires even when auto_reconnect is disabled.
         response_retry_strategy: Retry strategy for handling failed requests (default: None).
         retry_on_device_busy: Whether to retry on device busy errors (default: True).
                               Can be a custom AsyncRetrying instance when more control is needed.
@@ -126,6 +133,7 @@ def create_async_rtu_client(  # noqa: PLR0913
         wait_after_connect=wait_after_connect,
         auto_reconnect=auto_reconnect,
         on_reconnected=on_reconnected,
+        on_connection_lost=on_connection_lost,
         response_retry_strategy=response_retry_strategy,
         retry_on_device_busy=retry_on_device_busy,
         retry_on_device_failure=retry_on_device_failure,
@@ -141,6 +149,7 @@ def create_async_ascii_client(  # noqa: PLR0913
     wait_after_connect: float = 0.0,
     auto_reconnect: "bool | AsyncRetrying" = True,
     on_reconnected: Callable[[], Awaitable[None] | None] | None = None,
+    on_connection_lost: Callable[[Exception | None], None] | None = None,
     response_retry_strategy: "AsyncRetrying | None" = None,
     retry_on_device_busy: bool = True,
     retry_on_device_failure: bool = False,
@@ -158,6 +167,8 @@ def create_async_ascii_client(  # noqa: PLR0913
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).
                         Can be a custom AsyncRetrying instance when more control is needed.
         on_reconnected: Callback to be called after a successful reconnection.
+        on_connection_lost: Callback invoked the moment the connection is lost, receiving the causing
+                            exception (or None on a clean close). Fires even when auto_reconnect is disabled.
         response_retry_strategy: Retry strategy for handling failed requests (default: None).
         retry_on_device_busy: Whether to retry on device busy errors (default: True).
                               Can be a custom AsyncRetrying instance when more control is needed.
@@ -178,6 +189,7 @@ def create_async_ascii_client(  # noqa: PLR0913
         wait_after_connect=wait_after_connect,
         auto_reconnect=auto_reconnect,
         on_reconnected=on_reconnected,
+        on_connection_lost=on_connection_lost,
         response_retry_strategy=response_retry_strategy,
         retry_on_device_busy=retry_on_device_busy,
         retry_on_device_failure=retry_on_device_failure,
@@ -196,6 +208,7 @@ def create_async_rtu_over_tcp_client(  # noqa: PLR0913
     wait_after_connect: float = 0.0,
     auto_reconnect: "bool | AsyncRetrying" = True,
     on_reconnected: Callable[[], Awaitable[None] | None] | None = None,
+    on_connection_lost: Callable[[Exception | None], None] | None = None,
     response_retry_strategy: "AsyncRetrying | None" = None,
     retry_on_device_busy: bool = True,
     retry_on_device_failure: bool = False,
@@ -214,6 +227,8 @@ def create_async_rtu_over_tcp_client(  # noqa: PLR0913
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).
                         Can be a custom AsyncRetrying instance when more control is needed.
         on_reconnected: Callback to be called after a successful reconnection.
+        on_connection_lost: Callback invoked the moment the connection is lost, receiving the causing
+                            exception (or None on a clean close). Fires even when auto_reconnect is disabled.
         response_retry_strategy: Retry strategy for handling failed requests (default: None).
         retry_on_device_busy: Whether to retry on device busy errors (default: True).
                               Can be a custom AsyncRetrying instance when more control is needed.
@@ -237,6 +252,7 @@ def create_async_rtu_over_tcp_client(  # noqa: PLR0913
         wait_after_connect=wait_after_connect,
         auto_reconnect=auto_reconnect,
         on_reconnected=on_reconnected,
+        on_connection_lost=on_connection_lost,
         response_retry_strategy=response_retry_strategy,
         retry_on_device_busy=retry_on_device_busy,
         retry_on_device_failure=retry_on_device_failure,

--- a/src/tmodbus/transport/async_ascii.py
+++ b/src/tmodbus/transport/async_ascii.py
@@ -364,6 +364,7 @@ class AsyncAsciiTransport(AsyncBaseTransport):
         port: str,
         *,
         timeout: float | None = None,
+        on_connection_lost: Callable[[Exception | None], None] | None = None,
         **serialx_options: Unpack[SerialXOptions],
     ) -> None:
         """Initialize async Serial transport layer for ASCII.
@@ -371,6 +372,8 @@ class AsyncAsciiTransport(AsyncBaseTransport):
         Args:
             port: Target serial port (e.g., '/dev/ttyUSB0')
             timeout: Optional timeout for connection and response operations (in seconds)
+            on_connection_lost: Optional callback invoked the moment the connection is lost.
+                                Receives the causing exception, or None on a clean close.
             serialx_options: Additional SerialX options like baudrate, parity, stopbits, etc.
 
         """
@@ -378,6 +381,7 @@ class AsyncAsciiTransport(AsyncBaseTransport):
         if timeout is None:
             timeout = DEFAULT_TIMEOUT
         self.timeout = timeout
+        self.on_connection_lost = on_connection_lost
         self.serialx_options = serialx_options
 
     async def open(self) -> None:
@@ -466,6 +470,8 @@ class AsyncAsciiTransport(AsyncBaseTransport):
 
         self._transport = None
         self._protocol = None
+
+        self._notify_connection_lost(exc)
 
     async def send_and_receive(self, unit_id: int, pdu: BaseClientPDU[RT]) -> RT:
         """Async send PDU and receive response.

--- a/src/tmodbus/transport/async_base.py
+++ b/src/tmodbus/transport/async_base.py
@@ -3,13 +3,17 @@
 Defines the unified interface that all transport layer implementations must follow.
 """
 
+import logging
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from types import TracebackType
 from typing import Self, TypeVar
 
 from tmodbus.pdu import BaseClientPDU
 
 RT = TypeVar("RT")
+
+logger = logging.getLogger(__name__)
 
 
 class AsyncBaseTransport(ABC):
@@ -20,6 +24,29 @@ class AsyncBaseTransport(ABC):
     such as CRC verification and MBAP header processing within the transport layer,
     providing a unified and concise interface for clients.
     """
+
+    #: Optional callback invoked the moment the connection is lost.
+    #:
+    #: It is called with the exception that caused the loss (or ``None`` when the
+    #: connection was closed cleanly, e.g. by the remote host or via :meth:`close`).
+    #: This fires straight from the underlying protocol's ``connection_lost``, so it
+    #: is the earliest possible notification that the socket dropped, independent of
+    #: whether any request is in flight.
+    on_connection_lost: Callable[[Exception | None], None] | None = None
+
+    def _notify_connection_lost(self, exc: Exception | None) -> None:
+        """Invoke the ``on_connection_lost`` callback, swallowing any error it raises.
+
+        A misbehaving user callback must never break the transport teardown that runs
+        inside the event loop's ``connection_lost`` handling.
+        """
+        callback = self.on_connection_lost
+        if callback is None:
+            return
+        try:
+            callback(exc)
+        except Exception:
+            logger.exception("Unhandled error in on_connection_lost callback")
 
     @abstractmethod
     async def open(self) -> None:

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -133,6 +133,7 @@ class AsyncRtuTransport(AsyncBaseTransport):
         port: str,
         *,
         timeout: float | None = None,
+        on_connection_lost: Callable[[Exception | None], None] | None = None,
         **serialx_options: Unpack[SerialXOptions],
     ) -> None:
         """Initialize async Serial transport layer.
@@ -140,6 +141,8 @@ class AsyncRtuTransport(AsyncBaseTransport):
         Args:
             port: Target serial port (e.g., '/dev/ttyUSB0')
             timeout: Timeout in seconds, default 10.0 seconds
+            on_connection_lost: Optional callback invoked the moment the connection is lost.
+                                Receives the causing exception, or None on a clean close.
             serialx_options: Additional SerialX options like baudrate, parity, stopbits, etc.
 
         Raises:
@@ -152,6 +155,8 @@ class AsyncRtuTransport(AsyncBaseTransport):
         if timeout is None:
             timeout = DEFAULT_TIMEOUT
         self.timeout = timeout
+
+        self.on_connection_lost = on_connection_lost
 
         self.serialx_options = serialx_options
 
@@ -246,6 +251,8 @@ class AsyncRtuTransport(AsyncBaseTransport):
 
         self._transport = None
         self._protocol = None
+
+        self._notify_connection_lost(exc)
 
     async def send_and_receive(self, unit_id: int, pdu: BaseClientPDU[RT]) -> RT:
         """Async send PDU and receive response.

--- a/src/tmodbus/transport/async_rtu_over_tcp.py
+++ b/src/tmodbus/transport/async_rtu_over_tcp.py
@@ -10,6 +10,7 @@ in TCP packets without converting to Modbus TCP format.
 
 import asyncio
 import logging
+from collections.abc import Callable
 from functools import partial
 from typing import Any, TypeVar
 
@@ -52,6 +53,7 @@ class AsyncRtuOverTcpTransport(AsyncBaseTransport):
         *,
         timeout: float = 10.0,
         connect_timeout: float = 10.0,
+        on_connection_lost: Callable[[Exception | None], None] | None = None,
         **connection_kwargs: Any,
     ) -> None:
         """Initialize async RTU over TCP transport layer.
@@ -61,6 +63,8 @@ class AsyncRtuOverTcpTransport(AsyncBaseTransport):
             port: Target port, default 502 (Modbus TCP standard port)
             timeout: Timeout in seconds for read/write operations, default 10.0s
             connect_timeout: Timeout for establishing connection, default 10.0s
+            on_connection_lost: Optional callback invoked the moment the connection is lost.
+                                Receives the causing exception, or None on a clean close.
             connection_kwargs: Additional connection parameters passed to `asyncio.open_connection`
 
         Raises:
@@ -81,6 +85,7 @@ class AsyncRtuOverTcpTransport(AsyncBaseTransport):
         self.port = port
         self.timeout = timeout
         self.connect_timeout = connect_timeout
+        self.on_connection_lost = on_connection_lost
         self.connection_kwargs = connection_kwargs
 
     async def open(self) -> None:
@@ -133,6 +138,8 @@ class AsyncRtuOverTcpTransport(AsyncBaseTransport):
 
         self._transport = None
         self._protocol = None
+
+        self._notify_connection_lost(exc)
 
     async def send_and_receive(self, unit_id: int, pdu: BaseClientPDU[RT]) -> RT:
         """Async send PDU and receive response.

--- a/src/tmodbus/transport/async_smart.py
+++ b/src/tmodbus/transport/async_smart.py
@@ -113,6 +113,7 @@ class AsyncSmartTransport(AsyncBaseTransport):
         wait_after_connect: float = 0.0,
         auto_reconnect: bool | AsyncRetrying = True,
         on_reconnected: Callable[[], Awaitable[None] | None] | None = None,
+        on_connection_lost: Callable[[Exception | None], None] | None = None,
         response_retry_strategy: AsyncRetrying | None = None,
         retry_on_device_busy: bool = True,
         retry_on_device_failure: bool = False,
@@ -126,6 +127,12 @@ class AsyncSmartTransport(AsyncBaseTransport):
             auto_reconnect: Whether to automatically reconnect on connection loss (default: True).
                             Can be a custom AsyncRetrying instance when more control is needed.
             on_reconnected: Callback to be called after a successful reconnection.
+                            Requires auto_reconnect to be enabled.
+            on_connection_lost: Callback invoked the moment the underlying connection is lost, receiving
+                                the causing exception (or None on a clean close). Unlike on_reconnected,
+                                this works even when auto_reconnect is disabled: it is forwarded to the
+                                base transport and fires straight from its protocol's connection_lost,
+                                so it is the earliest notification that the socket dropped.
             response_retry_strategy: Retry strategy for handling failed requests (default: None).
             retry_on_device_busy: Whether to retry on device busy errors (default: True).
                                   Can be a custom AsyncRetrying instance when more control is needed.
@@ -134,6 +141,12 @@ class AsyncSmartTransport(AsyncBaseTransport):
 
         """
         self.base_transport = base_transport
+
+        # Forward the connection-lost callback to the base transport, which is where the socket
+        # actually lives and where connection_lost originates. Only override when a callback was
+        # provided, so a callback set directly on the base transport is not silently cleared.
+        if on_connection_lost is not None:
+            self.base_transport.on_connection_lost = on_connection_lost
         self._communication_lock = asyncio.Lock()
         self._should_be_connected = False
         self._must_reconnect = False

--- a/src/tmodbus/transport/async_tcp.py
+++ b/src/tmodbus/transport/async_tcp.py
@@ -52,6 +52,7 @@ class AsyncTcpTransport(AsyncBaseTransport):
         *,
         timeout: float = 10.0,
         connect_timeout: float = 10.0,
+        on_connection_lost: Callable[[Exception | None], None] | None = None,
         **connection_kwargs: Any,
     ) -> None:
         """Initialize async TCP transport layer.
@@ -61,6 +62,8 @@ class AsyncTcpTransport(AsyncBaseTransport):
             port: Target port, default 502 (Modbus TCP standard port)
             timeout: Timeout in seconds, default 10.0s
             connect_timeout: Timeout for establishing connection, default 10.0s
+            on_connection_lost: Optional callback invoked the moment the connection is lost.
+                                Receives the causing exception, or None on a clean close.
             connection_kwargs: Additional connection parameters passed to `asyncio.create_connection`
                                (e.g., SSL context)
 
@@ -83,6 +86,7 @@ class AsyncTcpTransport(AsyncBaseTransport):
         self.port = port
         self.timeout = timeout
         self.connect_timeout = connect_timeout
+        self.on_connection_lost = on_connection_lost
         self.connection_kwargs = connection_kwargs
 
     async def open(self) -> None:
@@ -135,6 +139,8 @@ class AsyncTcpTransport(AsyncBaseTransport):
 
         self._transport = None
         self._protocol = None
+
+        self._notify_connection_lost(exc)
 
     async def send_and_receive(self, unit_id: int, pdu: BaseClientPDU[RT]) -> RT:
         """Async send PDU and receive response.

--- a/tests/transport/test_async_base.py
+++ b/tests/transport/test_async_base.py
@@ -53,3 +53,38 @@ async def test_async_base_transport_context_manager() -> None:
 
     assert not transport.is_open()
     assert "close" in transport.performed_actions
+
+
+def test_notify_connection_lost_no_callback() -> None:
+    """_notify_connection_lost is a no-op when no callback is registered."""
+    transport = DummyAsyncTransport()
+    assert transport.on_connection_lost is None
+
+    # Should not raise.
+    transport._notify_connection_lost(None)
+
+
+def test_notify_connection_lost_invokes_callback() -> None:
+    """_notify_connection_lost forwards the causing exception to the callback."""
+    calls: list[Exception | None] = []
+    transport = DummyAsyncTransport()
+    transport.on_connection_lost = calls.append
+
+    error = RuntimeError("dropped")
+    transport._notify_connection_lost(error)
+
+    assert calls == [error]
+
+
+def test_notify_connection_lost_swallows_callback_error() -> None:
+    """A raising callback must not propagate out of _notify_connection_lost."""
+
+    def boom(_exc: Exception | None) -> None:
+        msg = "callback failed"
+        raise ValueError(msg)
+
+    transport = DummyAsyncTransport()
+    transport.on_connection_lost = boom
+
+    # Should not raise.
+    transport._notify_connection_lost(None)

--- a/tests/transport/test_async_smart.py
+++ b/tests/transport/test_async_smart.py
@@ -51,6 +51,41 @@ def test_on_reconnected_requires_auto_reconnect(base_transport_mock: AsyncBaseTr
         AsyncSmartTransport(base_transport_mock, auto_reconnect=False, on_reconnected=lambda: None)
 
 
+def test_on_connection_lost_forwarded_to_base_transport(base_transport_mock: AsyncBaseTransport) -> None:
+    """on_connection_lost is forwarded to the base transport, where the socket lives."""
+
+    def callback(_exc: Exception | None) -> None:
+        pass
+
+    AsyncSmartTransport(base_transport_mock, on_connection_lost=callback)
+
+    assert base_transport_mock.on_connection_lost is callback
+
+
+def test_on_connection_lost_works_without_auto_reconnect(base_transport_mock: AsyncBaseTransport) -> None:
+    """Unlike on_reconnected, on_connection_lost is allowed when auto_reconnect is disabled."""
+
+    def callback(_exc: Exception | None) -> None:
+        pass
+
+    # Must not raise.
+    AsyncSmartTransport(base_transport_mock, auto_reconnect=False, on_connection_lost=callback)
+
+    assert base_transport_mock.on_connection_lost is callback
+
+
+def test_on_connection_lost_not_provided_keeps_base_callback(base_transport_mock: AsyncBaseTransport) -> None:
+    """When no callback is passed, a callback set directly on the base transport is preserved."""
+
+    def existing(_exc: Exception | None) -> None:
+        pass
+
+    base_transport_mock.on_connection_lost = existing
+    AsyncSmartTransport(base_transport_mock)
+
+    assert base_transport_mock.on_connection_lost is existing
+
+
 def test_init_creates_instance_communication_state(base_transport_mock: AsyncBaseTransport) -> None:
     """Test that each transport instance has its own communication state."""
     t1 = AsyncSmartTransport(base_transport_mock)

--- a/tests/transport/test_async_tcp.py
+++ b/tests/transport/test_async_tcp.py
@@ -419,6 +419,40 @@ async def test_on_connection_lost_with_error() -> None:
         log.error.assert_called()
 
 
+async def test_on_connection_lost_user_callback_invoked() -> None:
+    """The user-supplied on_connection_lost callback fires with the causing exception."""
+    calls: list[Exception | None] = []
+    t = AsyncTcpTransport("host", port=1234, on_connection_lost=calls.append)
+    t._transport = MagicMock()
+    t._protocol = MagicMock()
+
+    test_error = RuntimeError("boom")
+    t._on_connection_lost(test_error)
+
+    # Callback receives the exception, and it is called after the transport is torn down,
+    # so the transport already reports itself as closed.
+    assert calls == [test_error]
+    assert not t.is_open()
+
+
+async def test_on_connection_lost_user_callback_error_swallowed() -> None:
+    """A raising on_connection_lost callback must not break protocol teardown."""
+
+    def boom(_exc: Exception | None) -> None:
+        msg = "callback failed"
+        raise ValueError(msg)
+
+    t = AsyncTcpTransport("host", port=1234, on_connection_lost=boom)
+    t._transport = MagicMock()
+    t._protocol = MagicMock()
+
+    # Should not raise despite the callback blowing up.
+    t._on_connection_lost(None)
+
+    assert t._transport is None
+    assert t._protocol is None
+
+
 async def test_close_closes_transport() -> None:
     """Test close actually closes the transport."""
     t = AsyncTcpTransport("host", port=1234)


### PR DESCRIPTION
Note: not tested with actual device. 

Expose an on_connection_lost callback so consumers can react the moment a socket drops, rather than waiting for the next request to fail. This mirrors pymodbus's trace_connect(False), firing straight from the asyncio protocol's connection_lost.

- Add the callback attribute and a safe-invocation helper on AsyncBaseTransport (errors raised by the callback are logged, never break transport teardown).
- Wire it into every base transport's _on_connection_lost (TCP, RTU, ASCII, RTU-over-TCP).
- Forward it through AsyncSmartTransport to the base transport. Unlike on_reconnected, it works even when auto_reconnect is disabled.
- Thread it through the create_async_* client factory helpers.


Claude-Session: https://claude.ai/code/session_01XUgJ5AXGqf5orSNUXtYigk

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
