### PR TITLE
Don't require the security extra for plain TCP servers

### DIFF
--- a/src/tmodbus/server/security.py
+++ b/src/tmodbus/server/security.py
@@ -103,8 +103,6 @@ def extract_client_cert(writer: asyncio.StreamWriter) -> x509.Certificate | None
     if not der_cert:
         return None
 
-    # Imported only once there is a certificate to parse, so that plain TCP
-    # servers do not require the optional ``security`` extra.
     try:
         from cryptography import x509  # noqa: PLC0415
     except ImportError as e:

--- a/src/tmodbus/server/security.py
+++ b/src/tmodbus/server/security.py
@@ -95,6 +95,16 @@ def extract_client_cert(writer: asyncio.StreamWriter) -> x509.Certificate | None
         connection is not TLS or the client did not present a certificate.
 
     """
+    ssl_object: _ssl.SSLObject | None = writer.get_extra_info("ssl_object")
+    if ssl_object is None:
+        return None
+
+    der_cert: bytes | None = ssl_object.getpeercert(binary_form=True)
+    if not der_cert:
+        return None
+
+    # Imported only once there is a certificate to parse, so that plain TCP
+    # servers do not require the optional ``security`` extra.
     try:
         from cryptography import x509  # noqa: PLC0415
     except ImportError as e:
@@ -103,14 +113,6 @@ def extract_client_cert(writer: asyncio.StreamWriter) -> x509.Certificate | None
             "from TLS client certificates. Install with 'pip install tmodbus[security]'."
         )
         raise ImportError(msg) from e
-
-    ssl_object: _ssl.SSLObject | None = writer.get_extra_info("ssl_object")
-    if ssl_object is None:
-        return None
-
-    der_cert: bytes | None = ssl_object.getpeercert(binary_form=True)
-    if not der_cert:
-        return None
 
     return x509.load_der_x509_certificate(der_cert)
 

--- a/tests/server/test_async_tcp_security.py
+++ b/tests/server/test_async_tcp_security.py
@@ -568,6 +568,31 @@ async def test_extract_client_cert_plain_connection() -> None:
     mock_writer.get_extra_info.assert_called_once_with("ssl_object")
 
 
+async def test_extract_client_cert_plain_connection_without_cryptography() -> None:
+    """A plain (non-TLS) writer needs no cryptography package.
+
+    ``AsyncTcpServer.handle_client`` calls this for *every* accepted connection,
+    including plain TCP ones, so importing cryptography here would make the
+    optional ``security`` extra mandatory for any server.
+    """
+    mock_writer = MagicMock(spec=asyncio.StreamWriter)
+    mock_writer.get_extra_info.return_value = None  # no ssl_object
+
+    with patch.dict("sys.modules", {"cryptography": None, "cryptography.x509": None}):
+        assert extract_client_cert(mock_writer) is None
+
+
+async def test_extract_client_cert_no_peercert_without_cryptography() -> None:
+    """A TLS client that presented no certificate needs no cryptography package."""
+    mock_writer = MagicMock(spec=asyncio.StreamWriter)
+    mock_ssl = MagicMock()
+    mock_writer.get_extra_info.return_value = mock_ssl
+    mock_ssl.getpeercert.return_value = None
+
+    with patch.dict("sys.modules", {"cryptography": None, "cryptography.x509": None}):
+        assert extract_client_cert(mock_writer) is None
+
+
 async def test_extract_client_cert_cryptography_missing() -> None:
     """extract_client_cert propagates ImportError when cryptography is not available."""
     mock_writer = MagicMock(spec=asyncio.StreamWriter)


### PR DESCRIPTION
# Proposed Changes

`AsyncTcpServer.handle_client` calls `extract_client_cert(writer)` for **every** accepted connection, including plain TCP ones. `extract_client_cert` imported `cryptography` before checking whether the connection was TLS at all, so on a plain TCP server without the optional `security` extra installed, the resulting `ImportError` propagated out of the `client_connected_cb` callback and killed every connection before a single request could be served:

```
Unhandled exception in client_connected_cb
Traceback (most recent call last):
  File "tmodbus/server/security.py", line 99, in extract_client_cert
    from cryptography import x509
ModuleNotFoundError: No module named 'cryptography'
...
ImportError: The 'cryptography' package is required to extract Modbus roles from TLS client certificates.
```

This also contradicted the function's own docstring, which promises it "Returns `None` ... if the connection is not TLS" — a branch that was unreachable without the extra.

This moves the import below the `ssl_object` / `getpeercert` checks so it only runs when there actually *is* a certificate to parse. Plain TCP servers now work with a bare `pip install tmodbus`, and the TLS paths are unchanged: a client that presents a certificate still gets it parsed, and the friendly `ImportError` still fires when the extra is genuinely needed.

Two regression tests are added. The existing tests all ran with `cryptography` installed, so the plain-TCP path was never exercised without it — the new ones patch it out of `sys.modules` and fail on `main`.

I hit this while using the new server support to build a test harness for [home-assistant-libs/modbus-connection](https://github.com/home-assistant-libs/modbus-connection); a plain `AsyncTcpServer` was unusable until I installed `cryptography`. Thanks for the 0.5 server work — it is otherwise a really nice fit for this.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDLzGMQBbuQExKVoA5Vj2X