### PR TITLE
Cache integration test binaries where possible

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,6 +38,23 @@ jobs:
         with:
           path: integration_tests/fieldtalk/diagslave
           key: diagslave-3.5-x86_64  # gitleaks:allow
+      - name: 📦 Cache simonvetter binaries
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            integration_tests/simonvetter/client
+            integration_tests/simonvetter/server
+          key: simonvetter-${{ hashFiles('integration_tests/simonvetter/go.sum', 'integration_tests/simonvetter/*.go') }}
+      - name: 📦 Cache rmodbus binaries
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: integration_tests/rmodbus/target/release
+          key: rmodbus-${{ hashFiles('integration_tests/rmodbus/Cargo.lock', 'integration_tests/rmodbus/*.rs') }}
+      - name: 📦 Cache tokio binaries
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: integration_tests/tokio/target/release
+          key: tokio-${{ hashFiles('integration_tests/tokio/Cargo.lock', 'integration_tests/tokio/*.rs') }}
       - name: 🏗 Compile integration test binaries
         run: |
           for dir in integration_tests/*/; do

--- a/integration_tests/rmodbus/compile.sh
+++ b/integration_tests/rmodbus/compile.sh
@@ -1,3 +1,26 @@
 #!/bin/bash
+set -euo pipefail
+
+FORCE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--force)
+      FORCE=true
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Skip build if binaries are already present (e.g. restored from CI cache) and no force flag
+if ! $FORCE && [ -f "target/release/server" ] && [ -f "target/release/client" ] && [ -f "target/release/ascii-server" ]; then
+    echo "rmodbus binaries already present, skipping build."
+    exit 0
+fi
 
 docker run --rm -v "$(pwd):/work" -w /work rust:1-trixie cargo build --release

--- a/integration_tests/simonvetter/compile.sh
+++ b/integration_tests/simonvetter/compile.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+set -euo pipefail
+
+FORCE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--force)
+      FORCE=true
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Skip build if binaries are already present (e.g. restored from CI cache)
+if ! $FORCE && [ -f "client" ] && [ -f "server" ]; then
+    echo "simonvetter binaries already present, skipping build."
+    exit 0
+fi
 
 docker run --rm -v "$(pwd)":/work  -w /work golang:1.22 go build -o client client.go
 docker run --rm -v "$(pwd)":/work  -w /work golang:1.22 go build -o server server.go

--- a/integration_tests/tokio/compile.sh
+++ b/integration_tests/tokio/compile.sh
@@ -1,3 +1,26 @@
 #!/bin/bash
+set -euo pipefail
+
+FORCE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--force)
+      FORCE=true
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Skip build if binaries are already present (e.g. restored from CI cache) and no force flag
+if ! $FORCE && [ -f "target/release/tokio-server" ] && [ -f "target/release/tokio-client" ]; then
+    echo "tokio binaries already present, skipping build."
+    exit 0
+fi
 
 docker run --rm -v "$(pwd):/work" -w /work rust:1-trixie cargo build --release


### PR DESCRIPTION
Prevents needless re-compilation of the integration test targets.