### PR TITLE
Use FunctionCodeError and HeaderMismatchError where appropriate.

### DIFF
--- a/src/tmodbus/pdu/base.py
+++ b/src/tmodbus/pdu/base.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from typing import Self, TypeVar
 
-from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
+from tmodbus.exceptions import FunctionCodeError, InvalidRequestError
 
 RT = TypeVar("RT")
 
@@ -128,7 +128,7 @@ class BaseSubFunctionClientPDU[RT](BaseClientPDU[RT]):
         # Always assume that the first byte of the data-part of the frame contains the sub-function code
         if data[0] != cls.sub_function_code:
             msg = f"Expected sub-function code {cls.sub_function_code}, got {data[0]}"
-            raise InvalidResponseError(msg, response_bytes=data)
+            raise FunctionCodeError(msg, response_bytes=data)
 
         # if a fixed length is defined for the response PDU, return it
         if cls.rtu_response_data_length is not None:
@@ -164,7 +164,7 @@ class BaseSubFunctionPDU[RT](BaseSubFunctionClientPDU[RT], BasePDU[RT]):
         # Always assume that the first byte of the data-part of the frame contains the sub-function code
         if data[0] != cls.sub_function_code:
             msg = f"Expected sub-function code {cls.sub_function_code}, got {data[0]}"
-            raise InvalidResponseError(msg, response_bytes=data)
+            raise FunctionCodeError(msg, response_bytes=data)
 
         # if a fixed length is defined for the response PDU, return it
         if cls.rtu_response_data_length is not None:

--- a/src/tmodbus/pdu/coils.py
+++ b/src/tmodbus/pdu/coils.py
@@ -4,7 +4,7 @@ import struct
 from typing import Self
 
 from tmodbus.const import FunctionCode
-from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
+from tmodbus.exceptions import FunctionCodeError, InvalidRequestError, InvalidResponseError
 
 from .base import BasePDU
 
@@ -62,7 +62,8 @@ class ReadCoilsPDU(BasePDU[list[bool]]):
             List of boolean values representing the coil states
 
         Raises:
-            ValueError: If response format is invalid
+            InvalidResponseError: If response format is invalid
+            FunctionCodeError: If function code is incorrect
 
         """
         # response format: function code + byte count + data
@@ -74,7 +75,7 @@ class ReadCoilsPDU(BasePDU[list[bool]]):
 
         if function_code != self.function_code:
             msg = f"Invalid function code: expected {self.function_code:#04x}, received {function_code:#04x}"
-            raise InvalidResponseError(msg, response_bytes=response)
+            raise FunctionCodeError(msg, response_bytes=response)
 
         if len(response) != 2 + byte_count:
             msg = f"Invalid response PDU length: expected {2 + byte_count}, got {len(response)}"
@@ -303,6 +304,7 @@ class WriteMultipleCoilsPDU(BasePDU[int]):
 
         Raises:
             InvalidResponseError: If response format is invalid
+            FunctionCodeError: If function code is incorrect
 
         """
         # Verify response: function code + starting address + quantity

--- a/src/tmodbus/pdu/device.py
+++ b/src/tmodbus/pdu/device.py
@@ -10,7 +10,7 @@ from enum import IntEnum
 from typing import Literal, Self
 
 from tmodbus.const import FunctionCode
-from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
+from tmodbus.exceptions import FunctionCodeError, InvalidRequestError, InvalidResponseError
 
 from .base import BaseSubFunctionPDU
 
@@ -171,13 +171,13 @@ class ReadDeviceIdentificationPDU(BaseSubFunctionPDU[ReadDeviceIdentificationRes
 
         if function_code != self.function_code:
             msg = f"Invalid function code: expected {self.function_code:#04x}, received {function_code:#04x}"
-            raise InvalidResponseError(msg, response_bytes=response)
+            raise FunctionCodeError(msg, response_bytes=response)
 
         if sub_function_code != self.sub_function_code:
             msg = (
                 f"Invalid sub function code: expected {self.sub_function_code:#04x}, received {sub_function_code:#04x}"
             )
-            raise InvalidResponseError(msg, response_bytes=response)
+            raise FunctionCodeError(msg, response_bytes=response)
 
         if more not in (0x00, 0xFF):
             msg = f"Invalid 'more' value: {more:#04x}"

--- a/src/tmodbus/pdu/exception_status.py
+++ b/src/tmodbus/pdu/exception_status.py
@@ -1,7 +1,7 @@
 """Exception status PDU Module (serial line only)."""
 
 from tmodbus.const import FunctionCode
-from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
+from tmodbus.exceptions import FunctionCodeError, InvalidRequestError, InvalidResponseError
 from tmodbus.pdu.base import BasePDU
 
 
@@ -87,6 +87,6 @@ class ReadExceptionStatusPDU(BasePDU[int]):
 
         if function_code != self.function_code:
             msg = f"Invalid function code: {function_code:#04x}. Expected {self.function_code:#04x}."
-            raise InvalidResponseError(msg, response_bytes=data)
+            raise FunctionCodeError(msg, response_bytes=data)
 
         return status

--- a/src/tmodbus/pdu/fifo.py
+++ b/src/tmodbus/pdu/fifo.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Self
 
 from tmodbus.const import FunctionCode
-from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
+from tmodbus.exceptions import FunctionCodeError, InvalidRequestError, InvalidResponseError
 from tmodbus.pdu.base import BasePDU
 
 
@@ -120,6 +120,7 @@ class ReadFifoQueuePDU(BasePDU[list[int]]):
             List of values from the FIFO queue
 
         Raises:
+            FunctionCodeError: If function code is incorrect
             InvalidResponseError: If data length is incorrect or count doesn't match values
 
         """
@@ -133,7 +134,7 @@ class ReadFifoQueuePDU(BasePDU[list[int]]):
 
         if function_code != self.function_code:
             msg = f"Invalid function code: {function_code:#04x}. Expected {self.function_code:#04x}."
-            raise InvalidResponseError(msg, response_bytes=data)
+            raise FunctionCodeError(msg, response_bytes=data)
 
         if byte_count != len(data) - 3:
             msg = f"Byte count {byte_count} does not match actual data length {len(data) - 3}."

--- a/src/tmodbus/pdu/file.py
+++ b/src/tmodbus/pdu/file.py
@@ -4,7 +4,7 @@ import struct
 from dataclasses import dataclass
 from typing import Self
 
-from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
+from tmodbus.exceptions import FunctionCodeError, InvalidRequestError, InvalidResponseError
 
 from .base import BasePDU
 
@@ -117,6 +117,7 @@ class ReadFileRecordPDU(BasePDU[list[bytes]]):
 
         Raises:
             InvalidResponseError: If the response is invalid.
+            FunctionCodeError: If function code is incorrect.
 
         """
         # response format: function code (1 byte) + byte count (1 byte)
@@ -130,7 +131,7 @@ class ReadFileRecordPDU(BasePDU[list[bytes]]):
 
         if function_code != self.function_code:
             msg = f"Invalid function code: expected {self.function_code:#04x}, received {function_code:#04x}"
-            raise InvalidResponseError(msg, response_bytes=response)
+            raise FunctionCodeError(msg, response_bytes=response)
 
         if len(response) - 2 != byte_count:
             msg = f"Response length {len(response)} is not equal to expected {2 + byte_count}"
@@ -311,6 +312,7 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
 
         Raises:
             InvalidResponseError: If the response is invalid.
+            FunctionCodeError: If function code is incorrect.
 
         """
         try:
@@ -321,7 +323,7 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
 
         if function_code != cls.function_code:
             msg = f"Invalid function code: expected {cls.function_code:#04x}, received {function_code:#04x}"
-            raise InvalidResponseError(msg, response_bytes=response)
+            raise FunctionCodeError(msg, response_bytes=response)
 
         if len(response) - 2 != byte_count:
             msg = f"Response length {len(response)} is not equal to expected {2 + byte_count}"

--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Self
 
 from tmodbus.const import FunctionCode
-from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
+from tmodbus.exceptions import FunctionCodeError, InvalidRequestError, InvalidResponseError
 
 from .base import BasePDU
 
@@ -57,7 +57,8 @@ class RawReadHoldingRegistersPDU(BasePDU[bytes]):
             List of boolean values representing the coil states
 
         Raises:
-            ValueError: If response format is invalid
+            FunctionCodeError: If function code is incorrect
+            InvalidResponseError: If response format is invalid
 
         """
         # response format: function code + byte count + data
@@ -69,7 +70,7 @@ class RawReadHoldingRegistersPDU(BasePDU[bytes]):
 
         if function_code != self.function_code:
             msg = f"Invalid function code: expected {self.function_code:#04x}, received {function_code:#04x}"
-            raise InvalidResponseError(msg, response_bytes=response)
+            raise FunctionCodeError(msg, response_bytes=response)
 
         if len(response) != 2 + byte_count:
             msg = f"Invalid response PDU length: expected {2 + byte_count}, got {len(response)}"
@@ -623,6 +624,7 @@ class MaskWriteRegisterPDU(BasePDU[tuple[int, int]]):
 
         Raises:
             InvalidResponseError: If response format is invalid
+            FunctionCodeError: If function code is incorrect
 
         """
         try:
@@ -633,7 +635,7 @@ class MaskWriteRegisterPDU(BasePDU[tuple[int, int]]):
 
         if function_code != self.function_code:
             msg = f"Invalid function code: expected {self.function_code:#04x}, received {function_code:#04x}"
-            raise InvalidResponseError(msg, response_bytes=response)
+            raise FunctionCodeError(msg, response_bytes=response)
 
         if address != self.address:
             msg = f"Invalid address: expected {self.address}, received {address}"
@@ -771,6 +773,7 @@ class ReadWriteMultipleRegistersPDU(BasePDU[list[int]]):
 
         Raises:
             InvalidResponseError: If response format is invalid
+            FunctionCodeError: If function code is incorrect
 
         """
         # response format: function code + byte count + data
@@ -782,7 +785,7 @@ class ReadWriteMultipleRegistersPDU(BasePDU[list[int]]):
 
         if function_code != self.function_code:
             msg = f"Invalid function code: expected {self.function_code:#04x}, received {function_code:#04x}"
-            raise InvalidResponseError(msg, response_bytes=response)
+            raise FunctionCodeError(msg, response_bytes=response)
 
         if len(response) != 2 + byte_count:
             msg = f"Invalid response PDU length: expected {2 + byte_count}, got {len(response)}"

--- a/src/tmodbus/pdu/serial_line.py
+++ b/src/tmodbus/pdu/serial_line.py
@@ -4,7 +4,7 @@ import struct
 from dataclasses import dataclass
 from typing import Self
 
-from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
+from tmodbus.exceptions import FunctionCodeError, InvalidRequestError, InvalidResponseError
 
 from .base import BasePDU
 
@@ -51,6 +51,7 @@ class ReportServerIdPDU(BasePDU[ServerIdResponse]):
 
         Raises:
             InvalidResponseError: If the response is invalid.
+            FunctionCodeError: If function code is incorrect.
 
         """
         # response format: function code (1 byte) + byte count (1 byte) + server ID + status (1 byte)
@@ -66,7 +67,7 @@ class ReportServerIdPDU(BasePDU[ServerIdResponse]):
 
         if function_code != self.function_code:
             msg = f"Invalid function code: expected {self.function_code:#04x}, received {function_code:#04x}"
-            raise InvalidResponseError(msg, response_bytes=response)
+            raise FunctionCodeError(msg, response_bytes=response)
 
         if len(response) != 2 + byte_count:
             msg = f"Response length {len(response)} does not match expected {2 + byte_count}"

--- a/src/tmodbus/transport/async_ascii.py
+++ b/src/tmodbus/transport/async_ascii.py
@@ -13,7 +13,7 @@ from typing import TypeVar, Unpack
 
 from tmodbus.exceptions import (
     ASCIIFrameError,
-    InvalidResponseError,
+    FunctionCodeError,
     LRCError,
     ModbusConnectionError,
     UnknownModbusResponseError,
@@ -207,7 +207,7 @@ class ModbusAsciiProtocol(asyncio.Protocol):
         response_function_code = response.pdu_bytes[0]
         if response_function_code != pdu.function_code:
             msg = f"Function code mismatch: expected {pdu.function_code}, received {response_function_code}"
-            raise InvalidResponseError(msg, response_bytes=response.bytes)
+            raise FunctionCodeError(msg, response_bytes=response.bytes)
 
         # 8. Return decoded response
         return pdu.decode_response(response.pdu_bytes)

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 
 from tmodbus.exceptions import (
     CRCError,
-    InvalidResponseError,
+    FunctionCodeError,
     ModbusConnectionError,
     RTUFrameError,
     UnknownModbusResponseError,
@@ -393,7 +393,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
         response_function_code = response.pdu_bytes[0]
         if response_function_code != pdu.function_code:
             msg = f"Function code mismatch: expected {pdu.function_code}, received {response_function_code}"
-            raise InvalidResponseError(msg, response_bytes=response.bytes)
+            raise FunctionCodeError(msg, response_bytes=response.bytes)
 
         # 9. Return decoded response
         return pdu.decode_response(response.pdu_bytes)

--- a/src/tmodbus/transport/async_tcp.py
+++ b/src/tmodbus/transport/async_tcp.py
@@ -12,7 +12,7 @@ from functools import partial
 from typing import Any, TypeVar
 
 from tmodbus.exceptions import (
-    InvalidResponseError,
+    HeaderMismatchError,
     ModbusConnectionError,
     UnknownModbusResponseError,
     error_code_to_exception_map,
@@ -280,7 +280,7 @@ class ModbusTcpProtocol(asyncio.Protocol):
 
         if response.unit_id != unit_id:
             msg = f"Unit ID mismatch: expected {unit_id:#04x}, received {response.unit_id:#04x}"
-            raise InvalidResponseError(msg, response_bytes=response.bytes)
+            raise HeaderMismatchError(msg, response_bytes=response.bytes)
 
         # 8.Check if it's an exception response
         if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & 0x80:  # Exception response

--- a/src/tmodbus/transport/async_udp.py
+++ b/src/tmodbus/transport/async_udp.py
@@ -12,7 +12,7 @@ from functools import partial
 from typing import Any, TypeVar
 
 from tmodbus.exceptions import (
-    InvalidResponseError,
+    HeaderMismatchError,
     ModbusConnectionError,
     UnknownModbusResponseError,
     error_code_to_exception_map,
@@ -251,7 +251,7 @@ class ModbusUdpProtocol(asyncio.DatagramProtocol):
 
         if response.unit_id != unit_id:
             msg = f"Unit ID mismatch: expected {unit_id:#04x}, received {response.unit_id:#04x}"
-            raise InvalidResponseError(msg, response_bytes=response.bytes)
+            raise HeaderMismatchError(msg, response_bytes=response.bytes)
 
         if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & 0x80:  # Exception response
             function_code = response.pdu_bytes[0] & 0x7F


### PR DESCRIPTION
This issue was raised as a side-remark in https://github.com/wlcrs/tmodbus/issues/88
