### PR TITLE
Properly handle broadcast messages in client and server.

### DIFF
--- a/src/tmodbus/const.py
+++ b/src/tmodbus/const.py
@@ -2,6 +2,8 @@
 
 from enum import IntEnum
 
+BROADCAST_UNIT_ID = 0
+
 
 class FunctionCode(IntEnum):
     """Modbus Function Codes."""

--- a/src/tmodbus/pdu/base.py
+++ b/src/tmodbus/pdu/base.py
@@ -34,6 +34,11 @@ class BaseClientPDU[RT](ABC):
 
         """
 
+    def get_broadcast_response(self) -> RT:
+        """Get the response for a broadcast PDU."""
+        msg = f"Function code {self.function_code:#04x} does not support broadcasting."
+        raise InvalidRequestError(msg)
+
     @classmethod
     def get_expected_response_data_length(cls, data: bytes) -> int | None:
         """Get the expected number of bytes for the data part of the response PDU.

--- a/src/tmodbus/pdu/coils.py
+++ b/src/tmodbus/pdu/coils.py
@@ -197,6 +197,10 @@ class WriteSingleCoilPDU(BasePDU[bool]):
             raise InvalidResponseError(msg, response_bytes=response)
         return self.value
 
+    def get_broadcast_response(self) -> bool:
+        """Return dummy response for a broadcast request."""
+        return self.value
+
     @classmethod
     def decode_request(cls, request: bytes) -> Self:
         """Decode Write Single Coil Request PDU.
@@ -319,6 +323,10 @@ class WriteMultipleCoilsPDU(BasePDU[int]):
             msg = "Device response does not match request"
             raise InvalidResponseError(msg, response_bytes=response)
 
+        return len(self.values)
+
+    def get_broadcast_response(self) -> int:
+        """Return dummy response for a broadcast request."""
         return len(self.values)
 
     @classmethod

--- a/src/tmodbus/pdu/file.py
+++ b/src/tmodbus/pdu/file.py
@@ -387,6 +387,10 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
         """
         return WriteFileRecordPDU._decode(response)
 
+    def get_broadcast_response(self) -> list[FileRecord]:
+        """Return dummy response for a broadcast request."""
+        return self.file_records
+
     def encode_response(self, value: list[FileRecord]) -> bytes:
         """Encode the response PDU.
 

--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -299,6 +299,10 @@ class WriteSingleRegisterPDU(BasePDU[int]):
             raise InvalidResponseError(msg, response_bytes=response)
         return self.value
 
+    def get_broadcast_response(self) -> int:
+        """Return dummy response for a broadcast request."""
+        return self.value
+
     @classmethod
     def decode_request(cls, request: bytes) -> Self:
         """Decode Write Single Register Request PDU.
@@ -418,6 +422,10 @@ class RawWriteMultipleRegistersPDU(BasePDU[int]):
             raise InvalidResponseError(msg, response_bytes=response)
         return len(self.content) // 2  # Return number of registers written
 
+    def get_broadcast_response(self) -> int:
+        """Return dummy response for a broadcast request."""
+        return len(self.content) // 2
+
     @classmethod
     def decode_request(cls, request: bytes) -> Self:
         """Decode Write Multiple Registers Request PDU.
@@ -532,6 +540,10 @@ class WriteMultipleRegistersPDU(BasePDU[int]):
 
         """
         return self.raw_pdu.decode_response(response)
+
+    def get_broadcast_response(self) -> int:
+        """Return dummy response for a broadcast request."""
+        return len(self.values)
 
     @classmethod
     def decode_request(cls, request: bytes) -> Self:
@@ -649,6 +661,10 @@ class MaskWriteRegisterPDU(BasePDU[tuple[int, int]]):
             raise InvalidResponseError(msg, response_bytes=response)
 
         return and_mask, or_mask
+
+    def get_broadcast_response(self) -> tuple[int, int]:
+        """Return dummy response for a broadcast request."""
+        return (self.and_mask, self.or_mask)
 
     @classmethod
     def decode_request(cls, request: bytes) -> Self:

--- a/src/tmodbus/server/async_ascii.py
+++ b/src/tmodbus/server/async_ascii.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 
 from serialx import open_serial_connection
 
+from tmodbus.const import BROADCAST_UNIT_ID
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.lrc import calculate_lrc, validate_lrc
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
@@ -201,7 +202,7 @@ class AsyncAsciiServer(AsyncBaseServer):
         else:
             response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)
 
-        if unit_id != 0:
+        if unit_id != BROADCAST_UNIT_ID:
             out_bin = bytearray([unit_id]) + response_pdu_bytes
             lrc = calculate_lrc(bytes(out_bin))
             out_bin.append(lrc)
@@ -215,6 +216,8 @@ class AsyncAsciiServer(AsyncBaseServer):
             else:
                 logger.warning("No writer available to send ASCII response; dropping frame")
                 log_raw_traffic("sent", out_frame, is_error=True)
+        else:
+            logger.debug("Response ignored for broadcast request (unit ID %d)", unit_id)
 
         return "error" if is_error else "success"
 

--- a/src/tmodbus/server/async_ascii.py
+++ b/src/tmodbus/server/async_ascii.py
@@ -11,6 +11,7 @@ from serialx import open_serial_connection
 from tmodbus.const import BROADCAST_UNIT_ID
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.lrc import calculate_lrc, validate_lrc
+from tmodbus.utils.raw_traffic_logger import format_bytes
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
 
 from .base import AsyncBaseServer, get_server_pdu_class
@@ -217,8 +218,10 @@ class AsyncAsciiServer(AsyncBaseServer):
                 logger.warning("No writer available to send ASCII response; dropping frame")
                 log_raw_traffic("sent", out_frame, is_error=True)
         else:
-            logger.debug("Response ignored for broadcast request (unit ID %d)", unit_id)
-
+            logger.debug(
+                "Response ignored for broadcast request. Not sending response bytes: %s",
+                format_bytes(response_pdu_bytes),
+            )
         return "error" if is_error else "success"
 
     async def _serve(self) -> None:

--- a/src/tmodbus/server/async_rtu.py
+++ b/src/tmodbus/server/async_rtu.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 
 from serialx import open_serial_connection
 
+from tmodbus.const import BROADCAST_UNIT_ID
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.crc import calculate_crc16, validate_crc16
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
@@ -170,7 +171,7 @@ class AsyncRtuServer(AsyncBaseServer):
         else:
             response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)
 
-        if unit_id != 0:
+        if unit_id != BROADCAST_UNIT_ID:
             out_frame = bytearray([unit_id]) + response_pdu_bytes
             crc = calculate_crc16(bytes(out_frame))
             out_frame.extend(crc)
@@ -185,6 +186,8 @@ class AsyncRtuServer(AsyncBaseServer):
             else:
                 logger.warning("No writer available to send RTU response; dropping frame")
                 log_raw_traffic("sent", bytes(out_frame), is_error=True)
+        else:
+            logger.debug("Response ignored for broadcast request (unit ID %d)", unit_id)
 
         return "error" if is_error else "success"
 

--- a/src/tmodbus/server/async_rtu.py
+++ b/src/tmodbus/server/async_rtu.py
@@ -11,6 +11,7 @@ from serialx import open_serial_connection
 from tmodbus.const import BROADCAST_UNIT_ID
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.crc import calculate_crc16, validate_crc16
+from tmodbus.utils.raw_traffic_logger import format_bytes
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
 
 from .base import AsyncBaseServer, get_server_pdu_class_from_buffer
@@ -187,7 +188,10 @@ class AsyncRtuServer(AsyncBaseServer):
                 logger.warning("No writer available to send RTU response; dropping frame")
                 log_raw_traffic("sent", bytes(out_frame), is_error=True)
         else:
-            logger.debug("Response ignored for broadcast request (unit ID %d)", unit_id)
+            logger.debug(
+                "Response ignored for broadcast request. Not sending response bytes: %s",
+                format_bytes(response_pdu_bytes),
+            )
 
         return "error" if is_error else "success"
 

--- a/src/tmodbus/server/async_rtu_over_tcp.py
+++ b/src/tmodbus/server/async_rtu_over_tcp.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 from tmodbus.const import BROADCAST_UNIT_ID, ExceptionCode
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.crc import calculate_crc16, validate_crc16
+from tmodbus.utils.raw_traffic_logger import format_bytes
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
 
 from .base import AsyncBaseServer, get_server_pdu_class_from_buffer
@@ -164,7 +165,10 @@ class AsyncRtuOverTcpServer(AsyncBaseServer):
             log_raw_traffic("sent", bytes(out_frame))
             await writer.drain()
         else:
-            logger.debug("Response ignored for broadcast request (unit ID %d)", unit_id)
+            logger.debug(
+                "Response ignored for broadcast request. Not sending response bytes: %s",
+                format_bytes(response_pdu_bytes),
+            )
         return not is_error
 
     async def _process_next_frame(

--- a/src/tmodbus/server/async_rtu_over_tcp.py
+++ b/src/tmodbus/server/async_rtu_over_tcp.py
@@ -6,7 +6,7 @@ import logging
 from functools import partial
 from typing import Any, Literal
 
-from tmodbus.const import ExceptionCode
+from tmodbus.const import BROADCAST_UNIT_ID, ExceptionCode
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.crc import calculate_crc16, validate_crc16
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
@@ -155,13 +155,16 @@ class AsyncRtuOverTcpServer(AsyncBaseServer):
             else:
                 response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)
 
-        out_frame = bytearray([unit_id]) + response_pdu_bytes
-        crc = calculate_crc16(bytes(out_frame))
-        out_frame.extend(crc)
+        if unit_id != BROADCAST_UNIT_ID:
+            out_frame = bytearray([unit_id]) + response_pdu_bytes
+            crc = calculate_crc16(bytes(out_frame))
+            out_frame.extend(crc)
 
-        writer.write(out_frame)
-        log_raw_traffic("sent", bytes(out_frame))
-        await writer.drain()
+            writer.write(out_frame)
+            log_raw_traffic("sent", bytes(out_frame))
+            await writer.drain()
+        else:
+            logger.debug("Response ignored for broadcast request (unit ID %d)", unit_id)
         return not is_error
 
     async def _process_next_frame(

--- a/src/tmodbus/transport/async_ascii.py
+++ b/src/tmodbus/transport/async_ascii.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import TypeVar, Unpack
 
+from tmodbus.const import BROADCAST_UNIT_ID
 from tmodbus.exceptions import (
     ASCIIFrameError,
     FunctionCodeError,
@@ -154,6 +155,10 @@ class ModbusAsciiProtocol(asyncio.Protocol):
         6. Validate LRC and address
         7. Return response PDU
         """
+        broadcast_response: RT | None = None
+        if unit_id == BROADCAST_UNIT_ID:
+            broadcast_response = pdu.get_broadcast_response()
+
         if self.transport is None or self.transport.is_closing():
             msg = "Not connected."
             raise ModbusConnectionError(msg)
@@ -172,6 +177,14 @@ class ModbusAsciiProtocol(asyncio.Protocol):
             await asyncio.sleep(to_wait)
 
         # 4. Async send request
+        if broadcast_response is not None:
+            # We're broadcasting, so we don't need to wait for a response
+            # Just send it and return immediately
+            self.transport.write(request_adu)
+            log_raw_traffic("sent", request_adu)
+            self._last_frame_ended_at = time.monotonic()
+            return broadcast_response
+
         read_future: asyncio.Future[_ModbusAsciiMessage] = asyncio.get_event_loop().create_future()
         self._pending_requests[unit_id] = read_future
 

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -53,6 +53,7 @@ from typing import TYPE_CHECKING, NotRequired, TypedDict, TypeVar, Unpack
 if TYPE_CHECKING:
     from serialx import Parity, StopBits
 
+from tmodbus.const import BROADCAST_UNIT_ID
 from tmodbus.exceptions import (
     CRCError,
     FunctionCodeError,
@@ -342,6 +343,10 @@ class ModbusRtuProtocol(asyncio.Protocol):
         6. Validate CRC and address
         7. Return response PDU
         """
+        broadcast_response: RT | None = None
+        if unit_id == BROADCAST_UNIT_ID:
+            broadcast_response = pdu.get_broadcast_response()
+
         if self.transport is None or self.transport.is_closing():
             msg = "Not connected."
             raise ModbusConnectionError(msg)
@@ -362,6 +367,14 @@ class ModbusRtuProtocol(asyncio.Protocol):
             await asyncio.sleep(to_wait)
 
         # 4. Async send request
+        if broadcast_response is not None:
+            # We're broadcasting an action, so just send it and return immediately
+            self.transport.write(request_adu)
+            log_raw_traffic("sent", request_adu)
+            # Mark the end of this frame
+            self._last_frame_ended_at = time.monotonic()
+            return broadcast_response
+
         read_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
         self._pending_requests[unit_id] = read_future
 

--- a/src/tmodbus/utils/raw_traffic_logger.py
+++ b/src/tmodbus/utils/raw_traffic_logger.py
@@ -30,11 +30,11 @@ def log_raw_traffic(
         "%6s %s: %s %s",
         transport_name,
         direction,
-        _format_bytes(data),
+        format_bytes(data),
         status,
     )
 
 
-def _format_bytes(data: bytes) -> str:
+def format_bytes(data: bytes) -> str:
     """Format bytes for logging."""
     return data.hex(" ").upper()

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -1,0 +1,318 @@
+"""Comprehensive tests for Modbus broadcast request support."""
+
+import asyncio
+from typing import Any
+
+import pytest
+from tmodbus.client import AsyncModbusClient
+from tmodbus.const import BROADCAST_UNIT_ID
+from tmodbus.exceptions import InvalidRequestError
+from tmodbus.pdu import (
+    BaseClientPDU,
+    FileRecord,
+    FileRecordRequest,
+    MaskWriteRegisterPDU,
+    ReadCoilsPDU,
+    ReadDeviceIdentificationPDU,
+    ReadDiscreteInputsPDU,
+    ReadExceptionStatusPDU,
+    ReadFifoQueuePDU,
+    ReadFileRecordPDU,
+    ReadHoldingRegistersPDU,
+    ReadInputRegistersPDU,
+    ReadWriteMultipleRegistersPDU,
+    ReportServerIdPDU,
+    WriteFileRecordPDU,
+    WriteMultipleCoilsPDU,
+    WriteMultipleRegistersPDU,
+    WriteSingleCoilPDU,
+    WriteSingleRegisterPDU,
+)
+from tmodbus.pdu.holding_registers import RawReadHoldingRegistersPDU, RawWriteMultipleRegistersPDU
+from tmodbus.server.async_ascii import AsyncAsciiServer
+from tmodbus.server.async_rtu import AsyncRtuServer
+from tmodbus.server.async_rtu_over_tcp import AsyncRtuOverTcpServer
+from tmodbus.server.handler import ModbusRequestRouter, handle_modbus_request
+from tmodbus.transport.async_ascii import ModbusAsciiProtocol
+from tmodbus.transport.async_rtu import ModbusRtuProtocol
+from tmodbus.utils.crc import calculate_crc16
+from tmodbus.utils.lrc import calculate_lrc
+
+
+class MockWriteTransport(asyncio.WriteTransport):
+    """Mock write transport for protocol testing."""
+
+    def __init__(self) -> None:
+        """Initialize mock write transport."""
+        super().__init__()
+        self.written: list[bytes] = []
+        self._closing = False
+
+    def write(self, data: bytes | bytearray | memoryview) -> None:
+        """Write data to the transport."""
+        self.written.append(bytes(data))
+
+    def is_closing(self) -> bool:
+        """Check if the transport is closing."""
+        return self._closing
+
+    def close(self) -> None:
+        """Close the transport."""
+        self._closing = True
+
+
+class MockStreamWriter:
+    """Mock asyncio.StreamWriter for server testing."""
+
+    def __init__(self) -> None:
+        """Initialize mock stream writer."""
+        self.written: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        """Write data to the stream writer."""
+        self.written.append(bytes(data))
+
+    async def drain(self) -> None:
+        """Drain the stream writer."""
+
+
+# ============================================================================
+# PDU Broadcast Tests
+# ============================================================================
+
+
+def test_pdu_write_single_coil_broadcast() -> None:
+    """Test get_broadcast_response for WriteSingleCoilPDU with True and False values."""
+    pdu_true = WriteSingleCoilPDU(0, True)  # noqa: FBT003
+    assert pdu_true.get_broadcast_response() is True
+
+    pdu_false = WriteSingleCoilPDU(0, False)  # noqa: FBT003
+    assert pdu_false.get_broadcast_response() is False
+
+
+def test_pdu_write_multiple_coils_broadcast() -> None:
+    """Test get_broadcast_response for WriteMultipleCoilsPDU."""
+    pdu = WriteMultipleCoilsPDU(0, [True, False, True])
+    assert pdu.get_broadcast_response() == 3
+
+
+def test_pdu_write_single_register_broadcast() -> None:
+    """Test get_broadcast_response for WriteSingleRegisterPDU."""
+    pdu = WriteSingleRegisterPDU(0, 12345)
+    assert pdu.get_broadcast_response() == 12345
+
+    pdu_zero = WriteSingleRegisterPDU(0, 0)
+    assert pdu_zero.get_broadcast_response() == 0
+
+
+def test_pdu_write_multiple_registers_broadcast() -> None:
+    """Test get_broadcast_response for WriteMultipleRegistersPDU."""
+    pdu = WriteMultipleRegistersPDU(0, [1, 2, 3, 4])
+    assert pdu.get_broadcast_response() == 4
+
+
+def test_pdu_raw_write_multiple_registers_broadcast() -> None:
+    """Test get_broadcast_response for RawWriteMultipleRegistersPDU."""
+    pdu = RawWriteMultipleRegistersPDU(0, b"\x00\x01\x00\x02")
+    assert pdu.get_broadcast_response() == 2
+
+
+def test_pdu_mask_write_register_broadcast() -> None:
+    """Test get_broadcast_response for MaskWriteRegisterPDU."""
+    pdu = MaskWriteRegisterPDU(0, 0x00FF, 0xFF00)
+    assert pdu.get_broadcast_response() == (0x00FF, 0xFF00)
+
+
+def test_pdu_write_file_record_broadcast() -> None:
+    """Test get_broadcast_response for WriteFileRecordPDU."""
+    records = [FileRecord(1, 2, b"\x00\x01\x00\x02")]
+    pdu = WriteFileRecordPDU(records)
+    assert pdu.get_broadcast_response() == records
+
+
+def test_non_broadcastable_pdus_raise_error() -> None:
+    """Test that all non-broadcastable PDUs raise InvalidRequestError."""
+    read_pdus: list[BaseClientPDU[Any]] = [
+        ReadCoilsPDU(0, 1),
+        ReadDiscreteInputsPDU(0, 1),
+        ReadHoldingRegistersPDU(0, 1),
+        RawReadHoldingRegistersPDU(0, 1),
+        ReadInputRegistersPDU(0, 1),
+        ReadFileRecordPDU([FileRecordRequest(1, 0, 1)]),
+        ReadFifoQueuePDU(0),
+        ReadDeviceIdentificationPDU(1, 0),
+        ReportServerIdPDU(),
+        ReadExceptionStatusPDU(),
+        ReadWriteMultipleRegistersPDU(0, 1, 0, [100]),
+    ]
+    for pdu in read_pdus:
+        with pytest.raises(InvalidRequestError, match="does not support broadcasting"):
+            pdu.get_broadcast_response()
+
+
+# ============================================================================
+# Client Transport Broadcast Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_rtu_client_broadcast() -> None:
+    """Test ModbusRtuProtocol broadcast request execution."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    mock_transport = MockWriteTransport()
+    protocol.connection_made(mock_transport)
+
+    # Test writing False (falsy value check)
+    pdu_false = WriteSingleCoilPDU(10, False)  # noqa: FBT003
+    res_false = await protocol.send_and_receive(BROADCAST_UNIT_ID, pdu_false)
+    assert res_false is False
+    assert len(mock_transport.written) == 1
+
+    # Test writing True
+    pdu_true = WriteSingleCoilPDU(10, True)  # noqa: FBT003
+    res_true = await protocol.send_and_receive(BROADCAST_UNIT_ID, pdu_true)
+    assert res_true is True
+    assert len(mock_transport.written) == 2
+
+
+@pytest.mark.asyncio
+async def test_ascii_client_broadcast() -> None:
+    """Test ModbusAsciiProtocol broadcast request execution."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None)
+    mock_transport = MockWriteTransport()
+    protocol.connection_made(mock_transport)
+
+    pdu = WriteSingleRegisterPDU(100, 42)
+    res = await protocol.send_and_receive(BROADCAST_UNIT_ID, pdu)
+    assert res == 42
+    assert len(mock_transport.written) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_client_broadcast_execution() -> None:
+    """Test AsyncModbusClient executing broadcast requests over serial RTU transport."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    mock_transport = MockWriteTransport()
+    protocol.connection_made(mock_transport)
+
+    class FakeAsyncTransport:
+        def is_open(self) -> bool:
+            return True
+
+        async def send_and_receive(self, unit_id: int, pdu: Any) -> Any:
+            return await protocol.send_and_receive(unit_id, pdu)
+
+    client = AsyncModbusClient(FakeAsyncTransport(), unit_id=BROADCAST_UNIT_ID)  # type: ignore[arg-type]
+    res = await client.write_single_coil(0, False)  # noqa: FBT003
+    assert res is False
+
+
+# ============================================================================
+# Server Broadcast Execution & Response Suppression Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_server_broadcast_handler_invocation() -> None:
+    """Test that handle_modbus_request processes broadcast requests for unit ID 0."""
+    executed = []
+
+    router = ModbusRequestRouter()
+
+    @router.register(WriteSingleRegisterPDU)
+    async def handle_write_register(unit_id: int, request: WriteSingleRegisterPDU) -> int:
+        executed.append((unit_id, request.address, request.value))
+        return request.value
+
+    pdu = WriteSingleRegisterPDU(10, 555)
+    res_bytes = await handle_modbus_request(BROADCAST_UNIT_ID, pdu, router)
+    assert len(executed) == 1
+    assert executed[0] == (0, 10, 555)
+    assert res_bytes == pdu.encode_response(555)
+
+
+@pytest.mark.asyncio
+async def test_rtu_server_broadcast_response_suppressed() -> None:
+    """Test AsyncRtuServer suppresses sending response frame when unit_id is 0."""
+    executed = []
+
+    router = ModbusRequestRouter()
+
+    @router.register(WriteSingleRegisterPDU)
+    async def handle_write(unit_id: int, request: WriteSingleRegisterPDU) -> int:
+        executed.append((unit_id, request.value))
+        return request.value
+
+    server = AsyncRtuServer(port="dummy", handler=router)
+    server._inter_frame_silence = 0.0
+
+    # Build RTU frame for unit 0, WriteSingleRegister (FC 0x06, addr 0x0001, val 0x0002)
+    pdu_bytes = bytes([0x06, 0x00, 0x01, 0x00, 0x02])
+    frame = bytearray([0x00]) + pdu_bytes
+    crc = calculate_crc16(bytes(frame))
+    frame.extend(crc)
+
+    mock_writer = MockWriteTransport()
+    server._writer = mock_writer  # type: ignore[assignment]
+
+    status = await server._handle_frame(bytes(frame))
+    assert status == "success"
+    assert len(executed) == 1
+    assert executed[0] == (0, 2)
+    # Output frame suppressed for unit_id 0
+    assert len(mock_writer.written) == 0
+
+
+@pytest.mark.asyncio
+async def test_ascii_server_broadcast_response_suppressed() -> None:
+    """Test AsyncAsciiServer suppresses sending response frame when unit_id is 0."""
+    executed = []
+
+    router = ModbusRequestRouter()
+
+    @router.register(WriteSingleCoilPDU)
+    async def handle_write(unit_id: int, request: WriteSingleCoilPDU) -> bool:
+        executed.append((unit_id, request.value))
+        return request.value
+
+    server = AsyncAsciiServer(port="dummy", handler=router)
+
+    # Build ASCII frame for unit 0, WriteSingleCoil (FC 0x05, addr 0, val FF00)
+    bin_data = bytes([0x00, 0x05, 0x00, 0x00, 0xFF, 0x00])
+    lrc = calculate_lrc(bin_data)
+    ascii_hex = (bin_data + bytes([lrc])).hex().upper().encode("ascii")
+    ascii_frame = b":" + ascii_hex + b"\r\n"
+
+    mock_writer = MockWriteTransport()
+    server._writer = mock_writer  # type: ignore[assignment]
+
+    status = await server._process_next_frame(ascii_frame)
+    assert status == "success"
+    assert len(executed) == 1
+    assert len(mock_writer.written) == 0
+
+
+@pytest.mark.asyncio
+async def test_rtu_over_tcp_server_broadcast_response_suppressed() -> None:
+    """Test AsyncRtuOverTcpServer suppresses sending response frame when unit_id is 0."""
+    executed = []
+
+    router = ModbusRequestRouter()
+
+    @router.register(WriteSingleRegisterPDU)
+    async def handle_write(unit_id: int, request: WriteSingleRegisterPDU) -> int:
+        executed.append((unit_id, request.value))
+        return request.value
+
+    server = AsyncRtuOverTcpServer(host="localhost", port=502, handler=router)
+
+    pdu_bytes = bytes([0x06, 0x00, 0x01, 0x00, 0x02])
+    frame = bytearray([0x00]) + pdu_bytes
+    crc = calculate_crc16(bytes(frame))
+    frame.extend(crc)
+
+    mock_writer = MockStreamWriter()
+    status = await server._handle_frame(bytes(frame), ("127.0.0.1", 12345), mock_writer)  # type: ignore[arg-type]
+    assert status is True
+    assert len(executed) == 1
+    assert len(mock_writer.written) == 0

--- a/tests/utils/test_raw_traffic_logger.py
+++ b/tests/utils/test_raw_traffic_logger.py
@@ -3,7 +3,7 @@
 from typing import Any
 from unittest.mock import patch
 
-from tmodbus.utils.raw_traffic_logger import _format_bytes, log_raw_traffic
+from tmodbus.utils.raw_traffic_logger import format_bytes, log_raw_traffic
 
 
 class _DummyLogger:
@@ -20,9 +20,9 @@ class _DummyLogger:
 
 def test_format_bytes() -> None:
     """Test formatting of bytes to hex string."""
-    assert _format_bytes(b"\x01\x02\xab") == "01 02 AB"
-    assert _format_bytes(b"") == ""
-    assert _format_bytes(b"\x00\xff") == "00 FF"
+    assert format_bytes(b"\x01\x02\xab") == "01 02 AB"
+    assert format_bytes(b"") == ""
+    assert format_bytes(b"\x00\xff") == "00 FF"
 
 
 def test_log_raw_traffic_sent() -> None:


### PR DESCRIPTION
tmodbus was lacking support for handling broadcast messages. This is a feature specific to Modbus-RTU, in which messages sent to unit-id 0 are treated as a broadcast to all units on the bus. Only write-operations are supported, and the slaves do not send a response to acknowledge receiving the broadcast.

On the RTU/ASCII/RTU-over-TCP clients: we don't wait for a response, but return immediately with a value that indicates a successful action.

On servers: the value returned by the handler is ignored and we log a message on debug-level instead.