### PR TITLE
Lower tenacity floor to >=8.2.0 for the smart extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ Changelog = "https://github.com/wlcrs/tmodbus/releases"
 [project.optional-dependencies]
 
 async-serial = ["serialx"]
-smart = ["tenacity>=9.1.4"]
+smart = ["tenacity>=8.2.0,!=8.4.0"]
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/uv.lock
+++ b/uv.lock
@@ -1075,7 +1075,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "serialx", marker = "extra == 'async-serial'" },
-    { name = "tenacity", marker = "extra == 'smart'", specifier = ">=9.1.4" },
+    { name = "tenacity", marker = "extra == 'smart'", specifier = ">=8.2.0,!=8.4.0" },
 ]
 provides-extras = ["async-serial", "smart"]
 


### PR DESCRIPTION
# Proposed Changes

The smart transport only relies on tenacity APIs available since 8.2.0 (the AttemptManager context-manager iteration protocol used in AsyncSmartTransport.send_and_receive). Pinning to >=9.1.4 was unnecessarily restrictive and made co-installation with other packages harder. Verified the full test suite passes against 8.2.0.

8.4.0 is excluded because that release shipped a broken wheel missing the tenacity.asyncio submodule (fixed in 8.4.1).


