### PR TITLE
Don't allow tenacity default stop/wait combination

### DIFF
--- a/src/tmodbus/transport/async_smart.py
+++ b/src/tmodbus/transport/async_smart.py
@@ -22,7 +22,9 @@ try:
         retry_any,
         retry_if_exception_type,
         stop_after_delay,
+        stop_never,
         wait_exponential,
+        wait_none,
     )
 except ImportError as ex:  # pragma: no cover
     msg = "tenacity is required for Smart Transport functionality.Install with 'pip install tmodbus[smart]'"
@@ -105,7 +107,7 @@ class AsyncSmartTransport(AsyncBaseTransport):
     auto_reconnect: AsyncRetrying | None = None
     response_retry_strategy: AsyncRetrying
 
-    def __init__(  # noqa: C901, PLR0913
+    def __init__(  # noqa: PLR0913
         self,
         base_transport: "AsyncBaseTransport",
         *,
@@ -134,6 +136,9 @@ class AsyncSmartTransport(AsyncBaseTransport):
                                 base transport and fires straight from its protocol's connection_lost,
                                 so it is the earliest notification that the socket dropped.
             response_retry_strategy: Retry strategy for handling failed requests (default: None).
+                                     Note: when providing a custom strategy, don't forget to set the stop and wait
+                                     parameters to sane values. The default stop_never and wait_none will cause the
+                                     request to retry indefinitely and without any delay, which is usually not desired.
             retry_on_device_busy: Whether to retry on device busy errors (default: True).
                                   Can be a custom AsyncRetrying instance when more control is needed.
             retry_on_device_failure: Whether to retry on device failure errors (default: False).
@@ -173,6 +178,24 @@ class AsyncSmartTransport(AsyncBaseTransport):
             raise ValueError(msg)
         self.on_reconnected = on_reconnected
 
+        self.response_retry_strategy = self._assemble_retry_strategy(
+            response_retry_strategy,
+            auto_reconnect=auto_reconnect,
+            retry_on_device_busy=retry_on_device_busy,
+            retry_on_device_failure=retry_on_device_failure,
+        )
+
+        self._last_request_finished_at: float | None = None
+
+    def _assemble_retry_strategy(
+        self,
+        response_retry_strategy: AsyncRetrying | None,
+        *,
+        auto_reconnect: AsyncRetrying | bool,
+        retry_on_device_busy: bool,
+        retry_on_device_failure: bool,
+    ) -> AsyncRetrying:
+        """Assemble the retry strategy for handling failed requests."""
         retry_functions: list[RetryBaseT] = []
 
         if not response_retry_strategy:
@@ -189,9 +212,22 @@ class AsyncSmartTransport(AsyncBaseTransport):
         if retry_on_device_failure:
             retry_functions.append(retry_if_exception_type(ServerDeviceFailureError))
 
-        self.response_retry_strategy = response_retry_strategy.copy(retry=retry_any(*retry_functions))  # type: ignore[arg-type]
+        retry_strategy = response_retry_strategy.copy(retry=retry_any(*retry_functions))  # type: ignore[arg-type]
 
-        self._last_request_finished_at: float | None = None
+        if retry_strategy.stop == stop_never and isinstance(retry_strategy.wait, wait_none):
+            # these are the default values of AsyncRetrying, but they are not suitable
+            # for a retry strategy in this context
+            logger.warning(
+                "response_retry_strategy.stop is set to stop_never and response_retry_strategy.wait is set to "
+                "wait_none. This would result in retries to be done indefinitely and without any delay, which is "
+                "undesired. Reverting to tmodbus stop/wait default values instead."
+            )
+
+            retry_strategy = retry_strategy.copy(
+                stop=DEFAULT_RESPONSE_RETRY_STRATEGY.stop, wait=DEFAULT_RESPONSE_RETRY_STRATEGY.wait
+            )
+
+        return retry_strategy
 
     async def open(self) -> None:
         """Open Transport Connection.

--- a/tests/transport/test_async_smart.py
+++ b/tests/transport/test_async_smart.py
@@ -4,7 +4,15 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tenacity import AsyncRetrying, Future, RetryCallState, retry_if_exception_type, stop_after_attempt
+from tenacity import (
+    AsyncRetrying,
+    Future,
+    RetryCallState,
+    retry_if_exception_type,
+    stop_after_attempt,
+    stop_never,
+    wait_none,
+)
 from tmodbus.exceptions import ModbusConnectionError, RequestRetryFailedError
 from tmodbus.pdu.base import BaseClientPDU
 from tmodbus.transport import async_smart as async_smart_module
@@ -596,3 +604,24 @@ async def test_retry_with_new_connection_if_needed_returns_false_different_excep
     # Should return False since it's not a ModbusConnectionError
     assert result is False
     assert not t._must_reconnect
+
+
+async def test_retry_strategy_force_sane_defaults(
+    base_transport_mock: AsyncBaseTransport,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that response_retry_strategy with stop_never and wait_none is overridden to sane defaults."""
+    # Create a custom strategy with stop_never and wait_none
+    custom_strategy = AsyncRetrying()
+
+    with caplog.at_level("DEBUG", logger="tmodbus.transport.async_smart"):
+        t = AsyncSmartTransport(
+            base_transport_mock,
+            response_retry_strategy=custom_strategy,
+        )
+
+    assert any("Reverting to tmodbus stop/wait default values instead" in record.message for record in caplog.records)
+
+    # The resulting strategy should not have stop_never and wait_none
+    assert t.response_retry_strategy.stop != stop_never
+    assert not isinstance(t.response_retry_strategy.wait, wait_none)


### PR DESCRIPTION
Fixes #80

Log a warning and revert to tmodbus default stop/wait instead.