### PR TITLE
Tenacity is a required dependency in practice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ classifiers = [
 
 dynamic = ["version"]
 
-dependencies = []
+dependencies = [
+  "tenacity>=8.2.0,!=8.4.0"
+]
 
 [project.urls]
 HomePage = "https://github.com/wlcrs/tmodbus"
@@ -40,7 +42,6 @@ Changelog = "https://github.com/wlcrs/tmodbus/releases"
 [project.optional-dependencies]
 
 async-serial = ["serialx"]
-smart = ["tenacity>=8.2.0,!=8.4.0"]
 security = ["cryptography>=38.0"]
 
 [build-system]

--- a/src/tmodbus/transport/async_smart.py
+++ b/src/tmodbus/transport/async_smart.py
@@ -14,21 +14,17 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, TypeVar
 
-try:
-    from tenacity import (
-        AsyncRetrying,
-        RetryCallState,
-        RetryError,
-        retry_any,
-        retry_if_exception_type,
-        stop_after_delay,
-        stop_never,
-        wait_exponential,
-        wait_none,
-    )
-except ImportError as ex:  # pragma: no cover
-    msg = "tenacity is required for Smart Transport functionality.Install with 'pip install tmodbus[smart]'"
-    raise ImportError(msg) from ex
+from tenacity import (
+    AsyncRetrying,
+    RetryCallState,
+    RetryError,
+    retry_any,
+    retry_if_exception_type,
+    stop_after_delay,
+    stop_never,
+    wait_exponential,
+    wait_none,
+)
 
 from tmodbus.exceptions import (
     ModbusConnectionError,

--- a/uv.lock
+++ b/uv.lock
@@ -1314,6 +1314,9 @@ wheels = [
 [[package]]
 name = "tmodbus"
 source = { editable = "." }
+dependencies = [
+    { name = "tenacity" },
+]
 
 [package.optional-dependencies]
 async-serial = [
@@ -1321,9 +1324,6 @@ async-serial = [
 ]
 security = [
     { name = "cryptography" },
-]
-smart = [
-    { name = "tenacity" },
 ]
 
 [package.dev-dependencies]
@@ -1362,9 +1362,9 @@ test = [
 requires-dist = [
     { name = "cryptography", marker = "extra == 'security'", specifier = ">=38.0" },
     { name = "serialx", marker = "extra == 'async-serial'" },
-    { name = "tenacity", marker = "extra == 'smart'", specifier = ">=8.2.0,!=8.4.0" },
+    { name = "tenacity", specifier = ">=8.2.0,!=8.4.0" },
 ]
-provides-extras = ["async-serial", "security", "smart"]
+provides-extras = ["async-serial", "security"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
The goal of `tmodbus` is to be a library with zero required dependencies. However, due to the reliance of convenience functions like `create_async_tcp_client` on  `AsyncSmartTransport` (which requires tenacity), the import of the library crashes when tenacity is not present.

This PR makes the dependency explicit, fixing the import crash.

At a later time, we can revisit if we can truly make tenacity an optional dependency. In practice this is quite hard without a lot of ugly checks and/or causing a lot of potential breakage in libraries relying on tmodbus. 