### PR TITLE
Add support for Modbus UDP

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,10 +33,18 @@ jobs:
         run: uv sync --all-extras --frozen --no-default-groups --group test
       - name: Install system dependencies (socat)
         run: sudo apt-get update && sudo apt-get install -y socat
+      - name: 📦 Cache diagslave binary
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: integration_tests/fieldtalk/diagslave
+          key: diagslave-3.5-x86_64  # gitleaks:allow
       - name: 🏗 Compile integration test binaries
         run: |
-          cd integration_tests/tokio && ./compile.sh && cd ../..
-          cd integration_tests/rmodbus && ./compile.sh && cd ../..
-          cd integration_tests/simonvetter && ./compile.sh && cd ../..
+          for dir in integration_tests/*/; do
+            if [ -f "${dir}compile.sh" ]; then
+              echo "Compiling in ${dir}..."
+              (cd "${dir}" && ./compile.sh) || echo "Warning: Compilation failed in ${dir}"
+            fi
+          done
       - name: 🚀 Run pytest
         run: uv run --no-sync pytest integration_tests

--- a/integration_tests/fieldtalk/.gitignore
+++ b/integration_tests/fieldtalk/.gitignore
@@ -1,0 +1,1 @@
+/diagslave

--- a/integration_tests/fieldtalk/compile.sh
+++ b/integration_tests/fieldtalk/compile.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+# Skip download if the binary is already present (e.g. restored from CI cache)
+if [ -f "diagslave" ]; then
+    echo "diagslave binary already present, skipping download."
+    exit 0
+fi
+
+# Download URL
+URL="https://www.modbusdriver.com/downloads/diagslave.tgz"
+TEMP_TGZ=$(mktemp)
+
+# Clean up temporary file on exit
+cleanup() {
+    rm -f "$TEMP_TGZ"
+}
+trap cleanup EXIT
+
+echo "Downloading diagslave..."
+if command -v curl >/dev/null 2>&1; then
+    curl -sSL "$URL" -o "$TEMP_TGZ"
+elif command -v wget >/dev/null 2>&1; then
+    wget -q "$URL" -O "$TEMP_TGZ"
+else
+    echo "Error: curl or wget is required to download diagslave." >&2
+    exit 1
+fi
+
+echo "Extracting x86_64 binary..."
+# Extract specifically the x86_64-linux-gnu version and output directly
+tar -O -xf "$TEMP_TGZ" diagslave/x86_64-linux-gnu/diagslave > diagslave
+chmod +x diagslave
+
+echo "Diagslave binary successfully set up."

--- a/integration_tests/fieldtalk/test_diagslave.py
+++ b/integration_tests/fieldtalk/test_diagslave.py
@@ -1,0 +1,196 @@
+"""Integration tests against the FieldTalk diagslave simulator."""
+
+import asyncio
+import contextlib
+import logging
+import sys
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+import pytest
+from tmodbus.client import AsyncModbusClient
+from tmodbus.transport import (
+    AsyncAsciiTransport,
+    AsyncRtuOverTcpTransport,
+    AsyncRtuTransport,
+    AsyncTcpTransport,
+    AsyncUdpTransport,
+)
+
+sys.path.append(str(Path(__file__).parent.parent))
+from helpers import find_free_port, make_virtual_serial_ports
+
+DIAGSLAVE_BIN = Path(__file__).parent / "diagslave"
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def log_traffic(caplog: pytest.LogCaptureFixture) -> None:
+    """Increase logging level for easy debugging."""
+    caplog.set_level("DEBUG", logger="tmodbus")
+
+
+@contextlib.asynccontextmanager
+async def diagslave(protocol_mode: str, *args: str) -> AsyncGenerator[asyncio.subprocess.Process, None]:
+    """Asynchronous context manager to manage the lifecycle of a diagslave server process."""
+    process = await asyncio.create_subprocess_exec(
+        str(DIAGSLAVE_BIN),
+        "-m",
+        protocol_mode,
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    # Wait for the simulator to fully initialize
+    await asyncio.sleep(0.5)
+    try:
+        yield process
+    finally:
+        if process.returncode is None:
+            process.terminate()
+        stdout, stderr = await process.communicate()
+        if stdout:
+            logger.debug("diagslave stdout:\n%s", stdout.decode())
+        if stderr:
+            logger.debug("diagslave stderr:\n%s", stderr.decode())
+
+
+async def run_client_assertions(client: AsyncModbusClient) -> None:
+    """Run all assertions against the diagslave client."""
+    # 1. Coils
+    # Write single coil and read back
+    await client.write_single_coil(0, value=True)
+
+    res = await client.read_coils(0, 1)
+    assert res == [True]
+
+    # Write multiple coils and read back
+    await client.write_multiple_coils(5, [True, False, True, True])
+
+    res = await client.read_coils(5, 4)
+    assert res == [True, False, True, True]
+
+    # 2. Discrete Inputs
+    # diagslave maps discrete inputs directly to coils memory.
+    # Verify we can read the discrete inputs written above.
+    res = await client.read_discrete_inputs(0, 1)
+    assert res == [True]
+
+    res = await client.read_discrete_inputs(5, 4)
+    assert res == [True, False, True, True]
+
+    # 3. Holding Registers
+    # Write single register and read back
+    await client.write_single_register(10, 42)
+
+    res = await client.read_holding_registers(10, 1)
+    assert res == [42]
+
+    # Write multiple registers and read back
+    await client.write_multiple_registers(20, [100, 200, 300])
+
+    res = await client.read_holding_registers(20, 3)
+    assert res == [100, 200, 300]
+
+    # Mask Write Register (FC22)
+    # Write 0x1234, mask it (AND 0x00FF, OR 0x5600), expect 0x5634
+    await client.write_single_register(30, 0x1234)
+
+    await client.mask_write_register(30, and_mask=0x00FF, or_mask=0x5600)
+
+    res = await client.read_holding_registers(30, 1)
+    assert res == [0x5634]
+
+    # Read/Write Multiple Registers (FC23)
+    # Read from address 40 (qty 2) and write values [88, 99] to address 40 in one transaction
+    res = await client.read_write_multiple_registers(
+        read_start_address=40,
+        read_quantity=2,
+        write_start_address=40,
+        write_values=[88, 99],
+    )
+    assert res == [88, 99]
+
+    # 4. Input Registers
+    # diagslave maps input registers directly to holding registers memory.
+    # Verify we can read holding registers as input registers.
+    res = await client.read_input_registers(10, 1)
+    assert res == [42]
+
+    res = await client.read_input_registers(20, 3)
+    assert res == [100, 200, 300]
+
+
+@pytest.mark.usefixtures("log_traffic")
+async def test_diagslave_tcp() -> None:
+    """Test tmodbus client using Modbus/TCP against diagslave."""
+    port = find_free_port()
+    async with diagslave("tcp", "-p", str(port)):
+        transport = AsyncTcpTransport("127.0.0.1", port)
+        client = AsyncModbusClient(transport=transport, unit_id=1)
+        await client.connect()
+        await run_client_assertions(client)
+        await client.disconnect()
+
+
+@pytest.mark.usefixtures("log_traffic")
+async def test_diagslave_udp() -> None:
+    """Test tmodbus client using Modbus UDP against diagslave."""
+    port = find_free_port()
+    async with diagslave("udp", "-p", str(port)):
+        transport = AsyncUdpTransport("127.0.0.1", port)
+        client = AsyncModbusClient(transport=transport, unit_id=1)
+        await client.connect()
+        await run_client_assertions(client)
+        await client.disconnect()
+
+
+@pytest.mark.usefixtures("log_traffic")
+async def test_diagslave_rtu_over_tcp() -> None:
+    """Test tmodbus client using Modbus RTU over TCP against diagslave."""
+    port = find_free_port()
+    async with diagslave("enc", "-p", str(port)):
+        transport = AsyncRtuOverTcpTransport("127.0.0.1", port)
+        client = AsyncModbusClient(transport=transport, unit_id=1)
+        await client.connect()
+        await run_client_assertions(client)
+        await client.disconnect()
+
+
+@pytest.mark.usefixtures("log_traffic")
+async def test_diagslave_rtu_serial() -> None:
+    """Test tmodbus client using Modbus RTU (serial) against diagslave."""
+    server_path = Path(__file__).parent / "rtu-server-socket"
+    client_path = Path(__file__).parent / "rtu-client-socket"
+
+    with make_virtual_serial_ports(server_path, client_path):
+        async with diagslave("rtu", "-o", "10", str(server_path)):
+            transport = AsyncRtuTransport(
+                str(client_path),
+                baudrate=19200,
+                timeout=3.0,
+            )
+            client = AsyncModbusClient(transport=transport, unit_id=1)
+            await client.connect()
+            await run_client_assertions(client)
+            await client.disconnect()
+
+
+@pytest.mark.usefixtures("log_traffic")
+async def test_diagslave_ascii_serial() -> None:
+    """Test tmodbus client using Modbus ASCII (serial) against diagslave."""
+    server_path = Path(__file__).parent / "ascii-server-socket"
+    client_path = Path(__file__).parent / "ascii-client-socket"
+
+    with make_virtual_serial_ports(server_path, client_path):
+        async with diagslave("ascii", "-o", "10", str(server_path)):
+            transport = AsyncAsciiTransport(
+                str(client_path),
+                baudrate=19200,
+                timeout=3.0,
+            )
+            client = AsyncModbusClient(transport=transport, unit_id=1)
+            await client.connect()
+            await run_client_assertions(client)
+            await client.disconnect()

--- a/src/tmodbus/__init__.py
+++ b/src/tmodbus/__init__.py
@@ -10,6 +10,7 @@ from .transport import (
     AsyncRtuTransport,
     AsyncSmartTransport,
     AsyncTcpTransport,
+    AsyncUdpTransport,
 )
 from .transport.async_rtu import SerialXOptions
 
@@ -260,6 +261,69 @@ def create_async_rtu_over_tcp_client(  # noqa: PLR0913
     return AsyncModbusClient(smart_transport, unit_id=unit_id)
 
 
+def create_async_udp_client(  # noqa: PLR0913
+    host: str,
+    port: int = 502,
+    *,
+    unit_id: int,
+    timeout: float = 10.0,
+    connect_timeout: float = 10.0,
+    wait_between_requests: float = 0.0,
+    wait_after_connect: float = 0.0,
+    auto_reconnect: "bool | AsyncRetrying" = True,
+    on_reconnected: Callable[[], Awaitable[None] | None] | None = None,
+    on_connection_lost: Callable[[Exception | None], None] | None = None,
+    response_retry_strategy: "AsyncRetrying | None" = None,
+    retry_on_device_busy: bool = True,
+    retry_on_device_failure: bool = False,
+    **connection_kwargs: Any,
+) -> AsyncModbusClient:
+    """Create an asynchronous UDP Modbus client with automatic reconnect and request retry functionality.
+
+    Args:
+        host: The IP address or hostname of the Modbus server.
+        port: The port number of the Modbus server (default is 502).
+        unit_id: The unit ID to use for requests.
+        timeout: Timeout in seconds, default 10.0s
+        connect_timeout: Timeout for establishing connection, default 10.0s
+        wait_between_requests: Wait time between requests in seconds (default: 0.0s)
+        wait_after_connect: Wait time after connection establishment in seconds (default: 0.0s)
+        auto_reconnect: Whether to automatically reconnect on connection loss (default: True).
+                        Can be a custom AsyncRetrying instance when more control is needed.
+        on_reconnected: Callback to be called after a successful reconnection.
+        on_connection_lost: Callback invoked the moment the connection is lost, receiving the causing
+                            exception (or None on a clean close). Fires even when auto_reconnect is disabled.
+        response_retry_strategy: Retry strategy for handling failed requests (default: None).
+        retry_on_device_busy: Whether to retry on device busy errors (default: True).
+                              Can be a custom AsyncRetrying instance when more control is needed.
+        retry_on_device_failure: Whether to retry on device failure errors (default: False).
+                                 Can be a custom AsyncRetrying instance when more control is needed.
+        connection_kwargs: Additional connection parameters passed to `asyncio.create_datagram_endpoint`
+
+    Returns:
+        An instance of AsyncModbusClient configured for UDP transport.
+
+    """
+    smart_transport = AsyncSmartTransport(
+        AsyncUdpTransport(
+            host,
+            port,
+            timeout=timeout,
+            connect_timeout=connect_timeout,
+            **connection_kwargs,
+        ),
+        wait_between_requests=wait_between_requests,
+        wait_after_connect=wait_after_connect,
+        auto_reconnect=auto_reconnect,
+        on_reconnected=on_reconnected,
+        on_connection_lost=on_connection_lost,
+        response_retry_strategy=response_retry_strategy,
+        retry_on_device_busy=retry_on_device_busy,
+        retry_on_device_failure=retry_on_device_failure,
+    )
+    return AsyncModbusClient(smart_transport, unit_id=unit_id)
+
+
 __all__ = [
     "AsyncAsciiTransport",
     "AsyncModbusClient",
@@ -267,8 +331,10 @@ __all__ = [
     "AsyncRtuTransport",
     "AsyncSmartTransport",
     "AsyncTcpTransport",
+    "AsyncUdpTransport",
     "create_async_ascii_client",
     "create_async_rtu_client",
     "create_async_rtu_over_tcp_client",
     "create_async_tcp_client",
+    "create_async_udp_client",
 ]

--- a/src/tmodbus/server/__init__.py
+++ b/src/tmodbus/server/__init__.py
@@ -4,6 +4,7 @@ from .async_ascii import AsyncAsciiServer
 from .async_rtu import AsyncRtuServer
 from .async_rtu_over_tcp import AsyncRtuOverTcpServer
 from .async_tcp import AsyncTcpServer
+from .async_udp import AsyncUdpServer
 from .handler import ModbusHandler, ModbusRequestRouter, handle_modbus_request, is_server_pdu_class
 
 __all__ = [
@@ -11,6 +12,7 @@ __all__ = [
     "AsyncRtuOverTcpServer",
     "AsyncRtuServer",
     "AsyncTcpServer",
+    "AsyncUdpServer",
     "ModbusHandler",
     "ModbusRequestRouter",
     "handle_modbus_request",

--- a/src/tmodbus/server/async_udp.py
+++ b/src/tmodbus/server/async_udp.py
@@ -1,0 +1,179 @@
+"""Async Modbus UDP Server."""
+
+import asyncio
+import logging
+import struct
+from functools import partial
+from typing import Any
+
+from tmodbus.const import ExceptionCode
+from tmodbus.exceptions import InvalidRequestError
+from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
+
+from .base import AsyncBaseServer, get_server_pdu_class
+from .handler import ModbusHandler, handle_modbus_request
+
+logger = logging.getLogger(__name__)
+log_raw_traffic = partial(base_log_raw_traffic, "UDP-Server")
+
+
+class AsyncUdpServer(AsyncBaseServer):
+    """Async Modbus UDP Server."""
+
+    def __init__(
+        self,
+        host: str,
+        handler: ModbusHandler,
+        port: int = 502,
+        *,
+        unregistered_unit_id_exception_code: int = ExceptionCode.GATEWAY_TARGET_DEVICE_FAILED_TO_RESPOND,
+        **server_kwargs: Any,
+    ) -> None:
+        """Initialize Async Modbus UDP Server.
+
+        Args:
+            host: Interface to bind to
+            port: Port to listen on (default: 502)
+            handler: User-defined async handler for processing requests
+            unregistered_unit_id_exception_code: Exception code returned when a request is received
+                for a Unit ID that is not registered in the handler (default: 0x0B).
+            server_kwargs: Additional arguments for `asyncio.loop.create_datagram_endpoint`
+
+        """
+        self.host = host
+        self.handler = handler
+        self.port = port
+        self.unregistered_unit_id_exception_code = unregistered_unit_id_exception_code
+        self.server_kwargs = server_kwargs
+        self._transport: asyncio.DatagramTransport | None = None
+        self._protocol: ModbusUdpServerProtocol | None = None
+        self._serve_forever_future: asyncio.Future[None] | None = None
+
+    async def start(self) -> None:
+        """Start the server."""
+        if self._transport is not None:
+            return
+
+        loop = asyncio.get_running_loop()
+        self._transport, self._protocol = await loop.create_datagram_endpoint(
+            lambda: ModbusUdpServerProtocol(self.handler, self.unregistered_unit_id_exception_code),
+            local_addr=(self.host, self.port),
+            **self.server_kwargs,
+        )
+        logger.info("Modbus UDP Server listening on %s:%d", self.host, self.port)
+
+    async def stop(self) -> None:
+        """Stop the server."""
+        if self._transport:
+            self._transport.close()
+            self._transport = None
+            self._protocol = None
+            logger.info("Modbus UDP Server stopped")
+        if self._serve_forever_future and not self._serve_forever_future.done():
+            self._serve_forever_future.set_result(None)
+
+    async def serve_forever(self) -> None:
+        """Start the server and block until cancelled."""
+        await self.start()
+        self._serve_forever_future = asyncio.get_running_loop().create_future()
+        try:
+            await self._serve_forever_future
+        except asyncio.CancelledError:
+            await self.stop()
+            raise
+
+    @property
+    def sockets(self) -> list[Any]:
+        """Get the sockets of the server (matching AsyncTcpServer sockets interface)."""
+        sock = self._transport.get_extra_info("socket") if self._transport else None
+        return [sock] if sock else []
+
+
+class ModbusUdpServerProtocol(asyncio.DatagramProtocol):
+    """Asyncio DatagramProtocol implementation for Modbus UDP Server."""
+
+    transport: asyncio.DatagramTransport | None = None
+
+    def __init__(
+        self,
+        handler: ModbusHandler,
+        unregistered_unit_id_exception_code: int,
+    ) -> None:
+        """Initialize Modbus UDP Server Protocol."""
+        super().__init__()
+        self.handler = handler
+        self.unregistered_unit_id_exception_code = unregistered_unit_id_exception_code
+        self._background_tasks: set[asyncio.Task[None]] = set()
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        """Handle connection made event."""
+        if not isinstance(transport, asyncio.DatagramTransport):
+            msg = "Expected a DatagramTransport"
+            raise TypeError(msg)
+        self.transport = transport
+        logger.info("Modbus UDP server protocol endpoint established.")
+
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        """Handle received datagram from client."""
+        # Schedule datagram processing in the background to avoid blocking other clients
+        task = asyncio.create_task(self._process_datagram(data, addr))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    async def _process_datagram(self, data: bytes, addr: tuple[str, int]) -> None:
+        try:
+            if len(data) < 7:
+                logger.warning("UDP packet from %s too short: %d bytes", addr, len(data))
+                log_raw_traffic("recv", data, is_error=True)
+                return
+
+            mbap_header = data[:7]
+            transaction_id, protocol_id, length, unit_id = struct.unpack(">HHHB", mbap_header)
+
+            if protocol_id != 0:
+                logger.warning("Invalid protocol ID from %s: %d", addr, protocol_id)
+                log_raw_traffic("recv", data, is_error=True)
+                return
+
+            pdu_length = length - 1  # Length includes unit_id
+            if pdu_length <= 0 or pdu_length > 253:
+                logger.warning("Invalid PDU length from %s: %d", addr, pdu_length)
+                log_raw_traffic("recv", data, is_error=True)
+                return
+
+            if len(data) != 7 + pdu_length:
+                logger.warning("UDP datagram length mismatch: expected %d, got %d", 7 + pdu_length, len(data))
+                log_raw_traffic("recv", data, is_error=True)
+                return
+
+            pdu_bytes = data[7:]
+            function_code = pdu_bytes[0]
+            is_error = False
+
+            if not self.handler.supports_unit_id(unit_id):
+                logger.warning("Request for unregistered unit ID %d from %s", unit_id, addr)
+                response_pdu_bytes = bytes([function_code | 0x80, self.unregistered_unit_id_exception_code])
+                is_error = True
+            else:
+                try:
+                    raw_pdu_class = get_server_pdu_class(pdu_bytes)
+                    request_pdu = raw_pdu_class.decode_request(pdu_bytes)
+                except (ValueError, InvalidRequestError) as e:
+                    logger.warning("Invalid request from %s: %s", addr, e)
+                    response_pdu_bytes = bytes([function_code | 0x80, 0x01])  # ILLEGAL_FUNCTION
+                    is_error = True
+                else:
+                    response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)
+
+            log_raw_traffic("recv", data, is_error=is_error)
+
+            # Build MBAP header for response
+            resp_length = len(response_pdu_bytes) + 1
+            resp_mbap = struct.pack(">HHHB", transaction_id, protocol_id, resp_length, unit_id)
+
+            out_bytes = resp_mbap + response_pdu_bytes
+            if self.transport:
+                self.transport.sendto(out_bytes, addr)
+                log_raw_traffic("sent", out_bytes)
+        except Exception:
+            logger.exception("Error processing UDP datagram from %s", addr)

--- a/src/tmodbus/transport/__init__.py
+++ b/src/tmodbus/transport/__init__.py
@@ -6,6 +6,7 @@ from .async_rtu import AsyncRtuTransport
 from .async_rtu_over_tcp import AsyncRtuOverTcpTransport
 from .async_smart import AsyncSmartTransport
 from .async_tcp import AsyncTcpTransport
+from .async_udp import AsyncUdpTransport
 
 __all__ = [
     "AsyncAsciiTransport",
@@ -14,4 +15,5 @@ __all__ = [
     "AsyncRtuTransport",
     "AsyncSmartTransport",
     "AsyncTcpTransport",
+    "AsyncUdpTransport",
 ]

--- a/src/tmodbus/transport/async_udp.py
+++ b/src/tmodbus/transport/async_udp.py
@@ -1,0 +1,322 @@
+"""Async UDP Transport Layer Implementation.
+
+Implements async Modbus UDP protocol transport based on asyncio, including MBAP header processing.
+"""
+
+import asyncio
+import logging
+import struct
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, TypeVar
+
+from tmodbus.exceptions import (
+    InvalidResponseError,
+    ModbusConnectionError,
+    UnknownModbusResponseError,
+    error_code_to_exception_map,
+)
+from tmodbus.pdu import BaseClientPDU
+from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
+
+from .async_base import AsyncBaseTransport
+
+RT = TypeVar("RT")
+
+logger = logging.getLogger(__name__)
+log_raw_traffic = partial(base_log_raw_traffic, "UDP")
+
+
+class AsyncUdpTransport(AsyncBaseTransport):
+    """Async Modbus UDP Transport Layer Implementation.
+
+    Handles async Modbus UDP communication based on asyncio, including:
+    - Async UDP socket connection management (using create_datagram_endpoint)
+    - MBAP header construction and parsing
+    - Transaction identifier management
+    - Async error handling and timeout management
+    """
+
+    _transport: asyncio.DatagramTransport | None = None
+    _protocol: "ModbusUdpProtocol | None" = None
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 502,
+        *,
+        timeout: float = 10.0,
+        connect_timeout: float = 10.0,
+        on_connection_lost: Callable[[Exception | None], None] | None = None,
+        **connection_kwargs: Any,
+    ) -> None:
+        """Initialize async UDP transport layer.
+
+        Args:
+            host: Target host IP address or domain name
+            port: Target port, default 502 (Modbus TCP/UDP standard port)
+            timeout: Timeout in seconds, default 10.0s
+            connect_timeout: Timeout for establishing connection, default 10.0s
+            on_connection_lost: Optional callback invoked the moment the connection is lost.
+                                Receives the causing exception, or None on a clean close.
+            connection_kwargs: Additional connection parameters passed to `asyncio.create_datagram_endpoint`
+
+        Raises:
+            ValueError: When parameters are invalid
+            TypeError: When parameter types are incorrect
+
+        """
+        if not 0 < port < 65535:
+            msg = "Port must be an integer between 1-65535."
+            raise ValueError(msg)
+        if timeout <= 0:
+            msg = "Timeout must be a positive number."
+            raise ValueError(msg)
+        if connect_timeout <= 0:
+            msg = "Connect timeout must be a positive number."
+            raise ValueError(msg)
+
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.connect_timeout = connect_timeout
+        self.on_connection_lost = on_connection_lost
+        self.connection_kwargs = connection_kwargs
+
+    async def open(self) -> None:
+        """Async establish UDP endpoint."""
+        loop = asyncio.get_running_loop()
+        if self.is_open():
+            logger.debug("Async UDP connection already open: %s:%d", self.host, self.port)
+            return
+
+        try:
+            self._transport, self._protocol = await asyncio.wait_for(
+                loop.create_datagram_endpoint(
+                    lambda: ModbusUdpProtocol(on_connection_lost=self._on_connection_lost, timeout=self.timeout),
+                    remote_addr=(self.host, self.port),
+                    **self.connection_kwargs,
+                ),
+                timeout=self.connect_timeout,
+            )
+
+            logger.info("Async UDP endpoint established: %s:%d", self.host, self.port)
+        except TimeoutError:
+            logger.warning("Async UDP endpoint creation timeout: %s:%d", self.host, self.port, exc_info=True)
+            raise
+        except Exception as e:
+            logger.exception("Async UDP endpoint creation error: %s:%d", self.host, self.port)
+            raise ModbusConnectionError from e
+
+    async def close(self) -> None:
+        """Close UDP transport."""
+        if not self._transport or self._transport.is_closing():
+            logger.debug("Async UDP connection already closed: %s:%d", self.host, self.port)
+            return
+
+        try:
+            self._transport.close()
+            logger.info("Async UDP connection closed: %s:%d", self.host, self.port)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Error during async connection close: %s", e)
+
+    def is_open(self) -> bool:
+        """Check if UDP connection is open."""
+        return self._transport is not None and not self._transport.is_closing()
+
+    def _on_connection_lost(self, exc: Exception | None) -> None:
+        if exc:
+            logger.error("Async UDP connection lost due to error: %s", exc)
+        else:
+            logger.info("Async UDP connection closed.")
+
+        self._transport = None
+        self._protocol = None
+
+        self._notify_connection_lost(exc)
+
+    async def send_and_receive(self, unit_id: int, pdu: BaseClientPDU[RT]) -> RT:
+        """Async send PDU and receive response.
+
+        Args:
+            unit_id: Unit identifier (slave address)
+            pdu: PDU object to send
+
+        """
+        if not self.is_open() or self._protocol is None:
+            msg = "Transport is not connected."
+            raise ModbusConnectionError(msg)
+
+        return await self._protocol.send_and_receive(unit_id, pdu)
+
+
+@dataclass(frozen=True)
+class _ModbusMessage:
+    """Dataclass representing a Modbus message with MBAP header and PDU."""
+
+    transaction_id: int
+    protocol_id: int
+    length: int
+    unit_id: int
+    pdu_bytes: bytes
+
+    @property
+    def bytes(self) -> bytes:
+        """Get full message bytes including MBAP header and PDU."""
+        mbap_header = struct.pack(">HHHB", self.transaction_id, self.protocol_id, self.length, self.unit_id)
+        return mbap_header + self.pdu_bytes
+
+
+class ModbusUdpProtocol(asyncio.DatagramProtocol):
+    """Asyncio DatagramProtocol implementation for Modbus UDP with MBAP headers."""
+
+    transport: asyncio.DatagramTransport | None = None
+
+    on_connection_lost: Callable[[Exception | None], None]
+    timeout: float
+
+    _next_transaction_id: int
+    _pending_requests: dict[int, asyncio.Future[_ModbusMessage]]
+
+    def __init__(
+        self,
+        *,
+        on_connection_lost: Callable[[Exception | None], None],
+        timeout: float = 10.0,
+    ) -> None:
+        """Initialize Modbus UDP Protocol."""
+        super().__init__()
+
+        self.on_connection_lost = on_connection_lost
+        self.timeout = timeout
+
+        self._next_transaction_id = 1
+        self._pending_requests = {}
+
+    def _get_next_transaction_id(self) -> int:
+        current_id = self._next_transaction_id
+        self._next_transaction_id = (self._next_transaction_id + 1) % 0x10000  # 16-bit wraparound
+        return current_id
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        """Handle connection made event."""
+        if not isinstance(transport, asyncio.DatagramTransport):
+            msg = "Expected a DatagramTransport"
+            raise TypeError(msg)
+
+        self.transport = transport
+        logger.info("Modbus UDP protocol connection established.")
+
+    async def send_and_receive(self, unit_id: int, pdu: BaseClientPDU[RT]) -> RT:
+        """Async send PDU and receive response.
+
+        Implements complete async UDP protocol communication flow:
+        1. Build MBAP header
+        2. Async send request (MBAP header + PDU)
+        3. Async wait for response matched by Transaction ID
+        4. Validate MBAP header
+        5. Return response PDU
+        """
+        if self.transport is None or self.transport.is_closing():
+            msg = "Not connected."
+            raise ModbusConnectionError(msg)
+
+        current_transaction_id = self._get_next_transaction_id()
+        request_pdu_bytes = pdu.encode_request()  # Convert PDU to bytes
+
+        mbap_header = struct.pack(
+            ">HHHB",
+            current_transaction_id,
+            0x0000,
+            len(request_pdu_bytes) + 1,
+            unit_id,
+        )
+
+        request_frame = mbap_header + request_pdu_bytes
+
+        read_future: asyncio.Future[_ModbusMessage] = asyncio.get_event_loop().create_future()
+        self._pending_requests[current_transaction_id] = read_future
+
+        self.transport.sendto(request_frame)
+        log_raw_traffic("sent", request_frame)
+
+        try:
+            response = await asyncio.wait_for(read_future, timeout=self.timeout)
+        except TimeoutError as e:
+            msg = f"Response timeout after {self.timeout} seconds for transaction with ID {current_transaction_id:#04x}"
+            raise TimeoutError(msg) from e
+        finally:
+            self._pending_requests.pop(current_transaction_id, None)
+
+        if response.unit_id != unit_id:
+            msg = f"Unit ID mismatch: expected {unit_id:#04x}, received {response.unit_id:#04x}"
+            raise InvalidResponseError(msg, response_bytes=response.bytes)
+
+        if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & 0x80:  # Exception response
+            function_code = response.pdu_bytes[0] & 0x7F
+            exception_code = response.pdu_bytes[1] if len(response.pdu_bytes) > 1 else 0
+
+            if exception_code in error_code_to_exception_map:
+                raise error_code_to_exception_map[exception_code](function_code)
+            raise UnknownModbusResponseError(exception_code, function_code)
+
+        return pdu.decode_response(response.pdu_bytes)
+
+    def datagram_received(self, data: bytes, _addr: tuple[str, int] | None) -> None:
+        """Handle incoming datagram."""
+        if len(data) < 7:
+            logger.warning("Received UDP packet too short: %d bytes", len(data))
+            log_raw_traffic("recv", data, is_error=True)
+            return
+
+        transaction_id, protocol_id, length, unit_id = struct.unpack_from(">HHHB", data)
+
+        if protocol_id != 0x0000:
+            logger.warning("Received UDP packet with invalid Protocol ID: %d", protocol_id)
+            log_raw_traffic("recv", data, is_error=True)
+            return
+
+        pdu_length = length - 1
+        if len(data) != 7 + pdu_length:
+            logger.warning("Received UDP packet length mismatch: expected %d, got %d", 7 + pdu_length, len(data))
+            log_raw_traffic("recv", data, is_error=True)
+            return
+
+        pdu_bytes = data[7:]
+
+        future = self._pending_requests.get(transaction_id)
+        if future and not future.done():
+            log_raw_traffic("recv", data)
+            future.set_result(
+                _ModbusMessage(
+                    transaction_id=transaction_id,
+                    protocol_id=protocol_id,
+                    length=length,
+                    unit_id=unit_id,
+                    pdu_bytes=pdu_bytes,
+                )
+            )
+        else:
+            logger.warning(
+                "Received unexpected response with Transaction ID: %d. Discarding bytes: %s",
+                transaction_id,
+                data.hex(" ").upper(),
+            )
+            log_raw_traffic("recv", data, is_ignored=True)
+
+    def error_received(self, exc: Exception) -> None:
+        """Handle error received (e.g. ICMP port unreachable)."""
+        logger.warning("Modbus UDP protocol error received: %s", exc)
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        """Handle connection lost event."""
+        for future in self._pending_requests.values():
+            if not future.done():
+                future.set_exception(ModbusConnectionError("Connection lost before response was received."))
+        self._pending_requests.clear()
+
+        self.on_connection_lost(exc)
+
+
+__all__ = ["AsyncUdpTransport"]

--- a/tests/server/test_async_udp.py
+++ b/tests/server/test_async_udp.py
@@ -1,0 +1,315 @@
+"""Tests for tmodbus/server/async_udp.py."""
+
+import asyncio
+import struct
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from tmodbus.pdu import ReadHoldingRegistersPDU
+from tmodbus.server import AsyncUdpServer, ModbusRequestRouter
+from tmodbus.server.async_udp import ModbusUdpServerProtocol
+
+
+@pytest.fixture
+async def udp_server() -> AsyncIterator[AsyncUdpServer]:
+    """Fixture to start a Modbus UDP server on a free local port."""
+    router = ModbusRequestRouter()
+
+    @router.register(ReadHoldingRegistersPDU)
+    async def handle_read(_unit_id: int, _request: ReadHoldingRegistersPDU) -> list[int]:
+        return [0x1234, 0x5678]
+
+    # Use port=0 so OS dynamically allocates a free port
+    server = AsyncUdpServer(host="127.0.0.1", port=0, handler=router)
+    await server.start()
+    yield server
+    await server.stop()
+
+
+def get_server_port(server: AsyncUdpServer) -> int:
+    """Get the dynamic port allocated to the UDP server."""
+    assert len(server.sockets) > 0
+    addr = server.sockets[0].getsockname()
+    assert isinstance(addr, tuple)
+    return int(addr[1])
+
+
+class UdpClientProtocol(asyncio.DatagramProtocol):
+    """Simple DatagramProtocol for testing the Modbus UDP server."""
+
+    transport: asyncio.DatagramTransport | None
+
+    def __init__(self) -> None:
+        """Initialize test UDP client protocol."""
+        self.transport = None
+        self.future: asyncio.Future[bytes] = asyncio.get_event_loop().create_future()
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        """Handle connection made event."""
+        if not isinstance(transport, asyncio.DatagramTransport):
+            msg = "Expected DatagramTransport"
+            raise TypeError(msg)
+        self.transport = transport
+
+    def datagram_received(self, data: bytes, _addr: tuple[str, int] | None) -> None:
+        """Handle received datagram from server."""
+        self.future.set_result(data)
+
+
+async def test_udp_server_happy_path(udp_server: AsyncUdpServer) -> None:
+    """Test successful request/response transaction on the UDP server."""
+    port = get_server_port(udp_server)
+    loop = asyncio.get_running_loop()
+
+    transport, protocol = await loop.create_datagram_endpoint(UdpClientProtocol, remote_addr=("127.0.0.1", port))
+
+    try:
+        # Build Read Holding Registers request: transaction_id=1, protocol_id=0, length=6, unit_id=1
+        # PDU: function_code=3, start_address=0, quantity=2
+        mbap = struct.pack(">HHHB", 1, 0, 6, 1)
+        pdu = b"\x03\x00\x00\x00\x02"
+        transport.sendto(mbap + pdu)
+
+        resp = await asyncio.wait_for(protocol.future, timeout=1.0)
+        assert len(resp) >= 7
+
+        tx, proto, _length, unit = struct.unpack(">HHHB", resp[:7])
+        assert tx == 1
+        assert proto == 0
+        assert unit == 1
+
+        resp_pdu = resp[7:]
+        # Expected: function_code=3, byte_count=4, data=[0x1234, 0x5678]
+        assert resp_pdu == b"\x03\x04\x12\x34\x56\x78"
+
+    finally:
+        transport.close()
+
+
+async def test_udp_server_invalid_protocol_id(udp_server: AsyncUdpServer) -> None:
+    """Test that request with invalid protocol ID is ignored (no response)."""
+    port = get_server_port(udp_server)
+    loop = asyncio.get_running_loop()
+
+    transport, protocol = await loop.create_datagram_endpoint(UdpClientProtocol, remote_addr=("127.0.0.1", port))
+
+    try:
+        # Protocol ID = 1 (invalid)
+        mbap = struct.pack(">HHHB", 1, 1, 6, 1)
+        pdu = b"\x03\x00\x00\x00\x02"
+        frame = mbap + pdu
+
+        with patch("tmodbus.server.async_udp.log_raw_traffic") as mock_log:
+            transport.sendto(frame)
+
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(protocol.future, timeout=0.1)
+
+            mock_log.assert_any_call("recv", frame, is_error=True)
+
+    finally:
+        transport.close()
+
+
+async def test_udp_server_invalid_pdu_length(udp_server: AsyncUdpServer) -> None:
+    """Test that request with too long PDU length is ignored (no response)."""
+    port = get_server_port(udp_server)
+    loop = asyncio.get_running_loop()
+
+    transport, protocol = await loop.create_datagram_endpoint(UdpClientProtocol, remote_addr=("127.0.0.1", port))
+
+    try:
+        # PDU length = 255 (so length = 256, which exceeds max allowed length of 253 bytes)
+        mbap = struct.pack(">HHHB", 1, 0, 256, 1)
+        pdu = b"\x03" + b"\x00" * 254
+        frame = mbap + pdu
+
+        with patch("tmodbus.server.async_udp.log_raw_traffic") as mock_log:
+            transport.sendto(frame)
+
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(protocol.future, timeout=0.1)
+
+            mock_log.assert_any_call("recv", frame, is_error=True)
+
+    finally:
+        transport.close()
+
+
+async def test_udp_server_unsupported_function_code(udp_server: AsyncUdpServer) -> None:
+    """Test that unsupported function code returns ILLEGAL_FUNCTION exception."""
+    port = get_server_port(udp_server)
+    loop = asyncio.get_running_loop()
+
+    transport, protocol = await loop.create_datagram_endpoint(UdpClientProtocol, remote_addr=("127.0.0.1", port))
+
+    try:
+        # Function code 0x99 is unsupported
+        mbap = struct.pack(">HHHB", 2, 0, 2, 1)
+        pdu = b"\x99"
+        frame = mbap + pdu
+
+        transport.sendto(frame)
+
+        resp = await asyncio.wait_for(protocol.future, timeout=1.0)
+        assert len(resp) >= 7
+
+        tx, proto, _length, unit = struct.unpack(">HHHB", resp[:7])
+        assert tx == 2
+        assert proto == 0
+        assert unit == 1
+
+        resp_pdu = resp[7:]
+        # Illegal function code exception response: 0x99 | 0x80 = 0x19, exception = 0x01
+        assert resp_pdu == b"\x99\x01"
+
+    finally:
+        transport.close()
+
+
+async def test_udp_server_start_twice(udp_server: AsyncUdpServer) -> None:
+    """Test starting the server twice returns early."""
+    await udp_server.start()  # Already started by fixture
+
+
+async def test_udp_server_stop_not_started() -> None:
+    """Test stopping a server that has not been started."""
+    server = AsyncUdpServer(host="127.0.0.1", port=0, handler=ModbusRequestRouter())
+    await server.stop()
+    assert server.sockets == []
+
+
+async def test_udp_server_serve_forever() -> None:
+    """Test serve_forever starts and can be stopped directly."""
+    server = AsyncUdpServer(host="127.0.0.1", port=0, handler=ModbusRequestRouter())
+    task = asyncio.create_task(server.serve_forever())
+    await asyncio.sleep(0.05)
+    assert len(server.sockets) > 0
+    await server.stop()
+    await task
+    assert len(server.sockets) == 0
+
+
+async def test_udp_server_serve_forever_cancelled() -> None:
+    """Test serve_forever starts and handles CancelledError."""
+    server = AsyncUdpServer(host="127.0.0.1", port=0, handler=ModbusRequestRouter())
+    task = asyncio.create_task(server.serve_forever())
+    await asyncio.sleep(0.05)
+    assert len(server.sockets) > 0
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert len(server.sockets) == 0
+
+
+async def test_server_protocol_connection_made_type_error() -> None:
+    """Test connection_made raises TypeError when transport is not a DatagramTransport."""
+    protocol = ModbusUdpServerProtocol(ModbusRequestRouter(), unregistered_unit_id_exception_code=0x0B)
+    mock_transport = MagicMock(spec=asyncio.WriteTransport)  # TCP transport
+    with pytest.raises(TypeError, match="Expected a DatagramTransport"):
+        protocol.connection_made(mock_transport)
+
+
+async def test_udp_server_packet_too_short(udp_server: AsyncUdpServer) -> None:
+    """Test that a packet shorter than 7 bytes is logged as error and ignored."""
+    port = get_server_port(udp_server)
+    loop = asyncio.get_running_loop()
+
+    transport, protocol = await loop.create_datagram_endpoint(UdpClientProtocol, remote_addr=("127.0.0.1", port))
+
+    try:
+        with patch("tmodbus.server.async_udp.log_raw_traffic") as mock_log:
+            # Send a 5-byte packet
+            transport.sendto(b"\x00\x01\x00\x00\x00")
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(protocol.future, timeout=0.1)
+            mock_log.assert_any_call("recv", b"\x00\x01\x00\x00\x00", is_error=True)
+    finally:
+        transport.close()
+
+
+async def test_udp_server_length_mismatch(udp_server: AsyncUdpServer) -> None:
+    """Test datagram length mismatch is logged as error and ignored."""
+    port = get_server_port(udp_server)
+    loop = asyncio.get_running_loop()
+
+    transport, protocol = await loop.create_datagram_endpoint(UdpClientProtocol, remote_addr=("127.0.0.1", port))
+
+    try:
+        # MBAP length field says length is 6, but we only send 5 bytes after MBAP
+        mbap = struct.pack(">HHHB", 1, 0, 6, 1)
+        pdu = b"\x03\x00\x00\x00"  # 4 bytes PDU, total 5 bytes after MBAP instead of 6
+        frame = mbap + pdu
+
+        with patch("tmodbus.server.async_udp.log_raw_traffic") as mock_log:
+            transport.sendto(frame)
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(protocol.future, timeout=0.1)
+            mock_log.assert_any_call("recv", frame, is_error=True)
+    finally:
+        transport.close()
+
+
+async def test_udp_server_unregistered_unit_id() -> None:
+    """Test that unregistered unit ID returns unregistered_unit_id_exception_code exception."""
+    router = ModbusRequestRouter()
+
+    # Register only for unit_id=1
+    @router.register(ReadHoldingRegistersPDU, unit_id=1)
+    async def handle_read(_unit_id: int, _request: ReadHoldingRegistersPDU) -> list[int]:
+        return [0x1234]
+
+    server = AsyncUdpServer(host="127.0.0.1", port=0, handler=router)
+    await server.start()
+
+    port = get_server_port(server)
+    loop = asyncio.get_running_loop()
+
+    transport, protocol = await loop.create_datagram_endpoint(UdpClientProtocol, remote_addr=("127.0.0.1", port))
+
+    try:
+        # Unit ID = 99 is unregistered (only unit ID 1 is registered)
+        mbap = struct.pack(">HHHB", 1, 0, 6, 99)
+        pdu = b"\x03\x00\x00\x00\x01"
+        frame = mbap + pdu
+
+        transport.sendto(frame)
+        resp = await asyncio.wait_for(protocol.future, timeout=1.0)
+        assert len(resp) >= 7
+        resp_pdu = resp[7:]
+        assert resp_pdu == b"\x83\x0b"  # 0x03 | 0x80 = 0x83, exception code 0x0B
+    finally:
+        transport.close()
+        await server.stop()
+
+
+async def test_server_protocol_process_datagram_no_transport() -> None:
+    """Test that _process_datagram doesn't crash when transport is None/closed."""
+    protocol = ModbusUdpServerProtocol(ModbusRequestRouter(), unregistered_unit_id_exception_code=0x0B)
+    protocol.transport = None  # No transport
+
+    mbap = struct.pack(">HHHB", 1, 0, 6, 1)
+    pdu = b"\x03\x00\x00\x00\x02"
+    frame = mbap + pdu
+
+    # Should not raise exception
+    await protocol._process_datagram(frame, ("127.0.0.1", 1234))
+
+
+async def test_server_protocol_process_datagram_exception() -> None:
+    """Test that exceptions during _process_datagram are caught and logged."""
+    protocol = ModbusUdpServerProtocol(ModbusRequestRouter(), unregistered_unit_id_exception_code=0x0B)
+
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    protocol.connection_made(mock_transport)
+
+    with (
+        patch("struct.unpack", side_effect=RuntimeError("unexpected unpack error")),
+        patch("tmodbus.server.async_udp.logger") as mock_logger,
+    ):
+        # Call it
+        await protocol._process_datagram(b"\x00\x01\x02\x03\x04\x05\x06\x07\x08", ("127.0.0.1", 1234))
+
+        # Verify exception log was called
+        mock_logger.exception.assert_called_with("Error processing UDP datagram from %s", ("127.0.0.1", 1234))

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,6 +11,7 @@ from tmodbus import (
     create_async_rtu_client,
     create_async_rtu_over_tcp_client,
     create_async_tcp_client,
+    create_async_udp_client,
 )
 from tmodbus.transport.async_base import AsyncBaseTransport
 
@@ -38,6 +39,7 @@ def patch_module() -> Generator[None, None, None]:
         mock.patch.object(tmodbus, "AsyncAsciiTransport", _DummyTransport),
         mock.patch.object(tmodbus, "AsyncModbusClient", _DummyClient),
         mock.patch.object(tmodbus, "AsyncRtuOverTcpTransport", _DummyTransport),
+        mock.patch.object(tmodbus, "AsyncUdpTransport", _DummyTransport),
     ):
         yield
 
@@ -142,6 +144,34 @@ async def test_create_async_rtu_over_tcp_client() -> None:
     assert client.transport.args[0].kwargs["extra"] == 456
 
 
+async def test_create_async_udp_client() -> None:
+    """Test create_async_udp_client function."""
+    client = create_async_udp_client(
+        "127.0.0.1",
+        port=1502,
+        unit_id=1,
+        timeout=5.0,
+        connect_timeout=2.0,
+        wait_between_requests=0.1,
+        wait_after_connect=0.2,
+        auto_reconnect=False,
+        on_reconnected=None,
+        response_retry_strategy=None,
+        retry_on_device_busy=False,
+        retry_on_device_failure=True,
+        extra=123,
+    )
+    assert isinstance(client, _DummyClient)
+    # Check transport chain
+    assert isinstance(client.transport, _DummyTransport)
+    assert isinstance(client.transport.args[0], _DummyTransport)
+    assert client.transport.args[0].args[0] == "127.0.0.1"
+    assert client.transport.args[0].args[1] == 1502
+    assert client.transport.args[0].kwargs["timeout"] == 5.0
+    assert client.transport.args[0].kwargs["connect_timeout"] == 2.0
+    assert client.transport.args[0].kwargs["extra"] == 123
+
+
 def test_public_transports_and_factories_are_exported() -> None:
     """Every public transport and client factory must be in __all__ and importable."""
     expected = {
@@ -151,10 +181,12 @@ def test_public_transports_and_factories_are_exported() -> None:
         "AsyncRtuTransport",
         "AsyncSmartTransport",
         "AsyncTcpTransport",
+        "AsyncUdpTransport",
         "create_async_ascii_client",
         "create_async_rtu_client",
         "create_async_rtu_over_tcp_client",
         "create_async_tcp_client",
+        "create_async_udp_client",
     }
     assert expected <= set(tmodbus.__all__)
     for name in tmodbus.__all__:

--- a/tests/transport/test_async_udp.py
+++ b/tests/transport/test_async_udp.py
@@ -1,0 +1,466 @@
+"""Tests for tmodbus/transport/async_udp.py."""
+
+import asyncio
+import struct
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from tmodbus.exceptions import (
+    InvalidResponseError,
+    ModbusConnectionError,
+    ModbusResponseError,
+    UnknownModbusResponseError,
+)
+from tmodbus.pdu.base import BaseClientPDU
+from tmodbus.transport.async_udp import AsyncUdpTransport, ModbusUdpProtocol
+
+
+class _DummyPDU(BaseClientPDU[tuple[str, bytes]]):
+    function_code = 0x03
+
+    def encode_request(self) -> bytes:
+        return b"\x03\x04"
+
+    def decode_response(self, data: bytes) -> tuple[str, bytes]:
+        return ("decoded", data)
+
+
+async def test_invalid_constructor_args() -> None:
+    """Test that invalid constructor arguments raise ValueError."""
+    with pytest.raises(ValueError, match=r"Port must be .*"):
+        AsyncUdpTransport("host", port=0)
+    with pytest.raises(ValueError, match=r"Timeout must .*"):
+        AsyncUdpTransport("host", timeout=0)
+    with pytest.raises(ValueError, match=r"Connect timeout must .*"):
+        AsyncUdpTransport("host", connect_timeout=0)
+
+
+async def test_open_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that connection errors during open are handled."""
+
+    async def mock_create_datagram_endpoint(*_args: object, **_kwargs: object) -> tuple[None, None]:
+        msg = "Connection failed"
+        raise RuntimeError(msg)
+
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "create_datagram_endpoint", mock_create_datagram_endpoint)
+
+    t = AsyncUdpTransport("host", port=1234)
+    with pytest.raises(ModbusConnectionError):
+        await t.open()
+
+
+async def test_open_respects_connect_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """open() must give up after connect_timeout when the endpoint creation never completes."""
+
+    async def never_connects(*_args: object, **_kwargs: object) -> tuple[None, None]:
+        await asyncio.sleep(10)
+        return None, None
+
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "create_datagram_endpoint", never_connects)
+
+    t = AsyncUdpTransport("host", port=1234, connect_timeout=0.05)
+    with pytest.raises(TimeoutError):
+        await t.open()
+    assert not t.is_open()
+
+
+async def test_is_open_false_when_not_connected() -> None:
+    """Test is_open returns False when not connected."""
+    t = AsyncUdpTransport("host", port=1234)
+    assert not t.is_open()
+
+
+async def test_send_and_receive_not_connected() -> None:
+    """Test that sending when not connected raises ModbusConnectionError."""
+    t = AsyncUdpTransport("host", port=1234)
+    pdu = _DummyPDU()
+    with pytest.raises(ModbusConnectionError):
+        await t.send_and_receive(1, pdu)
+
+
+async def test_close_already_closed() -> None:
+    """Test that closing an already closed transport logs and returns early."""
+    t = AsyncUdpTransport("host", port=1234)
+    with patch("tmodbus.transport.async_udp.logger") as log:
+        await t.close()
+        log.debug.assert_called()
+
+
+async def test_open_other_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that exceptions during open are logged and re-raised as ModbusConnectionError."""
+
+    async def mock_create_datagram_endpoint(*_args: object, **_kwargs: object) -> tuple[None, None]:
+        msg = "fail"
+        raise RuntimeError(msg)
+
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "create_datagram_endpoint", mock_create_datagram_endpoint)
+
+    t = AsyncUdpTransport("host", port=1234)
+    with patch("tmodbus.transport.async_udp.logger") as log:
+        with pytest.raises(ModbusConnectionError):
+            await t.open()
+        log.exception.assert_called()
+
+
+async def test_close_during_send_and_receive() -> None:
+    """Test that a ModbusConnectionError is raised if the connection is closed during send_and_receive."""
+    t = AsyncUdpTransport("host", port=1234)
+    t._protocol = None
+    with patch.object(t, "is_open", return_value=True):
+        pdu = _DummyPDU()
+        with pytest.raises(ModbusConnectionError):
+            await t.send_and_receive(1, pdu)
+
+
+async def test_is_open_with_transport() -> None:
+    """Test is_open returns True when transport is connected."""
+    t = AsyncUdpTransport("host", port=1234)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    t._transport = mock_transport
+
+    assert t.is_open()
+
+
+async def test_is_open_with_closing_transport() -> None:
+    """Test is_open returns False when transport is closing."""
+    t = AsyncUdpTransport("host", port=1234)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = True
+    t._transport = mock_transport
+
+    assert not t.is_open()
+
+
+async def test_protocol_transaction_id_wraparound() -> None:
+    """Test that Transaction ID wraps around after reaching 0xFFFF."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
+
+    protocol._next_transaction_id = 0xFFFF
+    tid1 = protocol._get_next_transaction_id()
+    tid2 = protocol._get_next_transaction_id()
+    assert tid1 == 0xFFFF
+    assert tid2 == 0
+
+
+async def test_protocol_connection_made() -> None:
+    """Test that connection_made is called correctly."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    protocol.connection_made(mock_transport)
+    assert protocol.transport == mock_transport
+
+
+async def test_protocol_connection_made_type_error() -> None:
+    """Test that connection_made raises TypeError when transport is not a DatagramTransport."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
+    mock_transport = MagicMock(spec=asyncio.WriteTransport)  # TCP transport
+    with pytest.raises(TypeError, match="Expected a DatagramTransport"):
+        protocol.connection_made(mock_transport)
+
+
+async def test_protocol_send_and_receive_happy_path() -> None:
+    """Test successful send_and_receive."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=1.0)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+
+    # Simulate response arriving in the event loop
+    async def simulate_recv() -> None:
+        await asyncio.sleep(0.05)
+        # response: tx_id=1, proto_id=0, length=4, unit_id=1, pdu=b"\x03\x99"
+        resp_data = struct.pack(">HHHB", 1, 0, 3, 1) + b"\x03\x99"
+        protocol.datagram_received(resp_data, None)
+
+    task = asyncio.create_task(simulate_recv())
+    res = await protocol.send_and_receive(unit_id=1, pdu=pdu)
+    await task
+
+    # Assert request sent correctly
+    expected_request = struct.pack(">HHHB", 1, 0, 3, 1) + b"\x03\x04"
+    mock_transport.sendto.assert_called_once_with(expected_request)
+    assert res == ("decoded", b"\x03\x99")
+
+
+async def test_protocol_send_and_receive_timeout() -> None:
+    """Test timeout in send_and_receive."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+    with pytest.raises(TimeoutError, match=r"Response timeout after .*"):
+        await protocol.send_and_receive(unit_id=1, pdu=pdu)
+
+
+async def test_protocol_datagram_received_invalid_length() -> None:
+    """Test packet too short is discarded and logged as error."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
+    # Less than 7 bytes
+    with (
+        patch("tmodbus.transport.async_udp.logger") as mock_logger,
+        patch("tmodbus.transport.async_udp.log_raw_traffic") as mock_log,
+    ):
+        protocol.datagram_received(b"\x00\x01\x00\x00\x00\x01", None)
+        mock_logger.warning.assert_called_with("Received UDP packet too short: %d bytes", 6)
+        mock_log.assert_called_once_with("recv", b"\x00\x01\x00\x00\x00\x01", is_error=True)
+
+
+async def test_protocol_datagram_received_invalid_protocol_id() -> None:
+    """Test invalid protocol ID is discarded and logged as error."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
+
+    data = struct.pack(">HHHB", 1, 1, 2, 1) + b"\x03"
+    with (
+        patch("tmodbus.transport.async_udp.logger") as mock_logger,
+        patch("tmodbus.transport.async_udp.log_raw_traffic") as mock_log,
+    ):
+        protocol.datagram_received(data, None)
+        mock_logger.warning.assert_called_with("Received UDP packet with invalid Protocol ID: %d", 1)
+        mock_log.assert_called_once_with("recv", data, is_error=True)
+
+
+async def test_protocol_datagram_received_length_mismatch() -> None:
+    """Test length mismatch is discarded and logged as error."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
+    # length field = 5, but we send shorter PDU
+    data = struct.pack(">HHHB", 1, 0, 5, 1) + b"\x03\x04"
+    with (
+        patch("tmodbus.transport.async_udp.logger") as mock_logger,
+        patch("tmodbus.transport.async_udp.log_raw_traffic") as mock_log,
+    ):
+        protocol.datagram_received(data, None)
+        mock_logger.warning.assert_called_with("Received UDP packet length mismatch: expected %d, got %d", 11, 9)
+        mock_log.assert_called_once_with("recv", data, is_error=True)
+
+
+async def test_protocol_datagram_received_unit_id_mismatch() -> None:
+    """Test unit ID mismatch raises InvalidResponseError."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+
+    async def simulate_recv() -> None:
+        await asyncio.sleep(0.05)
+        # response has unit_id = 2, expected 1
+        resp_data = struct.pack(">HHHB", 1, 0, 3, 2) + b"\x03\x99"
+        protocol.datagram_received(resp_data, None)
+
+    task = asyncio.create_task(simulate_recv())
+    with pytest.raises(InvalidResponseError, match="Unit ID mismatch"):
+        await protocol.send_and_receive(unit_id=1, pdu=pdu)
+    await task
+
+
+async def test_protocol_datagram_received_exception_response() -> None:
+    """Test that exception responses translate to exceptions."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+
+    async def simulate_recv() -> None:
+        await asyncio.sleep(0.05)
+        # PDU has function code 0x03 | 0x80 = 0x83 (exception) and exception code 0x01
+        resp_data = struct.pack(">HHHB", 1, 0, 3, 1) + b"\x83\x01"
+        protocol.datagram_received(resp_data, None)
+
+    task = asyncio.create_task(simulate_recv())
+    # Exception code 0x01 is Illegal Function
+    with pytest.raises(ModbusResponseError):
+        await protocol.send_and_receive(unit_id=1, pdu=pdu)
+    await task
+
+
+async def test_protocol_error_received() -> None:
+    """Test that error_received does not abort pending futures/requests."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=1.0)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+
+    async def simulate_events() -> None:
+        await asyncio.sleep(0.02)
+        # 1. Trigger an asynchronous ICMP error
+        protocol.error_received(ConnectionRefusedError("ICMP Port Unreachable"))
+        await asyncio.sleep(0.02)
+        # 2. Trigger the actual valid response to verify the future is still alive
+        resp_data = struct.pack(">HHHB", 1, 0, 3, 1) + b"\x03\x99"
+        protocol.datagram_received(resp_data, None)
+
+    task = asyncio.create_task(simulate_events())
+    res = await protocol.send_and_receive(unit_id=1, pdu=pdu)
+    await task
+
+    assert res == ("decoded", b"\x03\x99")
+
+
+async def test_protocol_datagram_received_unexpected_ignored() -> None:
+    """Test that an unexpected response is discarded and logged as ignored."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
+    # Valid datagram, but transaction ID 999 is unexpected/ignored
+    data = struct.pack(">HHHB", 999, 0, 3, 1) + b"\x03\x04"
+    with (
+        patch("tmodbus.transport.async_udp.logger") as mock_logger,
+        patch("tmodbus.transport.async_udp.log_raw_traffic") as mock_log,
+    ):
+        protocol.datagram_received(data, None)
+        mock_logger.warning.assert_called_once()
+        mock_log.assert_called_once_with("recv", data, is_ignored=True)
+
+
+async def test_open_called_twice() -> None:
+    """Test calling open() twice returns early."""
+    t = AsyncUdpTransport("host", port=1234)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    t._transport = mock_transport
+    t._protocol = MagicMock()
+    with patch("tmodbus.transport.async_udp.logger") as log:
+        await t.open()
+        log.debug.assert_called_with("Async UDP connection already open: %s:%d", "host", 1234)
+
+
+async def test_open_success_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test successful open() flow."""
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    mock_protocol = MagicMock(spec=ModbusUdpProtocol)
+
+    async def mock_create_datagram_endpoint(*_args: object, **_kwargs: object) -> tuple[Any, Any]:
+        return mock_transport, mock_protocol
+
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "create_datagram_endpoint", mock_create_datagram_endpoint)
+
+    t = AsyncUdpTransport("host", port=1234)
+    await t.open()
+    assert t.is_open()
+
+
+async def test_close_success() -> None:
+    """Test successful close()."""
+    t = AsyncUdpTransport("host", port=1234)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    t._transport = mock_transport
+
+    await t.close()
+    mock_transport.close.assert_called_once()
+
+
+async def test_close_raises_exception() -> None:
+    """Test that exceptions during close are swallowed."""
+    t = AsyncUdpTransport("host", port=1234)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    mock_transport.close.side_effect = RuntimeError("close failed")
+    t._transport = mock_transport
+
+    with patch("tmodbus.transport.async_udp.logger") as log:
+        await t.close()
+        log.debug.assert_called()
+
+
+async def test_on_connection_lost_with_exception() -> None:
+    """Test on_connection_lost callback with exception and notify user callback."""
+    cb = MagicMock()
+    t = AsyncUdpTransport("host", port=1234, on_connection_lost=cb)
+    exc = RuntimeError("lost")
+    t._on_connection_lost(exc)
+    cb.assert_called_once_with(exc)
+
+
+async def test_on_connection_lost_clean() -> None:
+    """Test on_connection_lost callback with clean exit."""
+    cb = MagicMock()
+    t = AsyncUdpTransport("host", port=1234, on_connection_lost=cb)
+    t._on_connection_lost(None)
+    cb.assert_called_once_with(None)
+
+
+async def test_transport_send_and_receive_delegates() -> None:
+    """Test AsyncUdpTransport.send_and_receive delegates to protocol."""
+    t = AsyncUdpTransport("host", port=1234)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    t._transport = mock_transport
+
+    mock_proto = AsyncMock()
+    t._protocol = mock_proto
+
+    pdu = _DummyPDU()
+    await t.send_and_receive(1, pdu)
+    mock_proto.send_and_receive.assert_called_once_with(1, pdu)
+
+
+async def test_protocol_send_and_receive_not_connected() -> None:
+    """Test ModbusUdpProtocol.send_and_receive raises when not connected."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=1.0)
+    # no transport set
+    pdu = _DummyPDU()
+    with pytest.raises(ModbusConnectionError, match=r"Not connected\."):
+        await protocol.send_and_receive(1, pdu)
+
+
+async def test_protocol_send_and_receive_unknown_exception_code() -> None:
+    """Test exception response with unknown exception code."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=1.0)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+
+    async def simulate_recv() -> None:
+        await asyncio.sleep(0.05)
+        # response has exception code 0x09 (which is not in standard map)
+        resp_data = struct.pack(">HHHB", 1, 0, 3, 1) + b"\x83\x09"
+        protocol.datagram_received(resp_data, None)
+
+    task = asyncio.create_task(simulate_recv())
+
+    with pytest.raises(UnknownModbusResponseError):
+        await protocol.send_and_receive(unit_id=1, pdu=pdu)
+    await task
+
+
+async def test_protocol_connection_lost_notifies_futures_and_callback() -> None:
+    """Test that connection_lost cancels pending futures and calls user callback."""
+    cb = MagicMock()
+    protocol = ModbusUdpProtocol(on_connection_lost=cb, timeout=1.0)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+    task = asyncio.create_task(protocol.send_and_receive(1, pdu))
+
+    # Add a done future to cover the branch where not future.done() is False
+    done_future = asyncio.get_event_loop().create_future()
+    done_future.set_result(None)
+    protocol._pending_requests[999] = done_future
+
+    await asyncio.sleep(0.01)
+    exc = ConnectionResetError("lost connection")
+    protocol.connection_lost(exc)
+
+    with pytest.raises(ModbusConnectionError, match=r"Connection lost before response was received\."):
+        await task
+
+    cb.assert_called_once_with(exc)


### PR DESCRIPTION
Add support for Modbus UDP as both a client and server .

Validated against a new integration test target: https://www.modbusdriver.com/diagslave.html