### PR TITLE
Type the serial options the clients actually accept

### DIFF
--- a/src/tmodbus/__init__.py
+++ b/src/tmodbus/__init__.py
@@ -107,7 +107,8 @@ def create_async_rtu_client(  # noqa: PLR0913
         port: The port number of the Modbus server (default is 502).
         unit_id: The unit ID to use for requests.
         timeout: Timeout in seconds, default 10.0s
-        connect_timeout: Timeout for establishing connection, for the URL-based transports
+        connect_timeout: Timeout for establishing connection, on the URL-based transports.
+                         Defaults to the transport's own: 10.0s, or 5.0s for rfc2217://
         wait_between_requests: Wait time between requests in seconds (default: 0.0s)
         wait_after_connect: Wait time after connection establishment in seconds (default: 0.0s)
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).
@@ -165,7 +166,8 @@ def create_async_ascii_client(  # noqa: PLR0913
         port: The port number of the Modbus server (default is 502).
         unit_id: The unit ID to use for requests.
         timeout: Timeout in seconds, default 10.0s
-        connect_timeout: Timeout for establishing connection, for the URL-based transports
+        connect_timeout: Timeout for establishing connection, on the URL-based transports.
+                         Defaults to the transport's own: 10.0s, or 5.0s for rfc2217://
         wait_between_requests: Wait time between requests in seconds (default: 0.0s)
         wait_after_connect: Wait time after connection establishment in seconds (default: 0.0s)
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).

--- a/src/tmodbus/__init__.py
+++ b/src/tmodbus/__init__.py
@@ -107,8 +107,7 @@ def create_async_rtu_client(  # noqa: PLR0913
         port: The port number of the Modbus server (default is 502).
         unit_id: The unit ID to use for requests.
         timeout: Timeout in seconds, default 10.0s
-        connect_timeout: Timeout for establishing connection, on the URL-based transports.
-                         Defaults to the transport's own: 10.0s, or 5.0s for rfc2217://
+        connect_timeout: Timeout for establishing connection, default 10.0s
         wait_between_requests: Wait time between requests in seconds (default: 0.0s)
         wait_after_connect: Wait time after connection establishment in seconds (default: 0.0s)
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).
@@ -166,8 +165,7 @@ def create_async_ascii_client(  # noqa: PLR0913
         port: The port number of the Modbus server (default is 502).
         unit_id: The unit ID to use for requests.
         timeout: Timeout in seconds, default 10.0s
-        connect_timeout: Timeout for establishing connection, on the URL-based transports.
-                         Defaults to the transport's own: 10.0s, or 5.0s for rfc2217://
+        connect_timeout: Timeout for establishing connection, default 10.0s
         wait_between_requests: Wait time between requests in seconds (default: 0.0s)
         wait_after_connect: Wait time after connection establishment in seconds (default: 0.0s)
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).

--- a/src/tmodbus/__init__.py
+++ b/src/tmodbus/__init__.py
@@ -107,6 +107,7 @@ def create_async_rtu_client(  # noqa: PLR0913
         port: The port number of the Modbus server (default is 502).
         unit_id: The unit ID to use for requests.
         timeout: Timeout in seconds, default 10.0s
+        connect_timeout: Timeout for establishing connection, for the URL-based transports
         wait_between_requests: Wait time between requests in seconds (default: 0.0s)
         wait_after_connect: Wait time after connection establishment in seconds (default: 0.0s)
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).
@@ -164,6 +165,7 @@ def create_async_ascii_client(  # noqa: PLR0913
         port: The port number of the Modbus server (default is 502).
         unit_id: The unit ID to use for requests.
         timeout: Timeout in seconds, default 10.0s
+        connect_timeout: Timeout for establishing connection, for the URL-based transports
         wait_between_requests: Wait time between requests in seconds (default: 0.0s)
         wait_after_connect: Wait time after connection establishment in seconds (default: 0.0s)
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).

--- a/src/tmodbus/__init__.py
+++ b/src/tmodbus/__init__.py
@@ -90,6 +90,7 @@ def create_async_rtu_client(  # noqa: PLR0913
     port: str,
     *,
     unit_id: int,
+    timeout: float | None = None,
     wait_between_requests: float = 0.0,
     wait_after_connect: float = 0.0,
     auto_reconnect: "bool | AsyncRetrying" = True,
@@ -106,7 +107,6 @@ def create_async_rtu_client(  # noqa: PLR0913
         port: The port number of the Modbus server (default is 502).
         unit_id: The unit ID to use for requests.
         timeout: Timeout in seconds, default 10.0s
-        connect_timeout: Timeout for establishing connection, default 10.0s
         wait_between_requests: Wait time between requests in seconds (default: 0.0s)
         wait_after_connect: Wait time after connection establishment in seconds (default: 0.0s)
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).
@@ -128,6 +128,7 @@ def create_async_rtu_client(  # noqa: PLR0913
     smart_transport = AsyncSmartTransport(
         AsyncRtuTransport(
             port,
+            timeout=timeout,
             **serialx_options,
         ),
         wait_between_requests=wait_between_requests,
@@ -146,6 +147,7 @@ def create_async_ascii_client(  # noqa: PLR0913
     port: str,
     *,
     unit_id: int,
+    timeout: float | None = None,
     wait_between_requests: float = 0.0,
     wait_after_connect: float = 0.0,
     auto_reconnect: "bool | AsyncRetrying" = True,
@@ -162,7 +164,6 @@ def create_async_ascii_client(  # noqa: PLR0913
         port: The port number of the Modbus server (default is 502).
         unit_id: The unit ID to use for requests.
         timeout: Timeout in seconds, default 10.0s
-        connect_timeout: Timeout for establishing connection, default 10.0s
         wait_between_requests: Wait time between requests in seconds (default: 0.0s)
         wait_after_connect: Wait time after connection establishment in seconds (default: 0.0s)
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).
@@ -184,6 +185,7 @@ def create_async_ascii_client(  # noqa: PLR0913
     smart_transport = AsyncSmartTransport(
         AsyncAsciiTransport(
             port,
+            timeout=timeout,
             **serialx_options,
         ),
         wait_between_requests=wait_between_requests,

--- a/src/tmodbus/transport/async_ascii.py
+++ b/src/tmodbus/transport/async_ascii.py
@@ -9,10 +9,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, NotRequired, TypedDict, TypeVar, Unpack
-
-if TYPE_CHECKING:
-    from serialx import Parity, StopBits
+from typing import TypeVar, Unpack
 
 from tmodbus.exceptions import (
     ASCIIFrameError,
@@ -27,6 +24,7 @@ from tmodbus.utils.lrc import calculate_lrc, validate_lrc
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
 
 from .async_base import AsyncBaseTransport
+from .async_rtu import SerialXOptions
 
 logger = logging.getLogger(__name__)
 log_raw_traffic = partial(base_log_raw_traffic, "ASCII")
@@ -34,17 +32,6 @@ RT = TypeVar("RT")
 
 DEFAULT_TIMEOUT = 10.0  # Default timeout in seconds for async operations
 MIN_INTERFRAME_GAP = 0.001  # Minimum gap between frames in seconds (1ms)
-
-
-class SerialXOptions(TypedDict):
-    """Options for the SerialX connection."""
-
-    baudrate: int
-    parity: NotRequired["Parity"]
-    stopbits: NotRequired["StopBits"]
-    xonxoff: NotRequired[bool]
-    rtscts: NotRequired[bool]
-    exclusive: NotRequired[bool]
 
 
 ASCII_FRAME_START = b":"

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -79,8 +79,11 @@ class SerialXOptions(TypedDict):
     """Options for the SerialX connection."""
 
     baudrate: int
-    parity: NotRequired["Parity"]
-    stopbits: NotRequired["StopBits"]
+    # serialx normalises the plain str/float forms, and accepts bytesize as a
+    # pyserial-compatibility keyword.
+    parity: NotRequired["Parity | str"]
+    stopbits: NotRequired["StopBits | float"]
+    bytesize: NotRequired[int]
     xonxoff: NotRequired[bool]
     rtscts: NotRequired[bool]
     exclusive: NotRequired[bool]

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -82,6 +82,9 @@ class SerialXOptions(TypedDict):
     parity: NotRequired["Parity"]
     stopbits: NotRequired["StopBits"]
     bytesize: NotRequired[int]  # data bits per character: 7 for ASCII, 8 for RTU
+    # Honoured by the URL-based transports (socket://, tcp://, rfc2217://,
+    # esphome://), which bound establishing the connection by it.
+    connect_timeout: NotRequired[float]
     xonxoff: NotRequired[bool]
     rtscts: NotRequired[bool]
     exclusive: NotRequired[bool]

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -79,11 +79,9 @@ class SerialXOptions(TypedDict):
     """Options for the SerialX connection."""
 
     baudrate: int
-    # serialx normalises the plain str/float forms, and accepts bytesize as a
-    # pyserial-compatibility keyword.
-    parity: NotRequired["Parity | str"]
-    stopbits: NotRequired["StopBits | float"]
-    bytesize: NotRequired[int]
+    parity: NotRequired["Parity"]
+    stopbits: NotRequired["StopBits"]
+    bytesize: NotRequired[int]  # data bits per character: 7 for ASCII, 8 for RTU
     xonxoff: NotRequired[bool]
     rtscts: NotRequired[bool]
     exclusive: NotRequired[bool]


### PR DESCRIPTION
Fixes #89.

## What

The serial client factories accept options their types do not declare, so a typed caller has to suppress an error to pass a documented, working argument.

**`timeout`** — documented in both serial factories' docstrings, declared by neither. It falls into `**serialx_options: Unpack[SerialXOptions]`, which does not carry it, and works only because `AsyncRtuTransport` / `AsyncAsciiTransport` take `timeout` explicitly and the factory forwards the mapping into them. mypy rejects it:

```
error: Unexpected keyword argument "timeout" for "create_async_ascii_client"  [call-arg]
```

It is now a declared parameter on both factories, forwarded to the transport.

**`connect_timeout`** — also documented, also undeclared. It reaches serialx, and the URL-based transports bound establishing the connection by it: `socket://`, `tcp://`, `rfc2217://` and `esphome://` each wrap their connect in `asyncio_timeout(self._serial._connect_timeout)`. Measured against a blackholed address through `create_async_ascii_client`:

```
connect_timeout=1.0  ->  failed after 1.12s
connect_timeout=3.0  ->  failed after 3.01s
```

Declared as `NotRequired`, since a local device transport has no connection to bound.

**`bytesize`** — a real serial line setting (7 data bits for ASCII, 8 for RTU) that serialx honours as a pyserial-compatibility keyword, but which `SerialXOptions` could not express at all. Now declared.

`parity` and `stopbits` stay typed as their enums. serialx normalises the plain str/float forms at runtime, but its own `create_serial_connection` is typed for the enums, so widening the TypedDict makes this package's forwarding call fail to type check. A caller holding a str converts at its own edge.

**Two copies of `SerialXOptions`** — `transport/async_ascii.py` defined its own instead of importing `transport/async_rtu.py`'s, which is the one `tmodbus/__init__.py` types the factories against. Identical today, so extending one alone makes the ascii transport call fail to type-check. It now imports the shared definition; there is no circular import, `async_rtu` does not reference `async_ascii`.

## Checks

Run with `--group test --all-extras`; without the extras, ten test modules fail to collect on missing `serialx` and `cryptography`, and mypy silently skips the serial call sites.

- `pytest` — 1252 passed
- `mypy src` — clean, same as `main`
- `ruff check`, `ruff format --check` — clean

## Why

[modbus-connection](https://github.com/home-assistant-libs/modbus-connection) carries `# type: ignore[call-arg]` on both of its serial client calls for this. A blanket suppression on a call hides every keyword in it, not just the one that needs it. With `timeout`, `connect_timeout` and `bytesize` declared, what remains on that side is its own to fix — it passes `parity`/`stopbits` as str/int and should convert to the enums.

---

AI disclosure: this change was drafted with Claude Code at my direction, and I have reviewed it.
