### PR TITLE
Harden RTU and ASCII transports

### DIFF
--- a/src/tmodbus/const.py
+++ b/src/tmodbus/const.py
@@ -4,6 +4,9 @@ from enum import IntEnum
 
 BROADCAST_UNIT_ID = 0
 
+EXCEPTION_RESPONSE_BIT = 0x80
+FUNCTION_CODE_MASK = 0xFF ^ EXCEPTION_RESPONSE_BIT  # 0x7F: strips exception bit to extract base function code
+
 
 class FunctionCode(IntEnum):
     """Modbus Function Codes."""

--- a/src/tmodbus/server/async_ascii.py
+++ b/src/tmodbus/server/async_ascii.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 
 from serialx import open_serial_connection
 
-from tmodbus.const import BROADCAST_UNIT_ID
+from tmodbus.const import BROADCAST_UNIT_ID, EXCEPTION_RESPONSE_BIT
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.lrc import calculate_lrc, validate_lrc
 from tmodbus.utils.raw_traffic_logger import format_bytes
@@ -198,7 +198,7 @@ class AsyncAsciiServer(AsyncBaseServer):
             request_pdu = pdu_class.decode_request(pdu_bytes)
         except (ValueError, InvalidRequestError) as e:
             logger.warning("Invalid request: %s", e)
-            response_pdu_bytes = bytes([function_code | 0x80, 0x01])
+            response_pdu_bytes = bytes([function_code | EXCEPTION_RESPONSE_BIT, 0x01])
             is_error = True
         else:
             response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)

--- a/src/tmodbus/server/async_rtu.py
+++ b/src/tmodbus/server/async_rtu.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 
 from serialx import open_serial_connection
 
-from tmodbus.const import BROADCAST_UNIT_ID
+from tmodbus.const import BROADCAST_UNIT_ID, EXCEPTION_RESPONSE_BIT
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.crc import calculate_crc16, validate_crc16
 from tmodbus.utils.raw_traffic_logger import format_bytes
@@ -167,7 +167,7 @@ class AsyncRtuServer(AsyncBaseServer):
             request_pdu = pdu_class.decode_request(pdu_bytes)
         except (ValueError, InvalidRequestError) as e:
             logger.warning("Invalid request: %s", e)
-            response_pdu_bytes = bytes([function_code | 0x80, 0x01])
+            response_pdu_bytes = bytes([function_code | EXCEPTION_RESPONSE_BIT, 0x01])
             is_error = True
         else:
             response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)

--- a/src/tmodbus/server/async_rtu_over_tcp.py
+++ b/src/tmodbus/server/async_rtu_over_tcp.py
@@ -6,7 +6,7 @@ import logging
 from functools import partial
 from typing import Any, Literal
 
-from tmodbus.const import BROADCAST_UNIT_ID, ExceptionCode
+from tmodbus.const import BROADCAST_UNIT_ID, EXCEPTION_RESPONSE_BIT, ExceptionCode
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.crc import calculate_crc16, validate_crc16
 from tmodbus.utils.raw_traffic_logger import format_bytes
@@ -142,7 +142,9 @@ class AsyncRtuOverTcpServer(AsyncBaseServer):
 
         if not handler_supports_unit_id(self.handler, unit_id):
             logger.warning("Request for unregistered unit ID %d from %s", unit_id, addr)
-            response_pdu_bytes = bytes([function_code | 0x80, self.unregistered_unit_id_exception_code])
+            response_pdu_bytes = bytes(
+                [function_code | EXCEPTION_RESPONSE_BIT, self.unregistered_unit_id_exception_code]
+            )
             is_error = True
         else:
             try:
@@ -151,7 +153,7 @@ class AsyncRtuOverTcpServer(AsyncBaseServer):
                 request_pdu = pdu_class.decode_request(pdu_bytes)
             except (ValueError, InvalidRequestError) as e:
                 logger.warning("Invalid request from %s: %s", addr, e)
-                response_pdu_bytes = bytes([function_code | 0x80, 0x01])
+                response_pdu_bytes = bytes([function_code | EXCEPTION_RESPONSE_BIT, 0x01])
                 is_error = True
             else:
                 response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)

--- a/src/tmodbus/server/async_tcp.py
+++ b/src/tmodbus/server/async_tcp.py
@@ -8,7 +8,7 @@ import struct
 from functools import partial
 from typing import Any
 
-from tmodbus.const import ExceptionCode
+from tmodbus.const import EXCEPTION_RESPONSE_BIT, ExceptionCode
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
 
@@ -210,7 +210,9 @@ class AsyncTcpServer(AsyncBaseServer):
 
         if not handler_supports_unit_id(self.handler, unit_id):
             logger.warning("Request for unregistered unit ID %d from %s", unit_id, addr)
-            response_pdu_bytes = bytes([function_code | 0x80, self.unregistered_unit_id_exception_code])
+            response_pdu_bytes = bytes(
+                [function_code | EXCEPTION_RESPONSE_BIT, self.unregistered_unit_id_exception_code]
+            )
             is_error = True
         else:
             try:
@@ -220,7 +222,7 @@ class AsyncTcpServer(AsyncBaseServer):
                 logger.warning("Invalid request from %s: %s", addr, e)
                 # Cannot respond if we don't even know the function code properly, or if unsupported
                 # We might reply with IllegalFunction if we at least have function_code
-                response_pdu_bytes = bytes([function_code | 0x80, 0x01])  # ILLEGAL_FUNCTION
+                response_pdu_bytes = bytes([function_code | EXCEPTION_RESPONSE_BIT, 0x01])  # ILLEGAL_FUNCTION
                 is_error = True
             else:
                 response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler, context=context)

--- a/src/tmodbus/server/async_udp.py
+++ b/src/tmodbus/server/async_udp.py
@@ -6,7 +6,7 @@ import struct
 from functools import partial
 from typing import Any
 
-from tmodbus.const import ExceptionCode
+from tmodbus.const import EXCEPTION_RESPONSE_BIT, ExceptionCode
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
 
@@ -152,7 +152,9 @@ class ModbusUdpServerProtocol(asyncio.DatagramProtocol):
 
             if not handler_supports_unit_id(self.handler, unit_id):
                 logger.warning("Request for unregistered unit ID %d from %s", unit_id, addr)
-                response_pdu_bytes = bytes([function_code | 0x80, self.unregistered_unit_id_exception_code])
+                response_pdu_bytes = bytes(
+                    [function_code | EXCEPTION_RESPONSE_BIT, self.unregistered_unit_id_exception_code]
+                )
                 is_error = True
             else:
                 try:
@@ -160,7 +162,7 @@ class ModbusUdpServerProtocol(asyncio.DatagramProtocol):
                     request_pdu = raw_pdu_class.decode_request(pdu_bytes)
                 except (ValueError, InvalidRequestError) as e:
                     logger.warning("Invalid request from %s: %s", addr, e)
-                    response_pdu_bytes = bytes([function_code | 0x80, 0x01])  # ILLEGAL_FUNCTION
+                    response_pdu_bytes = bytes([function_code | EXCEPTION_RESPONSE_BIT, 0x01])  # ILLEGAL_FUNCTION
                     is_error = True
                 else:
                     context = RequestContext(peer_addr=addr)

--- a/src/tmodbus/server/handler.py
+++ b/src/tmodbus/server/handler.py
@@ -9,7 +9,7 @@ import logging
 from collections.abc import Awaitable, Callable, Iterable
 from typing import TYPE_CHECKING, Any, Protocol, TypeGuard, cast
 
-from tmodbus.const import ExceptionCode
+from tmodbus.const import EXCEPTION_RESPONSE_BIT, ExceptionCode
 from tmodbus.exceptions import IllegalFunctionError, ModbusResponseError
 from tmodbus.pdu import BaseClientPDU, BasePDU
 
@@ -308,11 +308,11 @@ async def handle_modbus_request[T](
             unit_id,
             request.function_code,
         )
-        return bytes([request.function_code | 0x80, e.error_code])
+        return bytes([request.function_code | EXCEPTION_RESPONSE_BIT, e.error_code])
     except Exception:
         logger.exception("Unexpected error in Modbus handler for unit_id %d", unit_id)
         # For completely unexpected errors, we default to returning ServerDeviceFailure
-        return bytes([request.function_code | 0x80, ExceptionCode.SERVER_DEVICE_FAILURE])
+        return bytes([request.function_code | EXCEPTION_RESPONSE_BIT, ExceptionCode.SERVER_DEVICE_FAILURE])
 
 
 def handler_supports_unit_id(handler: AnyModbusHandler, unit_id: int) -> bool:

--- a/src/tmodbus/transport/async_ascii.py
+++ b/src/tmodbus/transport/async_ascii.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import TypeVar, Unpack
 
-from tmodbus.const import BROADCAST_UNIT_ID
+from tmodbus.const import BROADCAST_UNIT_ID, EXCEPTION_RESPONSE_BIT, FUNCTION_CODE_MASK
 from tmodbus.exceptions import (
     ASCIIFrameError,
     FunctionCodeError,
@@ -208,8 +208,8 @@ class ModbusAsciiProtocol(asyncio.Protocol):
             self._pending_requests.pop(unit_id, None)
 
         # 6. Check if it's an exception response
-        if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & 0x80:  # Exception response
-            function_code = response.pdu_bytes[0] & 0x7F  # Remove exception flag bit
+        if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & EXCEPTION_RESPONSE_BIT:  # Exception response
+            function_code = response.pdu_bytes[0] & FUNCTION_CODE_MASK  # Remove exception flag bit
             exception_code = response.pdu_bytes[1] if len(response.pdu_bytes) > 1 else 0
 
             if exception_code in error_code_to_exception_map:

--- a/src/tmodbus/transport/async_ascii.py
+++ b/src/tmodbus/transport/async_ascii.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import TypeVar, Unpack
+from typing import Any, TypeVar, Unpack
 
 from tmodbus.const import BROADCAST_UNIT_ID, EXCEPTION_RESPONSE_BIT, FUNCTION_CODE_MASK
 from tmodbus.exceptions import (
@@ -100,6 +100,15 @@ class _ModbusAsciiMessage:
         return bytes([self.unit_id]) + self.pdu_bytes + self.lrc
 
 
+@dataclass(frozen=True)
+class _PendingRequest:
+    """Dataclass representing an in-flight request."""
+
+    unit_id: int
+    future: asyncio.Future[_ModbusAsciiMessage]
+    pdu: BaseClientPDU[Any]
+
+
 class ModbusAsciiProtocol(asyncio.Protocol):
     """Asyncio Protocol implementation for Modbus ASCII with frame detection."""
 
@@ -109,9 +118,11 @@ class ModbusAsciiProtocol(asyncio.Protocol):
     timeout: float
     interframe_gap: float
 
+    _lock: asyncio.Lock
     _buffer: bytearray
     _last_frame_ended_at: float
-    _pending_requests: dict[int, asyncio.Future[_ModbusAsciiMessage]]
+    _pending_request: _PendingRequest | None
+    _timed_out_requests: dict[int, BaseClientPDU[Any]]
 
     def __init__(
         self,
@@ -127,9 +138,11 @@ class ModbusAsciiProtocol(asyncio.Protocol):
         self.timeout = timeout
         self.interframe_gap = interframe_gap
 
+        self._lock = asyncio.Lock()
         self._buffer = bytearray()
         self._last_frame_ended_at = 0.0
-        self._pending_requests = {}
+        self._pending_request = None
+        self._timed_out_requests = {}
 
         self.connection_made_event = asyncio.Event()
 
@@ -147,100 +160,81 @@ class ModbusAsciiProtocol(asyncio.Protocol):
         r"""Async send PDU and receive response (ASCII mode).
 
         Implements complete ASCII protocol communication flow:
-        1. Wait for any pending request for this unit_id to complete
-        2. Build ASCII frame (':' + hex + LRC + '\r\n')
-        3. Wait for inter-frame gap
-        4. Async send request
-        5. Async receive response
-        6. Validate LRC and address
-        7. Return response PDU
+        1. Build ASCII frame (':' + hex + LRC + '\r\n')
+        2. Wait for inter-frame gap
+        3. Async send request
+        4. Async receive response
+        5. Validate LRC and address
+        6. Return response PDU
         """
-        broadcast_response: RT | None = None
-        if unit_id == BROADCAST_UNIT_ID:
-            broadcast_response = pdu.get_broadcast_response()
+        async with self._lock:
+            broadcast_response: RT | None = None
+            if unit_id == BROADCAST_UNIT_ID:
+                broadcast_response = pdu.get_broadcast_response()
 
-        if self.transport is None or self.transport.is_closing():
-            msg = "Not connected."
-            raise ModbusConnectionError(msg)
+            if self.transport is None or self.transport.is_closing():
+                msg = "Not connected."
+                raise ModbusConnectionError(msg)
 
-        # 1. Wait for any existing request for this unit_id to complete
-        await self._wait_on_pending_request(unit_id)
+            # Build request frame
+            request_pdu_bytes = pdu.encode_request()
+            request_adu = build_ascii_frame(unit_id, request_pdu_bytes)
 
-        # 2. Build request frame
-        request_pdu_bytes = pdu.encode_request()
-        request_adu = build_ascii_frame(unit_id, request_pdu_bytes)
+            # Wait for inter-frame gap
+            time_since_last_frame = time.monotonic() - self._last_frame_ended_at
+            if time_since_last_frame < self.interframe_gap:
+                to_wait = self.interframe_gap - time_since_last_frame
+                await asyncio.sleep(to_wait)
 
-        # 3. Wait for inter-frame gap
-        time_since_last_frame = time.monotonic() - self._last_frame_ended_at
-        if time_since_last_frame < self.interframe_gap:
-            to_wait = self.interframe_gap - time_since_last_frame
-            await asyncio.sleep(to_wait)
+            # Async send request
+            if broadcast_response is not None:
+                # We're broadcasting, so we don't need to wait for a response
+                # Just send it and return immediately
+                self.transport.write(request_adu)
+                log_raw_traffic("sent", request_adu)
+                self._last_frame_ended_at = time.monotonic()
+                return broadcast_response
 
-        # 4. Async send request
-        if broadcast_response is not None:
-            # We're broadcasting, so we don't need to wait for a response
-            # Just send it and return immediately
+            read_future: asyncio.Future[_ModbusAsciiMessage] = asyncio.get_event_loop().create_future()
+            self._pending_request = _PendingRequest(unit_id=unit_id, future=read_future, pdu=pdu)
+
             self.transport.write(request_adu)
             log_raw_traffic("sent", request_adu)
+            # Mark the end of this frame
             self._last_frame_ended_at = time.monotonic()
-            return broadcast_response
 
-        read_future: asyncio.Future[_ModbusAsciiMessage] = asyncio.get_event_loop().create_future()
-        self._pending_requests[unit_id] = read_future
-
-        self.transport.write(request_adu)
-        log_raw_traffic("sent", request_adu)
-        # Mark the end of this frame
-        self._last_frame_ended_at = time.monotonic()
-
-        # 5. Async wait for response or timeout
-        try:
-            response = await asyncio.wait_for(read_future, timeout=self.timeout)
-        except TimeoutError as e:
-            logger.exception(
-                "Response timeout for unit %d after %.2f seconds. Cancelling read future.", unit_id, self.timeout
-            )
-            read_future.cancel()
-            msg = f"Response timeout after {self.timeout} seconds"
-            raise TimeoutError(msg) from e
-        finally:
-            # Remove from pending requests
-            self._pending_requests.pop(unit_id, None)
-
-        # 6. Check if it's an exception response
-        if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & EXCEPTION_RESPONSE_BIT:  # Exception response
-            function_code = response.pdu_bytes[0] & FUNCTION_CODE_MASK  # Remove exception flag bit
-            exception_code = response.pdu_bytes[1] if len(response.pdu_bytes) > 1 else 0
-
-            if exception_code in error_code_to_exception_map:
-                raise error_code_to_exception_map[exception_code](function_code)
-            raise UnknownModbusResponseError(exception_code, function_code)
-
-        # 7. Validate function code
-        response_function_code = response.pdu_bytes[0]
-        if response_function_code != pdu.function_code:
-            msg = f"Function code mismatch: expected {pdu.function_code}, received {response_function_code}"
-            raise FunctionCodeError(msg, response_bytes=response.bytes)
-
-        # 8. Return decoded response
-        return pdu.decode_response(response.pdu_bytes)
-
-    async def _wait_on_pending_request(self, unit_id: int) -> None:
-        """Wait for any existing pending request for the given unit_id to complete."""
-        existing_future = self._pending_requests.get(unit_id)
-        if existing_future is not None and not existing_future.done():
-            # Wait for the previous request to complete (or fail)
-            # If it fails, we continue with the new request
+            # Async wait for response or timeout
             try:
-                await asyncio.wait_for(existing_future, timeout=self.timeout)
-            except TimeoutError:
-                logger.debug("Previous request for unit %d timed out, proceeding with new request", unit_id)
-            except asyncio.CancelledError:
-                logger.debug("Previous request for unit %d was cancelled, proceeding with new request", unit_id)
-            except Exception as e:  # noqa: BLE001
-                logger.debug("Previous request for unit %d failed: %s, proceeding with new request", unit_id, e)
-            else:
-                logger.debug("Previous request for unit %d succeeded, proceeding with new request", unit_id)
+                response = await asyncio.wait_for(read_future, timeout=self.timeout)
+            except TimeoutError as e:
+                # Save PDU for timed-out request so any delayed response can be discarded cleanly
+                self._timed_out_requests[unit_id] = pdu
+                logger.exception(
+                    "Response timeout for unit %d after %.2f seconds. Cancelling read future.", unit_id, self.timeout
+                )
+                read_future.cancel()
+                msg = f"Response timeout after {self.timeout} seconds"
+                raise TimeoutError(msg) from e
+            finally:
+                self._pending_request = None
+
+            # Check if it's an exception response
+            if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & EXCEPTION_RESPONSE_BIT:  # Exception response
+                function_code = response.pdu_bytes[0] & FUNCTION_CODE_MASK  # Remove exception flag bit
+                exception_code = response.pdu_bytes[1] if len(response.pdu_bytes) > 1 else 0
+
+                if exception_code in error_code_to_exception_map:
+                    raise error_code_to_exception_map[exception_code](function_code)
+                raise UnknownModbusResponseError(exception_code, function_code)
+
+            # Validate function code
+            response_function_code = response.pdu_bytes[0]
+            if response_function_code != pdu.function_code:
+                msg = f"Function code mismatch: expected {pdu.function_code}, received {response_function_code}"
+                raise FunctionCodeError(msg, response_bytes=response.bytes)
+
+            # Return decoded response
+            return pdu.decode_response(response.pdu_bytes)
 
     def _discard_garbage_data(self) -> None:
         """Discard garbage data from the buffer until we find a frame start."""
@@ -265,6 +259,26 @@ class ModbusAsciiProtocol(asyncio.Protocol):
                 discarded.hex(" ").upper(),
             )
             del self._buffer[:start_pos]
+
+    def _handle_inactive_unit_data(self, unit_id: int, base_function_code: int) -> None:
+        """Handle data for a unit ID with no active request."""
+        timed_out_pdu = self._timed_out_requests.get(unit_id)
+        if timed_out_pdu is None and self._pending_request is not None and self._pending_request.unit_id == unit_id:
+            timed_out_pdu = self._pending_request.pdu
+
+        if timed_out_pdu is not None and base_function_code == (timed_out_pdu.function_code & FUNCTION_CODE_MASK):
+            logger.info(
+                "Received delayed response (FC 0x%02X) for timed-out unit %d. Discarding.",
+                base_function_code,
+                unit_id,
+            )
+            self._timed_out_requests.pop(unit_id, None)
+            return
+
+        logger.warning(
+            "Received frame for unit %d with no pending request. Discarding frame.",
+            unit_id,
+        )
 
     def data_received(self, data: bytes) -> None:
         """Handle data received event."""
@@ -306,17 +320,40 @@ class ModbusAsciiProtocol(asyncio.Protocol):
                 # Continue to next frame
                 continue
 
-            # Extract unit_id from frame
+            # Extract unit_id and function code from frame
             unit_id = raw[0]
-            # Check if this unit_id has a pending request
-            pending_future = self._pending_requests.get(unit_id)
-            if pending_future is None or pending_future.done():
-                # No pending request for this unit_id
-                logger.warning(
-                    "Received frame for unit %d with no pending request. Discarding frame.",
-                    unit_id,
-                )
+            pdu_bytes = raw[1:-1]
+            base_function_code = pdu_bytes[0] & FUNCTION_CODE_MASK if pdu_bytes else 0
+
+            # Check if this unit_id has an active pending request
+            pending = self._pending_request
+            has_active_request = pending is not None and pending.unit_id == unit_id and not pending.future.done()
+
+            if not has_active_request:
+                self._handle_inactive_unit_data(unit_id, base_function_code)
                 continue
+
+            assert pending is not None
+
+            # Active request is present. Check if incoming frame belongs to active request or timed-out request.
+            active_expected_fc = pending.pdu.function_code & FUNCTION_CODE_MASK
+            if base_function_code != active_expected_fc:
+                timed_out_pdu = self._timed_out_requests.get(unit_id)
+                if timed_out_pdu is not None and base_function_code == (
+                    timed_out_pdu.function_code & FUNCTION_CODE_MASK
+                ):
+                    logger.info(
+                        "Received delayed response (FC 0x%02X) for previous timed-out request on unit %d during "
+                        "active request (FC 0x%02X). Discarding.",
+                        base_function_code,
+                        unit_id,
+                        pending.pdu.function_code,
+                    )
+                    self._timed_out_requests.pop(unit_id, None)
+                    continue
+
+            # Frame matches active request (or mismatch to be handled downstream)
+            self._timed_out_requests.pop(unit_id, None)
 
             if not validate_ascii_frame(raw):
                 # The unit id is also part of the raw frame, so in theory it is possible that the LRC is caused by
@@ -328,26 +365,28 @@ class ModbusAsciiProtocol(asyncio.Protocol):
                 # As we're trying to recover from a bad frame, we prefer to fail fast instead of letting pending
                 # requests wait for a timeout. Therefore, we set an exception on the pending future and continue.
 
-                pending_future.set_exception(LRCError(response_bytes=frame))
+                pending.future.set_exception(LRCError(response_bytes=frame))
                 continue
 
             # Deliver response to pending request
-            pending_future.set_result(
+            pending.future.set_result(
                 _ModbusAsciiMessage(
                     unit_id=unit_id,
-                    pdu_bytes=raw[1:-1],  # Remove address and LRC
+                    pdu_bytes=pdu_bytes,  # Remove address and LRC
                     lrc=raw[-1:],
                 )
             )
 
     def connection_lost(self, exc: Exception | None) -> None:
         """Handle connection lost event."""
-        # Set exception on all pending requests
-        for pending_future in self._pending_requests.values():
-            if not pending_future.done():
-                pending_future.set_exception(ModbusConnectionError("Connection lost before response was received."))
+        if self._pending_request is not None and not self._pending_request.future.done():
+            self._pending_request.future.set_exception(
+                ModbusConnectionError("Connection lost before response was received.")
+            )
 
-        self._pending_requests.clear()
+        self._pending_request = None
+        self._timed_out_requests.clear()
+        self.transport = None
         self.on_connection_lost(exc)
 
 

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -526,19 +526,64 @@ class ModbusRtuProtocol(asyncio.Protocol):
                 "This is a bug in the PDU class. Discarding buffer: %s",
                 bytes(self._buffer).hex(" ").upper(),
             )
+            response_bytes = bytes(self._buffer)
             self._buffer.clear()
             msg = (
                 f"Expected frame length {expected_total_frame_length} is invalid: "
                 f"must be between 0 and {MAX_RTU_FRAME_SIZE}"
             )
-            raise RTUFrameError(msg, response_bytes=bytes(self._buffer))
+            raise RTUFrameError(msg, response_bytes=response_bytes)
 
         return expected_total_frame_length
+
+    def _validate_and_deliver_frame(
+        self,
+        unit_id: int,
+        expected_length: int,
+        pending_future: asyncio.Future[_ModbusRtuMessage],
+        last_errors: dict[int, Exception],
+    ) -> None:
+        """Extract, validate, and deliver a complete candidate frame."""
+        candidate_frame = bytes(self._buffer[:expected_length])
+        if validate_crc16(candidate_frame):
+            del self._buffer[:expected_length]
+            pdu_bytes = candidate_frame[1:-2]  # Remove address and CRC
+            crc = candidate_frame[-2:]
+            last_errors.pop(unit_id, None)
+            pending_future.set_result(
+                _ModbusRtuMessage(
+                    unit_id=unit_id,
+                    pdu_bytes=pdu_bytes,
+                    crc=crc,
+                )
+            )
+        else:
+            logger.warning(
+                "CRC validation failed for candidate frame (%d bytes: %s). "
+                "Discarding leading byte %s to resynchronize.",
+                len(candidate_frame),
+                candidate_frame.hex(" ").upper(),
+                self._buffer[0:1].hex(" ").upper(),
+            )
+            last_errors[unit_id] = CRCError(response_bytes=candidate_frame)
+            del self._buffer[0]
+
+    def _fail_pending_requests_with_errors(self, last_errors: dict[int, Exception]) -> None:
+        """Fail pending requests that encountered errors when buffer is exhausted."""
+        if not last_errors or len(self._buffer) >= MIN_RTU_RESPONSE_LENGTH:
+            return
+        for uid, err in last_errors.items():
+            if uid not in self._buffer:
+                pending_future = self._pending_requests.get(uid)
+                if pending_future is not None and not pending_future.done():
+                    pending_future.set_exception(err)
 
     def data_received(self, data: bytes) -> None:
         """Handle data received event."""
         self._buffer.extend(data)
         log_raw_traffic("recv", data)
+
+        last_errors: dict[int, Exception] = {}
 
         # Try to process complete frames
         while len(self._buffer) >= MIN_RTU_RESPONSE_LENGTH:
@@ -555,41 +600,25 @@ class ModbusRtuProtocol(asyncio.Protocol):
             # Step 3: Determine expected frame length
             try:
                 expected_total_frame_length = self._determine_expected_frame_length()
-            except RTUFrameError as e:
-                pending_future.set_exception(e)
-                return
+            except (RTUFrameError, FunctionCodeError) as e:
+                logger.warning(
+                    "Framing error for unit %d: %s. Discarding leading byte %s",
+                    unit_id,
+                    e,
+                    self._buffer[0:1].hex(" ").upper() if self._buffer else "",
+                )
+                last_errors[unit_id] = e
+                if self._buffer:
+                    del self._buffer[0]
+                continue
 
             if expected_total_frame_length is None or len(self._buffer) < expected_total_frame_length:
                 return  # Wait for more data
 
-            # Step 6: Extract complete frame
-            frame = bytes(self._buffer[:expected_total_frame_length])
-            del self._buffer[:expected_total_frame_length]
+            # Step 6: Extract, validate CRC, and deliver frame
+            self._validate_and_deliver_frame(unit_id, expected_total_frame_length, pending_future, last_errors)
 
-            # Step 7: Deliver response to pending request
-            pdu_bytes = frame[1:-2]  # Remove address and CRC
-            crc = frame[-2:]
-
-            # 6. Validate CRC
-            if validate_crc16(frame):
-                pending_future.set_result(
-                    _ModbusRtuMessage(
-                        unit_id=unit_id,
-                        pdu_bytes=pdu_bytes,
-                        crc=crc,
-                    )
-                )
-            else:
-                # The unit id is also part of the raw frame, so in theory it is possible that the CRC is caused by
-                # a bit flip on the unit id.
-
-                # However, in most cases this corrupt unit id would not correspond with a pending request,
-                # and the frame would have been discarded already anyway.
-
-                # As we're trying to recover from a bad frame, we prefer to fail fast instead of letting pending
-                # requests wait for a timeout. Therefore, we set an exception on the pending future and continue.
-
-                pending_future.set_exception(CRCError(response_bytes=frame))
+        self._fail_pending_requests_with_errors(last_errors)
 
     def connection_lost(self, exc: Exception | None) -> None:
         """Handle connection lost event."""

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -290,8 +290,9 @@ class _ModbusRtuMessage:
 
 @dataclass
 class _PendingRequest:
-    """Dataclass representing an in-flight pending request for a unit ID."""
+    """Dataclass representing an in-flight pending request."""
 
+    unit_id: int
     future: asyncio.Future[_ModbusRtuMessage]
     pdu: BaseClientPDU[Any] | None = None
 
@@ -305,9 +306,10 @@ class ModbusRtuProtocol(asyncio.Protocol):
     timeout: float
     interframe_delay: float
 
+    _lock: asyncio.Lock
     _buffer: bytearray
     _last_frame_ended_at: float
-    _pending_requests: dict[int, _PendingRequest]
+    _pending_request: _PendingRequest | None
     _timed_out_requests: dict[int, BaseClientPDU[Any]]
 
     def __init__(
@@ -324,9 +326,10 @@ class ModbusRtuProtocol(asyncio.Protocol):
         self.timeout = timeout
         self.interframe_delay = interframe_delay
 
+        self._lock = asyncio.Lock()
         self._buffer = bytearray()
         self._last_frame_ended_at = 0.0
-        self._pending_requests = {}
+        self._pending_request = None
         self._timed_out_requests = {}
 
         self.connection_made_event = asyncio.Event()
@@ -341,121 +344,88 @@ class ModbusRtuProtocol(asyncio.Protocol):
         logger.info("Modbus RTU protocol connection established.")
         self.connection_made_event.set()
 
-    def _get_active_pending_request(
-        self, unit_id: int
-    ) -> tuple[asyncio.Future[_ModbusRtuMessage] | None, BaseClientPDU[Any] | None]:
-        """Get the active (non-done) future and expected PDU for a unit ID."""
-        pending = self._pending_requests.get(unit_id)
-        if pending is None or pending.future.done():
-            return None, None
-        return pending.future, pending.pdu
-
     async def send_and_receive(self, unit_id: int, pdu: BaseClientPDU[RT]) -> RT:
         """Async send PDU and receive response.
 
         Implements complete RTU protocol communication flow:
-        1. Wait for any pending request for this unit_id to complete
+        1. Acquire bus lock (ensuring only one active transaction on the wire)
         2. Build ADU (Address + PDU + CRC)
         3. Wait for inter-frame delay
         4. Async send request
         5. Async receive response
-        6. Validate CRC and address
-        7. Return response PDU
+        6. Validate CRC, address, and function code
+        7. Return decoded response PDU
         """
-        broadcast_response: RT | None = None
-        if unit_id == BROADCAST_UNIT_ID:
-            broadcast_response = pdu.get_broadcast_response()
+        async with self._lock:
+            broadcast_response: RT | None = None
+            if unit_id == BROADCAST_UNIT_ID:
+                broadcast_response = pdu.get_broadcast_response()
 
-        if self.transport is None or self.transport.is_closing():
-            msg = "Not connected."
-            raise ModbusConnectionError(msg)
+            if self.transport is None or self.transport.is_closing():
+                msg = "Not connected."
+                raise ModbusConnectionError(msg)
 
-        # 1. Wait for any existing request for this unit_id to complete
-        await self._wait_on_pending_request(unit_id)
+            # Build request frame
+            request_pdu_bytes = pdu.encode_request()
+            frame_prefix = bytes([unit_id]) + request_pdu_bytes
+            crc = calculate_crc16(frame_prefix)
+            request_adu = frame_prefix + crc
 
-        # 2. Build request frame
-        request_pdu_bytes = pdu.encode_request()
-        frame_prefix = bytes([unit_id]) + request_pdu_bytes
-        crc = calculate_crc16(frame_prefix)
-        request_adu = frame_prefix + crc
+            # Wait for inter-frame delay
+            time_since_last_frame = time.monotonic() - self._last_frame_ended_at
+            if time_since_last_frame < self.interframe_delay:
+                to_wait = self.interframe_delay - time_since_last_frame
+                await asyncio.sleep(to_wait)
 
-        # 3. Wait for inter-frame delay
-        time_since_last_frame = time.monotonic() - self._last_frame_ended_at
-        if time_since_last_frame < self.interframe_delay:
-            to_wait = self.interframe_delay - time_since_last_frame
-            await asyncio.sleep(to_wait)
+            # Async send request
+            if broadcast_response is not None:
+                # We're broadcasting an action, so just send it and return immediately
+                self.transport.write(request_adu)
+                log_raw_traffic("sent", request_adu)
+                self._last_frame_ended_at = time.monotonic()
+                return broadcast_response
 
-        # 4. Async send request
-        if broadcast_response is not None:
-            # We're broadcasting an action, so just send it and return immediately
+            read_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
+            self._pending_request = _PendingRequest(unit_id=unit_id, future=read_future, pdu=pdu)
+
             self.transport.write(request_adu)
             log_raw_traffic("sent", request_adu)
-            # Mark the end of this frame
             self._last_frame_ended_at = time.monotonic()
-            return broadcast_response
 
-        read_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
-        self._pending_requests[unit_id] = _PendingRequest(future=read_future, pdu=pdu)
-
-        self.transport.write(request_adu)
-        log_raw_traffic("sent", request_adu)
-        # Mark the end of this frame
-        self._last_frame_ended_at = time.monotonic()
-
-        # 5. Async wait for response or timeout
-        try:
-            response = await asyncio.wait_for(read_future, timeout=self.timeout)
-        except TimeoutError as e:
-            # Save PDU for timed-out request so any delayed response can be framed and discarded cleanly
-            self._timed_out_requests[unit_id] = pdu
-            msg = f"Response timeout after {self.timeout} seconds"
-            raise TimeoutError(msg) from e
-        finally:
-            # Remove from pending requests
-            self._pending_requests.pop(unit_id, None)
-
-        # 7. Check if it's an exception response
-        if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & EXCEPTION_RESPONSE_BIT:  # Exception response
-            function_code = response.pdu_bytes[0] & FUNCTION_CODE_MASK  # Remove exception flag bit
-            exception_code = response.pdu_bytes[1] if len(response.pdu_bytes) > 1 else 0
-
-            if exception_code in error_code_to_exception_map:
-                raise error_code_to_exception_map[exception_code](function_code)
-            raise UnknownModbusResponseError(exception_code, function_code)
-
-        # 8. Validate function code
-        response_function_code = response.pdu_bytes[0]
-        if response_function_code != pdu.function_code:
-            msg = f"Function code mismatch: expected {pdu.function_code}, received {response_function_code}"
-            raise FunctionCodeError(msg, response_bytes=response.bytes)
-
-        # 9. Return decoded response
-        return pdu.decode_response(response.pdu_bytes)
-
-    async def _wait_on_pending_request(self, unit_id: int) -> None:
-        """Wait for any existing pending request for the given unit_id to complete."""
-        pending = self._pending_requests.get(unit_id)
-        if pending is None:
-            return
-        if not pending.future.done():
-            # Wait for the previous request to complete (or fail)
-            # If it fails, we continue with the new request
+            # Async wait for response or timeout
             try:
-                await asyncio.wait_for(pending.future, timeout=self.timeout)
-            except TimeoutError:
-                logger.debug("Previous request for unit %d timed out, proceeding with new request", unit_id)
-            except asyncio.CancelledError:
-                logger.debug("Previous request for unit %d was cancelled, proceeding with new request", unit_id)
-            except Exception as e:  # noqa: BLE001
-                logger.debug("Previous request for unit %d failed: %s, proceeding with new request", unit_id, e)
-            else:
-                logger.debug("Previous request for unit %d succeeded, proceeding with new request", unit_id)
+                response = await asyncio.wait_for(read_future, timeout=self.timeout)
+            except TimeoutError as e:
+                # Save PDU for timed-out request so any delayed response can be framed and discarded cleanly
+                self._timed_out_requests[unit_id] = pdu
+                msg = f"Response timeout after {self.timeout} seconds"
+                raise TimeoutError(msg) from e
+            finally:
+                self._pending_request = None
+
+            # Check if it's an exception response
+            if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & EXCEPTION_RESPONSE_BIT:  # Exception response
+                function_code = response.pdu_bytes[0] & FUNCTION_CODE_MASK  # Remove exception flag bit
+                exception_code = response.pdu_bytes[1] if len(response.pdu_bytes) > 1 else 0
+
+                if exception_code in error_code_to_exception_map:
+                    raise error_code_to_exception_map[exception_code](function_code)
+                raise UnknownModbusResponseError(exception_code, function_code)
+
+            # Validate function code
+            response_function_code = response.pdu_bytes[0]
+            if response_function_code != pdu.function_code:
+                msg = f"Function code mismatch: expected {pdu.function_code}, received {response_function_code}"
+                raise FunctionCodeError(msg, response_bytes=response.bytes)
+
+            # Return decoded response
+            return pdu.decode_response(response.pdu_bytes)
 
     def _discard_garbage_data(self) -> None:
         """Discard garbage data from the buffer."""
-        # Find the first byte that matches a unit_id with an outstanding or timed-out request
-        expected_unit_ids = {uid for uid, req in self._pending_requests.items() if not req.future.done()}
-        expected_unit_ids.update(self._timed_out_requests.keys())
+        expected_unit_ids: set[int] = set(self._timed_out_requests.keys())
+        if self._pending_request is not None and not self._pending_request.future.done():
+            expected_unit_ids.add(self._pending_request.unit_id)
 
         if not expected_unit_ids:
             # No pending requests at all - discard everything
@@ -468,31 +438,19 @@ class ModbusRtuProtocol(asyncio.Protocol):
             return
 
         # Search for the first byte matching an expected unit_id
-        discard_count = 0
-        for i in range(len(self._buffer)):
-            if self._buffer[i] in expected_unit_ids:
-                # Found a potential match
+        discard_count = len(self._buffer)
+        for i, byte in enumerate(self._buffer):
+            if byte in expected_unit_ids:
                 discard_count = i
                 break
-        else:
-            # No matching unit_id found in buffer
-            discard_count = len(self._buffer)
 
-        if discard_count > 0:
-            discarded = bytes(self._buffer[:discard_count])
-            logger.warning(
-                "Discarding %d byte(s): %s",
-                discard_count,
-                discarded.hex(" ").upper(),
-            )
-            del self._buffer[:discard_count]
-        else:  # pragma: no cover
-            # This shouldn't happen, but just in case
-            logger.warning(
-                "Unexpected state in garbage handling. Discarding first byte: %s",
-                self._buffer[0:1].hex(" ").upper(),
-            )
-            del self._buffer[0]
+        discarded = bytes(self._buffer[:discard_count])
+        logger.warning(
+            "Discarding %d byte(s): %s",
+            discard_count,
+            discarded.hex(" ").upper(),
+        )
+        del self._buffer[:discard_count]
 
     def _determine_expected_frame_length(self, pending_pdu: BaseClientPDU[Any] | None = None) -> int | None:
         """Determine expected frame length based on current buffer contents.
@@ -605,15 +563,13 @@ class ModbusRtuProtocol(asyncio.Protocol):
         unit_id: int,
         expected_length: int,
         pending_future: asyncio.Future[_ModbusRtuMessage],
-        last_errors: dict[int, Exception],
-    ) -> None:
+    ) -> Exception | None:
         """Extract, validate, and deliver a complete candidate frame."""
         candidate_frame = bytes(self._buffer[:expected_length])
         if validate_crc16(candidate_frame):
             del self._buffer[:expected_length]
             pdu_bytes = candidate_frame[1:-2]  # Remove address and CRC
             crc = candidate_frame[-2:]
-            last_errors.pop(unit_id, None)
             self._timed_out_requests.pop(unit_id, None)
             pending_future.set_result(
                 _ModbusRtuMessage(
@@ -622,26 +578,16 @@ class ModbusRtuProtocol(asyncio.Protocol):
                     crc=crc,
                 )
             )
-        else:
-            logger.warning(
-                "CRC validation failed for candidate frame (%d bytes: %s). "
-                "Discarding leading byte %s to resynchronize.",
-                len(candidate_frame),
-                candidate_frame.hex(" ").upper(),
-                self._buffer[0:1].hex(" ").upper(),
-            )
-            last_errors[unit_id] = CRCError(response_bytes=candidate_frame)
-            del self._buffer[0]
+            return None
 
-    def _fail_pending_requests_with_errors(self, last_errors: dict[int, Exception]) -> None:
-        """Fail pending requests that encountered errors when buffer is exhausted."""
-        if not last_errors or len(self._buffer) >= MIN_RTU_RESPONSE_LENGTH:
-            return
-        for uid, err in last_errors.items():
-            if uid not in self._buffer:
-                fut, _ = self._get_active_pending_request(uid)
-                if fut is not None and not fut.done():
-                    fut.set_exception(err)
+        logger.warning(
+            "CRC validation failed for candidate frame (%d bytes: %s). Discarding leading byte %s to resynchronize.",
+            len(candidate_frame),
+            candidate_frame.hex(" ").upper(),
+            self._buffer[0:1].hex(" ").upper(),
+        )
+        del self._buffer[0]
+        return CRCError(response_bytes=candidate_frame)
 
     def _try_drain_delayed_matching_response(
         self,
@@ -666,6 +612,24 @@ class ModbusRtuProtocol(asyncio.Protocol):
                 return self._try_drain_timed_out_response(unit_id, timed_out_pdu)
         return None
 
+    def _handle_inactive_unit_data(self, unit_id: int) -> bool:
+        """Handle data for a unit ID with no active request.
+
+        Returns:
+            True if caller should return immediately (waiting for more data), False to continue.
+
+        """
+        timed_out_pdu = self._timed_out_requests.get(unit_id)
+        if timed_out_pdu is None and self._pending_request is not None and self._pending_request.unit_id == unit_id:
+            timed_out_pdu = self._pending_request.pdu
+
+        if timed_out_pdu is not None:
+            return self._try_drain_timed_out_response(unit_id, timed_out_pdu)
+
+        # No pending or timed-out request for this unit_id - this is garbage data
+        self._discard_garbage_data()
+        return False
+
     def data_received(self, data: bytes) -> None:
         """Handle data received event.
 
@@ -682,28 +646,25 @@ class ModbusRtuProtocol(asyncio.Protocol):
         self._buffer.extend(data)
         log_raw_traffic("recv", data)
 
-        last_errors: dict[int, Exception] = {}
+        last_error: Exception | None = None
 
         # Try to process complete frames
         while len(self._buffer) >= MIN_RTU_RESPONSE_LENGTH:
-            # Step 1: Check if first byte is a unit_id with a pending request
+            # Step 1: Check if first byte is a unit_id with an active or timed-out request
             unit_id = self._buffer[0]
 
             # Step 2: Check if this unit_id has an active pending request
-            pending_future, pending_pdu = self._get_active_pending_request(unit_id)
-            if pending_future is None:
-                timed_out_pdu = self._timed_out_requests.get(unit_id)
-                if timed_out_pdu is not None:
-                    if self._try_drain_timed_out_response(unit_id, timed_out_pdu):
-                        return
-                    continue
+            pending = self._pending_request
+            has_active_request = pending is not None and pending.unit_id == unit_id and not pending.future.done()
 
-                # No pending or timed-out request for this unit_id - this is garbage data
-                self._discard_garbage_data()
+            if not has_active_request:
+                if self._handle_inactive_unit_data(unit_id):
+                    return
                 continue
 
             # Step 3: We have an active pending request. Check for matching delayed response.
-            delayed_drain_result = self._try_drain_delayed_matching_response(unit_id, pending_pdu)
+            assert pending is not None
+            delayed_drain_result = self._try_drain_delayed_matching_response(unit_id, pending.pdu)
             if delayed_drain_result is True:
                 return
             if delayed_drain_result is False:
@@ -711,7 +672,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
 
             # Step 4: Determine expected frame length for active request
             try:
-                expected_total_frame_length = self._determine_expected_frame_length(pending_pdu)
+                expected_total_frame_length = self._determine_expected_frame_length(pending.pdu)
             except (RTUFrameError, FunctionCodeError) as e:
                 logger.warning(
                     "Framing error for unit %d: %s. Discarding leading byte %s",
@@ -719,7 +680,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
                     e,
                     self._buffer[0:1].hex(" ").upper() if self._buffer else "",
                 )
-                last_errors[unit_id] = e
+                last_error = e
                 if self._buffer:
                     del self._buffer[0]
                 continue
@@ -728,17 +689,22 @@ class ModbusRtuProtocol(asyncio.Protocol):
                 return  # Wait for more data
 
             # Step 5: Extract, validate CRC, and deliver frame
-            self._validate_and_deliver_frame(unit_id, expected_total_frame_length, pending_future, last_errors)
+            last_error = self._validate_and_deliver_frame(unit_id, expected_total_frame_length, pending.future)
 
-        self._fail_pending_requests_with_errors(last_errors)
+        if (
+            last_error is not None
+            and self._pending_request is not None
+            and self._pending_request.unit_id not in self._buffer
+        ):
+            self._pending_request.future.set_exception(last_error)
 
     def connection_lost(self, exc: Exception | None) -> None:
         """Handle connection lost event."""
-        # Set exception on all pending requests
-        for pending in self._pending_requests.values():
-            if not pending.future.done():
-                pending.future.set_exception(ModbusConnectionError("Connection lost before response was received."))
+        if self._pending_request is not None and not self._pending_request.future.done():
+            self._pending_request.future.set_exception(
+                ModbusConnectionError("Connection lost before response was received.")
+            )
 
-        self._pending_requests.clear()
+        self._pending_request = None
         self._timed_out_requests.clear()
         self.on_connection_lost(exc)

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -53,7 +53,7 @@ from typing import TYPE_CHECKING, Any, NotRequired, TypedDict, TypeVar, Unpack
 if TYPE_CHECKING:
     from serialx import Parity, StopBits
 
-from tmodbus.const import BROADCAST_UNIT_ID
+from tmodbus.const import BROADCAST_UNIT_ID, EXCEPTION_RESPONSE_BIT, FUNCTION_CODE_MASK
 from tmodbus.exceptions import (
     CRCError,
     FunctionCodeError,
@@ -308,6 +308,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
     _buffer: bytearray
     _last_frame_ended_at: float
     _pending_requests: dict[int, _PendingRequest]
+    _timed_out_requests: dict[int, BaseClientPDU[Any]]
 
     def __init__(
         self,
@@ -326,6 +327,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
         self._buffer = bytearray()
         self._last_frame_ended_at = 0.0
         self._pending_requests = {}
+        self._timed_out_requests = {}
 
         self.connection_made_event = asyncio.Event()
 
@@ -404,6 +406,8 @@ class ModbusRtuProtocol(asyncio.Protocol):
         try:
             response = await asyncio.wait_for(read_future, timeout=self.timeout)
         except TimeoutError as e:
+            # Save PDU for timed-out request so any delayed response can be framed and discarded cleanly
+            self._timed_out_requests[unit_id] = pdu
             msg = f"Response timeout after {self.timeout} seconds"
             raise TimeoutError(msg) from e
         finally:
@@ -411,8 +415,8 @@ class ModbusRtuProtocol(asyncio.Protocol):
             self._pending_requests.pop(unit_id, None)
 
         # 7. Check if it's an exception response
-        if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & 0x80:  # Exception response
-            function_code = response.pdu_bytes[0] & 0x7F  # Remove exception flag bit
+        if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & EXCEPTION_RESPONSE_BIT:  # Exception response
+            function_code = response.pdu_bytes[0] & FUNCTION_CODE_MASK  # Remove exception flag bit
             exception_code = response.pdu_bytes[1] if len(response.pdu_bytes) > 1 else 0
 
             if exception_code in error_code_to_exception_map:
@@ -449,8 +453,9 @@ class ModbusRtuProtocol(asyncio.Protocol):
 
     def _discard_garbage_data(self) -> None:
         """Discard garbage data from the buffer."""
-        # Find the first byte that matches a unit_id with an outstanding request
+        # Find the first byte that matches a unit_id with an outstanding or timed-out request
         expected_unit_ids = {uid for uid, req in self._pending_requests.items() if not req.future.done()}
+        expected_unit_ids.update(self._timed_out_requests.keys())
 
         if not expected_unit_ids:
             # No pending requests at all - discard everything
@@ -504,7 +509,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
             return None  # Need at least address + function code
         function_code = self._buffer[1]
 
-        if function_code & 0x80:  # Exception response
+        if function_code & EXCEPTION_RESPONSE_BIT:  # Exception response
             expected_total_frame_length = 5  # address + exception FC + exception code + CRC
         else:
             if pending_pdu is not None and function_code != pending_pdu.function_code:
@@ -565,6 +570,36 @@ class ModbusRtuProtocol(asyncio.Protocol):
 
         return expected_total_frame_length
 
+    def _try_drain_timed_out_response(self, unit_id: int, timed_out_pdu: BaseClientPDU[Any]) -> bool:
+        """Attempt to frame and discard a delayed response for a timed-out request.
+
+        Returns:
+            True if waiting for more data, False if frame was processed or skipped.
+
+        """
+        try:
+            expected_total_frame_length = self._determine_expected_frame_length(timed_out_pdu)
+        except (RTUFrameError, FunctionCodeError):
+            self._timed_out_requests.pop(unit_id, None)
+            del self._buffer[0]
+            return False
+
+        if expected_total_frame_length is None or len(self._buffer) < expected_total_frame_length:
+            return True  # Wait for full delayed frame
+
+        candidate_frame = bytes(self._buffer[:expected_total_frame_length])
+        if validate_crc16(candidate_frame):
+            del self._buffer[:expected_total_frame_length]
+            self._timed_out_requests.pop(unit_id, None)
+            logger.info(
+                "Cleanly framed and discarded delayed response for timed-out request on unit %d: %s",
+                unit_id,
+                candidate_frame.hex(" ").upper(),
+            )
+        else:
+            del self._buffer[0]
+        return False
+
     def _validate_and_deliver_frame(
         self,
         unit_id: int,
@@ -579,6 +614,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
             pdu_bytes = candidate_frame[1:-2]  # Remove address and CRC
             crc = candidate_frame[-2:]
             last_errors.pop(unit_id, None)
+            self._timed_out_requests.pop(unit_id, None)
             pending_future.set_result(
                 _ModbusRtuMessage(
                     unit_id=unit_id,
@@ -607,8 +643,42 @@ class ModbusRtuProtocol(asyncio.Protocol):
                 if fut is not None and not fut.done():
                     fut.set_exception(err)
 
+    def _try_drain_delayed_matching_response(
+        self,
+        unit_id: int,
+        pending_pdu: BaseClientPDU[Any] | None,
+    ) -> bool | None:
+        """Check and attempt to drain a delayed response matching a timed-out request.
+
+        Returns:
+            True if waiting for more data, False if drained or skipped, or None if no match.
+
+        """
+        timed_out_pdu = self._timed_out_requests.get(unit_id)
+        if timed_out_pdu is not None and len(self._buffer) >= 2:
+            raw_function_code = self._buffer[1]
+            base_function_code = raw_function_code & FUNCTION_CODE_MASK
+            if (
+                pending_pdu is not None
+                and base_function_code != (pending_pdu.function_code & FUNCTION_CODE_MASK)
+                and base_function_code == (timed_out_pdu.function_code & FUNCTION_CODE_MASK)
+            ):
+                return self._try_drain_timed_out_response(unit_id, timed_out_pdu)
+        return None
+
     def data_received(self, data: bytes) -> None:
-        """Handle data received event."""
+        """Handle data received event.
+
+        Limitations of RTU delayed-response detection:
+            Modbus RTU responses do not contain Transaction IDs (TIDs) or sequence numbers.
+            - If a delayed response arrives with a DIFFERENT Function Code than the active
+              request, tmodbus accurately attributes it to the timed-out request and drains it
+              without disrupting the active request.
+            - If a delayed response arrives with the SAME Function Code and byte structure as
+              the active request, it is mathematically indistinguishable on the wire from the
+              genuine response to the active request. In that case, it will be accepted as the
+              response to the active request and the timed-out tracking will be cleared.
+        """
         self._buffer.extend(data)
         log_raw_traffic("recv", data)
 
@@ -619,14 +689,27 @@ class ModbusRtuProtocol(asyncio.Protocol):
             # Step 1: Check if first byte is a unit_id with a pending request
             unit_id = self._buffer[0]
 
-            # Step 2: Check if this unit_id has a pending request
+            # Step 2: Check if this unit_id has an active pending request
             pending_future, pending_pdu = self._get_active_pending_request(unit_id)
             if pending_future is None:
-                # No pending request for this unit_id - this is garbage data
+                timed_out_pdu = self._timed_out_requests.get(unit_id)
+                if timed_out_pdu is not None:
+                    if self._try_drain_timed_out_response(unit_id, timed_out_pdu):
+                        return
+                    continue
+
+                # No pending or timed-out request for this unit_id - this is garbage data
                 self._discard_garbage_data()
                 continue
 
-            # Step 3: Determine expected frame length
+            # Step 3: We have an active pending request. Check for matching delayed response.
+            delayed_drain_result = self._try_drain_delayed_matching_response(unit_id, pending_pdu)
+            if delayed_drain_result is True:
+                return
+            if delayed_drain_result is False:
+                continue
+
+            # Step 4: Determine expected frame length for active request
             try:
                 expected_total_frame_length = self._determine_expected_frame_length(pending_pdu)
             except (RTUFrameError, FunctionCodeError) as e:
@@ -644,7 +727,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
             if expected_total_frame_length is None or len(self._buffer) < expected_total_frame_length:
                 return  # Wait for more data
 
-            # Step 6: Extract, validate CRC, and deliver frame
+            # Step 5: Extract, validate CRC, and deliver frame
             self._validate_and_deliver_frame(unit_id, expected_total_frame_length, pending_future, last_errors)
 
         self._fail_pending_requests_with_errors(last_errors)
@@ -657,4 +740,5 @@ class ModbusRtuProtocol(asyncio.Protocol):
                 pending.future.set_exception(ModbusConnectionError("Connection lost before response was received."))
 
         self._pending_requests.clear()
+        self._timed_out_requests.clear()
         self.on_connection_lost(exc)

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -48,7 +48,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, NotRequired, TypedDict, TypeVar, Unpack
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict, TypeVar, Unpack
 
 if TYPE_CHECKING:
     from serialx import Parity, StopBits
@@ -288,6 +288,14 @@ class _ModbusRtuMessage:
         return bytes([self.unit_id]) + self.pdu_bytes + self.crc
 
 
+@dataclass
+class _PendingRequest:
+    """Dataclass representing an in-flight pending request for a unit ID."""
+
+    future: asyncio.Future[_ModbusRtuMessage]
+    pdu: BaseClientPDU[Any] | None = None
+
+
 class ModbusRtuProtocol(asyncio.Protocol):
     """Asyncio Protocol implementation for Modbus RTU with frame detection."""
 
@@ -299,7 +307,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
 
     _buffer: bytearray
     _last_frame_ended_at: float
-    _pending_requests: dict[int, asyncio.Future[_ModbusRtuMessage]]
+    _pending_requests: dict[int, _PendingRequest]
 
     def __init__(
         self,
@@ -330,6 +338,15 @@ class ModbusRtuProtocol(asyncio.Protocol):
         self.transport = transport
         logger.info("Modbus RTU protocol connection established.")
         self.connection_made_event.set()
+
+    def _get_active_pending_request(
+        self, unit_id: int
+    ) -> tuple[asyncio.Future[_ModbusRtuMessage] | None, BaseClientPDU[Any] | None]:
+        """Get the active (non-done) future and expected PDU for a unit ID."""
+        pending = self._pending_requests.get(unit_id)
+        if pending is None or pending.future.done():
+            return None, None
+        return pending.future, pending.pdu
 
     async def send_and_receive(self, unit_id: int, pdu: BaseClientPDU[RT]) -> RT:
         """Async send PDU and receive response.
@@ -376,7 +393,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
             return broadcast_response
 
         read_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
-        self._pending_requests[unit_id] = read_future
+        self._pending_requests[unit_id] = _PendingRequest(future=read_future, pdu=pdu)
 
         self.transport.write(request_adu)
         log_raw_traffic("sent", request_adu)
@@ -413,12 +430,14 @@ class ModbusRtuProtocol(asyncio.Protocol):
 
     async def _wait_on_pending_request(self, unit_id: int) -> None:
         """Wait for any existing pending request for the given unit_id to complete."""
-        existing_future = self._pending_requests.get(unit_id)
-        if existing_future is not None and not existing_future.done():
+        pending = self._pending_requests.get(unit_id)
+        if pending is None:
+            return
+        if not pending.future.done():
             # Wait for the previous request to complete (or fail)
             # If it fails, we continue with the new request
             try:
-                await asyncio.wait_for(existing_future, timeout=self.timeout)
+                await asyncio.wait_for(pending.future, timeout=self.timeout)
             except TimeoutError:
                 logger.debug("Previous request for unit %d timed out, proceeding with new request", unit_id)
             except asyncio.CancelledError:
@@ -431,7 +450,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
     def _discard_garbage_data(self) -> None:
         """Discard garbage data from the buffer."""
         # Find the first byte that matches a unit_id with an outstanding request
-        expected_unit_ids = {uid for uid, fut in self._pending_requests.items() if not fut.done()}
+        expected_unit_ids = {uid for uid, req in self._pending_requests.items() if not req.future.done()}
 
         if not expected_unit_ids:
             # No pending requests at all - discard everything
@@ -470,7 +489,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
             )
             del self._buffer[0]
 
-    def _determine_expected_frame_length(self) -> int | None:
+    def _determine_expected_frame_length(self, pending_pdu: BaseClientPDU[Any] | None = None) -> int | None:
         """Determine expected frame length based on current buffer contents.
 
         Returns:
@@ -478,6 +497,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
 
         Raises:
             RTUFrameError: If the frame length is invalid.
+            FunctionCodeError: If the function code does not match the pending request.
 
         """
         if len(self._buffer) < 2:
@@ -487,6 +507,12 @@ class ModbusRtuProtocol(asyncio.Protocol):
         if function_code & 0x80:  # Exception response
             expected_total_frame_length = 5  # address + exception FC + exception code + CRC
         else:
+            if pending_pdu is not None and function_code != pending_pdu.function_code:
+                msg = (
+                    f"Function code mismatch: expected {pending_pdu.function_code:#04x}, received {function_code:#04x}"
+                )
+                raise FunctionCodeError(msg, response_bytes=bytes(self._buffer))
+
             # check if we can already determine the expected length with the available data
             try:
                 if not is_function_code_for_subfunction_pdu(function_code):
@@ -499,11 +525,14 @@ class ModbusRtuProtocol(asyncio.Protocol):
                     sub_function_code = self._buffer[2]
                     pdu_class = get_subfunction_pdu_class(function_code, sub_function_code)
             except ValueError as e:
-                # Unknown or unsupported (sub-)function code, for example a bit flip on the
-                # line. We cannot determine where the frame ends, so fail the pending request
-                # with a frame error rather than letting the exception crash the protocol.
-                msg = f"Cannot frame response with unsupported function code {function_code:#04x}"
-                raise RTUFrameError(msg, response_bytes=bytes(self._buffer)) from e
+                if pending_pdu is not None:
+                    pdu_class = type(pending_pdu)
+                else:
+                    # Unknown or unsupported (sub-)function code, for example a bit flip on the
+                    # line. We cannot determine where the frame ends, so fail the pending request
+                    # with a frame error rather than letting the exception crash the protocol.
+                    msg = f"Cannot frame response with unsupported function code {function_code:#04x}"
+                    raise RTUFrameError(msg, response_bytes=bytes(self._buffer)) from e
 
             expected_response_data_length = pdu_class.get_expected_response_data_length(bytes(self._buffer[2:]))
 
@@ -574,9 +603,9 @@ class ModbusRtuProtocol(asyncio.Protocol):
             return
         for uid, err in last_errors.items():
             if uid not in self._buffer:
-                pending_future = self._pending_requests.get(uid)
-                if pending_future is not None and not pending_future.done():
-                    pending_future.set_exception(err)
+                fut, _ = self._get_active_pending_request(uid)
+                if fut is not None and not fut.done():
+                    fut.set_exception(err)
 
     def data_received(self, data: bytes) -> None:
         """Handle data received event."""
@@ -591,15 +620,15 @@ class ModbusRtuProtocol(asyncio.Protocol):
             unit_id = self._buffer[0]
 
             # Step 2: Check if this unit_id has a pending request
-            pending_future = self._pending_requests.get(unit_id)
-            if pending_future is None or pending_future.done():
+            pending_future, pending_pdu = self._get_active_pending_request(unit_id)
+            if pending_future is None:
                 # No pending request for this unit_id - this is garbage data
                 self._discard_garbage_data()
                 continue
 
             # Step 3: Determine expected frame length
             try:
-                expected_total_frame_length = self._determine_expected_frame_length()
+                expected_total_frame_length = self._determine_expected_frame_length(pending_pdu)
             except (RTUFrameError, FunctionCodeError) as e:
                 logger.warning(
                     "Framing error for unit %d: %s. Discarding leading byte %s",
@@ -623,9 +652,9 @@ class ModbusRtuProtocol(asyncio.Protocol):
     def connection_lost(self, exc: Exception | None) -> None:
         """Handle connection lost event."""
         # Set exception on all pending requests
-        for pending_future in self._pending_requests.values():
-            if not pending_future.done():
-                pending_future.set_exception(ModbusConnectionError("Connection lost before response was received."))
+        for pending in self._pending_requests.values():
+            if not pending.future.done():
+                pending.future.set_exception(ModbusConnectionError("Connection lost before response was received."))
 
         self._pending_requests.clear()
         self.on_connection_lost(exc)

--- a/src/tmodbus/transport/async_tcp.py
+++ b/src/tmodbus/transport/async_tcp.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any, TypeVar
 
+from tmodbus.const import EXCEPTION_RESPONSE_BIT, FUNCTION_CODE_MASK
 from tmodbus.exceptions import (
     HeaderMismatchError,
     ModbusConnectionError,
@@ -283,8 +284,8 @@ class ModbusTcpProtocol(asyncio.Protocol):
             raise HeaderMismatchError(msg, response_bytes=response.bytes)
 
         # 8.Check if it's an exception response
-        if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & 0x80:  # Exception response
-            function_code = response.pdu_bytes[0] & 0x7F  # Remove exception flag bit
+        if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & EXCEPTION_RESPONSE_BIT:  # Exception response
+            function_code = response.pdu_bytes[0] & FUNCTION_CODE_MASK  # Remove exception flag bit
             exception_code = response.pdu_bytes[1] if len(response.pdu_bytes) > 1 else 0
 
             if exception_code in error_code_to_exception_map:

--- a/src/tmodbus/transport/async_udp.py
+++ b/src/tmodbus/transport/async_udp.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any, TypeVar
 
+from tmodbus.const import EXCEPTION_RESPONSE_BIT, FUNCTION_CODE_MASK
 from tmodbus.exceptions import (
     HeaderMismatchError,
     ModbusConnectionError,
@@ -253,8 +254,8 @@ class ModbusUdpProtocol(asyncio.DatagramProtocol):
             msg = f"Unit ID mismatch: expected {unit_id:#04x}, received {response.unit_id:#04x}"
             raise HeaderMismatchError(msg, response_bytes=response.bytes)
 
-        if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & 0x80:  # Exception response
-            function_code = response.pdu_bytes[0] & 0x7F
+        if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & EXCEPTION_RESPONSE_BIT:  # Exception response
+            function_code = response.pdu_bytes[0] & FUNCTION_CODE_MASK
             exception_code = response.pdu_bytes[1] if len(response.pdu_bytes) > 1 else 0
 
             if exception_code in error_code_to_exception_map:

--- a/tests/transport/test_async_ascii.py
+++ b/tests/transport/test_async_ascii.py
@@ -23,7 +23,7 @@ from tmodbus.transport.async_ascii import (
     MAX_ASCII_FRAME_SIZE,
     AsyncAsciiTransport,
     ModbusAsciiProtocol,
-    _ModbusAsciiMessage,
+    _PendingRequest,
     ascii_decode,
     ascii_encode,
     build_ascii_frame,
@@ -770,9 +770,9 @@ async def test_protocol_connection_lost_with_multiple_pending(mock_transport: Ma
     # All tasks should raise ModbusConnectionError
     with pytest.raises(ModbusConnectionError, match="Connection lost"):
         await task1
-    with pytest.raises(ModbusConnectionError, match="Connection lost"):
+    with pytest.raises(ModbusConnectionError, match="Not connected"):
         await task2
-    with pytest.raises(ModbusConnectionError, match="Connection lost"):
+    with pytest.raises(ModbusConnectionError, match="Not connected"):
         await task3
 
 
@@ -780,36 +780,40 @@ async def test_protocol_multiple_frames(mock_transport: MagicMock) -> None:
     """Test receiving multiple frames in one data_received call."""
     protocol = ModbusAsciiProtocol(
         on_connection_lost=lambda _exc: None,
-        timeout=10.0,
+        timeout=0.05,
     )
     protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
 
-    pdu = _DummyPDU()
+    pdu1 = _DummyPDU()
+    pdu1.function_code = 0x03
 
-    # Start two requests for different units
-    task1 = asyncio.create_task(protocol.send_and_receive(1, pdu))
-    task2 = asyncio.create_task(protocol.send_and_receive(2, pdu))
-    await asyncio.sleep(0.01)
+    pdu2 = _DummyPDU()
+    pdu2.function_code = 0x06
 
-    # Build two responses
-    response_pdu = b"\x03\x02\x00\x00"
+    unit_id = 1
 
-    response1_message = bytes([1]) + response_pdu
-    lrc1 = calculate_lrc(response1_message)
-    frame1 = b":" + ascii_encode(response1_message + bytes([lrc1])) + b"\r\n"
+    # Request 1 times out
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu1)
 
-    response2_message = bytes([2]) + response_pdu
-    lrc2 = calculate_lrc(response2_message)
-    frame2 = b":" + ascii_encode(response2_message + bytes([lrc2])) + b"\r\n"
+    assert protocol._timed_out_requests[unit_id] is pdu1
 
-    # Send both frames at once
-    protocol.data_received(frame1 + frame2)
+    # Build delayed response for request 1 and valid response for request 2
+    frame1 = build_ascii_frame(unit_id, b"\x03\x02\xaa\xbb")
+    frame2 = build_ascii_frame(unit_id, b"\x06\x00\x01\x11\x22")
 
-    result1 = await task1
-    result2 = await task2
+    async def deliver_both_frames() -> None:
+        await asyncio.sleep(0.01)
+        # Send both frames at once in single data_received call
+        protocol.data_received(frame1 + frame2)
 
-    assert result1 == ("decoded", response_pdu)
-    assert result2 == ("decoded", response_pdu)
+    deliv_task = asyncio.create_task(deliver_both_frames())
+    res2 = await protocol.send_and_receive(unit_id, pdu2)
+    await deliv_task
+
+    assert res2 == ("decoded", b"\x06\x00\x01\x11\x22")
+    assert len(protocol._buffer) == 0
 
 
 async def test_protocol_send_not_connected() -> None:
@@ -1171,135 +1175,250 @@ async def test_connection_lost_without_exception(
     assert t._protocol is None
 
 
-async def test_wait_on_pending_request_no_pending() -> None:
-    """Test _wait_on_pending_request when there's no pending request for the unit_id."""
-    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None)
-
-    # Should return immediately when there's no pending request
-    await protocol._wait_on_pending_request(1)
-    # If we get here without blocking, the test passes
-
-
-async def test_wait_on_pending_request_already_done() -> None:
-    """Test _wait_on_pending_request when pending request is already done."""
-    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None)
-
-    # Create a future that's already done
-    done_future: asyncio.Future[_ModbusAsciiMessage] = asyncio.get_event_loop().create_future()
-    done_future.set_result(_ModbusAsciiMessage(unit_id=1, pdu_bytes=b"\x03\x00", lrc=b"\x00\x00"))
-    protocol._pending_requests[1] = done_future
-
-    # Should return immediately when future is already done
-    await protocol._wait_on_pending_request(1)
-    # If we get here without blocking, the test passes
-
-
-async def test_wait_on_pending_request_waits_for_completion(caplog: pytest.LogCaptureFixture) -> None:
-    """Test _wait_on_pending_request waits for pending request to complete successfully."""
-    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=1.0)
-
-    # Create a pending future
-    pending_future: asyncio.Future[_ModbusAsciiMessage] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = pending_future
-
-    # Set up a task to complete the future after a delay
-    async def complete_future() -> None:
-        await asyncio.sleep(0.05)
-        pending_future.set_result(_ModbusAsciiMessage(unit_id=1, pdu_bytes=b"\x03\x00", lrc=b"\x00\x00"))
-
-    complete_task = asyncio.create_task(complete_future())
-
-    # Should wait for the future to complete
-    with caplog.at_level(logging.DEBUG, logger="tmodbus.transport.async_ascii"):
-        await protocol._wait_on_pending_request(1)
-
-        # Should have logged success
-        assert any("succeeded" in record.message for record in caplog.records)
-
-    await complete_task
-
-
-async def test_wait_on_pending_request_cancelled(caplog: pytest.LogCaptureFixture) -> None:
-    """Test _wait_on_pending_request when pending request is cancelled."""
-    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=1.0)
-
-    # Create a pending future
-    pending_future: asyncio.Future[_ModbusAsciiMessage] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = pending_future
-
-    # Set up a task to cancel the future after a delay
-    async def cancel_future() -> None:
-        await asyncio.sleep(0.05)
-        pending_future.cancel()
-
-    cancel_task = asyncio.create_task(cancel_future())
-
-    # Should wait for the future and handle cancellation
-    with caplog.at_level(logging.DEBUG, logger="tmodbus.transport.async_ascii"):
-        await protocol._wait_on_pending_request(1)
-
-        # Should have logged cancellation
-        assert any("cancelled" in record.message for record in caplog.records)
-
-    await cancel_task
-
-
-async def test_wait_on_pending_request_generic_exception(caplog: pytest.LogCaptureFixture) -> None:
-    """Test _wait_on_pending_request when pending request raises a generic exception."""
-    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=1.0)
-
-    # Create a pending future
-    pending_future: asyncio.Future[_ModbusAsciiMessage] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = pending_future
-
-    # Set up a task to fail the future after a delay
-    async def fail_future() -> None:
-        await asyncio.sleep(0.05)
-        pending_future.set_exception(RuntimeError("Previous request error"))
-
-    fail_task = asyncio.create_task(fail_future())
-
-    # Should wait for the future and handle the exception
-    with caplog.at_level(logging.DEBUG, logger="tmodbus.transport.async_ascii"):
-        await protocol._wait_on_pending_request(1)
-
-        # Should have logged the failure
-        assert any("failed" in record.message for record in caplog.records)
-
-    await fail_task
-
-
-async def test_wait_on_pending_request_timeout_waiting(caplog: pytest.LogCaptureFixture) -> None:
-    """Test _wait_on_pending_request when waiting times out."""
-    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=0.1)
-
-    # Create a pending future that never completes
-    pending_future: asyncio.Future[_ModbusAsciiMessage] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = pending_future
-
-    # Should timeout and log it
-    with caplog.at_level(logging.DEBUG, logger="tmodbus.transport.async_ascii"):
-        await protocol._wait_on_pending_request(1)
-
-        # Should have logged timeout
-        assert any("timed out" in record.message for record in caplog.records)
-
-
-async def test_connection_lost_dont_set_exception_on_done_requests(
+async def test_send_and_receive_timeout_resets_pending_request(
     mock_transport: MagicMock,
 ) -> None:
-    """Test that connection_lost sets exception on all pending requests."""
-    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None)
+    """Test that send_and_receive resets _pending_request and stores timed-out PDU on timeout."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=0.05)
     protocol.connection_made(mock_transport)
     protocol._last_frame_ended_at = time.monotonic() - 10
 
     pdu = _DummyPDU()
     unit_id = 1
 
-    # add a future that is already done to _pending_requests to test that it is skipped
-    done_future = asyncio.get_event_loop().create_future()
-    done_future.set_result(None)
-    protocol._pending_requests[2] = done_future
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu)
+
+    assert protocol._pending_request is None
+    assert protocol._timed_out_requests[unit_id] is pdu
+
+
+async def test_send_and_receive_serialized_by_bus_lock(
+    mock_transport: MagicMock,
+) -> None:
+    """Test that concurrent send_and_receive calls are serialized by the bus lock."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=1.0)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    pdu1 = _DummyPDU()
+    pdu2 = _DummyPDU()
+    unit_id_1 = 1
+    unit_id_2 = 2
+
+    resp1 = build_ascii_frame(unit_id_1, b"\x03\x02\x00\x0a")
+    resp2 = build_ascii_frame(unit_id_2, b"\x03\x02\x00\x0b")
+
+    async def deliver_responses() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(resp1)
+        await asyncio.sleep(0.01)
+        protocol.data_received(resp2)
+
+    task1 = asyncio.create_task(protocol.send_and_receive(unit_id_1, pdu1))
+    task2 = asyncio.create_task(protocol.send_and_receive(unit_id_2, pdu2))
+    deliv_task = asyncio.create_task(deliver_responses())
+
+    res1, res2 = await asyncio.gather(task1, task2)
+    await deliv_task
+
+    assert res1 == ("decoded", b"\x03\x02\x00\x0a")
+    assert res2 == ("decoded", b"\x03\x02\x00\x0b")
+
+
+async def test_delayed_response_after_timeout_is_cleanly_discarded(
+    mock_transport: MagicMock,
+) -> None:
+    """Test that delayed response arriving after timeout is cleanly discarded using timed-out tracking."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    pdu = _DummyPDU()
+    unit_id = 1
+
+    # Request times out
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu)
+
+    assert protocol._timed_out_requests[unit_id] is pdu
+
+    # Delayed response arrives
+    delayed_frame = build_ascii_frame(unit_id, b"\x03\x02\x00\x55")
+    protocol.data_received(delayed_frame)
+
+    assert len(protocol._buffer) == 0
+    assert unit_id not in protocol._timed_out_requests
+
+
+async def test_delayed_response_during_active_request_same_unit(
+    mock_transport: MagicMock,
+) -> None:
+    """Test that delayed response from timed-out request does not fail active request with different FC."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    pdu1 = _DummyPDU()
+    pdu1.function_code = 0x03
+
+    pdu2 = _DummyPDU()
+    pdu2.function_code = 0x06
+
+    unit_id = 1
+
+    # Step 1: Request 1 (FC 0x03) times out
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu1)
+
+    assert protocol._timed_out_requests[unit_id] is pdu1
+
+    # Step 2: Request 2 (FC 0x06) is sent and active
+    delayed_frame_1 = build_ascii_frame(unit_id, b"\x03\x02\xaa\xbb")
+    real_frame_2 = build_ascii_frame(unit_id, b"\x06\x00\x01\x11\x22")
+
+    async def deliver_delayed_then_real() -> None:
+        await asyncio.sleep(0.01)
+        # Deliver late response for request 1
+        protocol.data_received(delayed_frame_1)
+        # Active request should still be pending and not failed
+        assert protocol._pending_request is not None
+        assert not protocol._pending_request.future.done()
+        assert unit_id not in protocol._timed_out_requests
+
+        # Deliver real response for request 2
+        await asyncio.sleep(0.01)
+        protocol.data_received(real_frame_2)
+
+    req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
+    deliv_task = asyncio.create_task(deliver_delayed_then_real())
+
+    result = await req2_task
+    await deliv_task
+
+    assert result == ("decoded", b"\x06\x00\x01\x11\x22")
+    assert len(protocol._buffer) == 0
+
+
+async def test_delayed_exception_response_during_active_request_same_unit(
+    mock_transport: MagicMock,
+) -> None:
+    """Test that delayed exception response from timed-out request does not fail active request."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    pdu1 = _DummyPDU()
+    pdu1.function_code = 0x03
+
+    pdu2 = _DummyPDU()
+    pdu2.function_code = 0x06
+
+    unit_id = 1
+
+    # Step 1: Request 1 (FC 0x03) times out
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu1)
+
+    assert protocol._timed_out_requests[unit_id] is pdu1
+
+    # Step 2: Request 2 (FC 0x06) is sent and active
+    # Late exception response for Request 1 (FC 0x83, exception code 0x02)
+    delayed_exc_frame_1 = build_ascii_frame(unit_id, b"\x83\x02")
+    real_frame_2 = build_ascii_frame(unit_id, b"\x06\x00\x01\x11\x22")
+
+    async def deliver_delayed_exc_then_real() -> None:
+        await asyncio.sleep(0.01)
+        # Deliver late exception response for request 1
+        protocol.data_received(delayed_exc_frame_1)
+        # Active request should still be pending and not failed
+        assert protocol._pending_request is not None
+        assert not protocol._pending_request.future.done()
+        assert unit_id not in protocol._timed_out_requests
+
+        # Deliver real response for request 2
+        await asyncio.sleep(0.01)
+        protocol.data_received(real_frame_2)
+
+    req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
+    deliv_task = asyncio.create_task(deliver_delayed_exc_then_real())
+
+    result = await req2_task
+    await deliv_task
+
+    assert result == ("decoded", b"\x06\x00\x01\x11\x22")
+    assert len(protocol._buffer) == 0
+
+
+async def test_active_request_succeeds_and_clears_stale_timed_out_request(
+    mock_transport: MagicMock,
+) -> None:
+    """Test that a successful response to an active request clears stale timed-out tracking."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    pdu1 = _DummyPDU()
+    pdu2 = _DummyPDU()
+    unit_id = 1
+
+    # Request 1 times out
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu1)
+
+    assert protocol._timed_out_requests[unit_id] is pdu1
+
+    # Request 2 is sent and succeeds
+    response = build_ascii_frame(unit_id, b"\x03\x02\x00\x55")
+
+    async def deliver_response() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(response)
+
+    req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
+    deliv_task = asyncio.create_task(deliver_response())
+
+    result = await req2_task
+    await deliv_task
+
+    assert result == ("decoded", b"\x03\x02\x00\x55")
+    assert unit_id not in protocol._timed_out_requests
+
+
+async def test_data_received_falls_back_to_pending_request_pdu_when_future_done(
+    mock_transport: MagicMock,
+) -> None:
+    """Test that data_received uses _pending_request.pdu if future is done but _timed_out_requests not yet set."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+    pdu.function_code = 0x03
+    unit_id = 1
+
+    # Simulate future cancelled/done by asyncio.wait_for timeout before send_and_receive cleans up
+    fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+    fut.cancel()
+
+    protocol._pending_request = _PendingRequest(unit_id=unit_id, future=fut, pdu=pdu)
+
+    # Response arrives for the timed-out request
+    response = build_ascii_frame(unit_id, b"\x03\x02\x00\x55")
+
+    protocol.data_received(response)
+    assert len(protocol._buffer) == 0
+
+
+async def test_connection_lost_sets_exception_on_pending_request(
+    mock_transport: MagicMock,
+) -> None:
+    """Test that connection_lost sets exception on pending request and clears state."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    pdu = _DummyPDU()
+    unit_id = 1
 
     async def lose_connection() -> None:
         await asyncio.sleep(0.05)
@@ -1312,3 +1431,5 @@ async def test_connection_lost_dont_set_exception_on_done_requests(
         await result_task
 
     await connection_task
+    assert protocol._pending_request is None
+    assert len(protocol._timed_out_requests) == 0

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -502,8 +502,8 @@ async def test_protocol_per_unit_request_tracking(
     mock_transport: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that protocol tracks pending requests per unit_id."""
-    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    """Test that protocol tracks timed-out requests per unit_id across serialized transactions."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=0.05)
     protocol.connection_made(mock_transport)
 
     pdu1 = _DummyPDU()
@@ -519,32 +519,28 @@ async def test_protocol_per_unit_request_tracking(
     monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
     protocol._last_frame_ended_at = time.monotonic() - 10
 
-    # Start two requests for different units simultaneously
-    async def send_and_respond(unit_id: int, pdu: BaseClientPDU) -> Any:  # type: ignore[type-arg]
-        response_data = b"\x05"
-        payload = bytes([unit_id, pdu.function_code]) + response_data
-        crc = calculate_crc16(payload)
-        response_adu = payload + crc
+    # Request 1 times out -> stored in _timed_out_requests[unit_id_1]
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id_1, pdu1)
 
-        async def simulate_response() -> None:
-            await asyncio.sleep(0.02)
-            protocol.data_received(response_adu)
+    assert protocol._timed_out_requests[unit_id_1] is pdu1
 
-        result_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
-        response_task = asyncio.create_task(simulate_response())
+    # Request 2 succeeds -> stored in _timed_out_requests[unit_id_2] (if timed out), but unit 1 is kept
+    resp2_payload = bytes([unit_id_2, pdu2.function_code, 0x05])
+    resp2_frame = resp2_payload + calculate_crc16(resp2_payload)
 
-        result = await result_task
-        await response_task
-        return result
+    async def deliver_resp2() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(resp2_frame)
 
-    # Send requests to two different units - should work concurrently
-    result1, result2 = await asyncio.gather(
-        send_and_respond(unit_id_1, pdu1),
-        send_and_respond(unit_id_2, pdu2),
-    )
+    deliv_task = asyncio.create_task(deliver_resp2())
+    res2 = await protocol.send_and_receive(unit_id_2, pdu2)
+    await deliv_task
 
-    assert result1[0] == "decoded"
-    assert result2[0] == "decoded"
+    assert res2[0] == "decoded"
+    # Unit 1 timed-out request is still tracked safely!
+    assert protocol._timed_out_requests[unit_id_1] is pdu1
+    assert unit_id_2 not in protocol._timed_out_requests
 
 
 async def test_protocol_waits_for_previous_request_same_unit(
@@ -567,59 +563,25 @@ async def test_protocol_waits_for_previous_request_same_unit(
     monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
     protocol._last_frame_ended_at = time.monotonic() - 10
 
-    request1_started = False
-    request2_started = False
+    resp1 = bytes([unit_id, pdu1.function_code, 0x05])
+    resp1_frame = resp1 + calculate_crc16(resp1)
 
-    async def send_request_1() -> Any:
-        nonlocal request1_started
-        request1_started = True
+    resp2 = bytes([unit_id, pdu2.function_code, 0x06])
+    resp2_frame = resp2 + calculate_crc16(resp2)
 
-        response_data = b"\x05"
-        payload = bytes([unit_id, pdu1.function_code]) + response_data
-        crc = calculate_crc16(payload)
-        response_adu = payload + crc
-
-        async def simulate_response() -> None:
-            await asyncio.sleep(0.05)
-            protocol.data_received(response_adu)
-
-        result_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu1))
-        response_task = asyncio.create_task(simulate_response())
-
-        result = await result_task
-        await response_task
-        return result
-
-    async def send_request_2() -> Any:
-        # Wait a bit to ensure request1 starts first
+    async def deliver_responses() -> None:
         await asyncio.sleep(0.01)
-        nonlocal request2_started
-        request2_started = True
+        protocol.data_received(resp1_frame)
+        await asyncio.sleep(0.01)
+        protocol.data_received(resp2_frame)
 
-        response_data = b"\x06"
-        payload = bytes([unit_id, pdu2.function_code]) + response_data
-        crc = calculate_crc16(payload)
-        response_adu = payload + crc
+    task1 = asyncio.create_task(protocol.send_and_receive(unit_id, pdu1))
+    task2 = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
+    deliv_task = asyncio.create_task(deliver_responses())
 
-        async def simulate_response() -> None:
-            await asyncio.sleep(0.01)
-            protocol.data_received(response_adu)
+    result1, result2 = await asyncio.gather(task1, task2)
+    await deliv_task
 
-        result_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
-        response_task = asyncio.create_task(simulate_response())
-
-        result = await result_task
-        await response_task
-        return result
-
-    # Both requests should complete, but request2 waits for request1
-    result1, result2 = await asyncio.gather(
-        send_request_1(),
-        send_request_2(),
-    )
-
-    assert request1_started
-    assert request2_started
     assert result1[0] == "decoded"
     assert result2[0] == "decoded"
 
@@ -739,19 +701,15 @@ async def test_on_connection_lost_pending_futures(mock_serial_connection: tuple[
     pdu = _DummyPDU()
     unit_id = 1
 
-    # add a future that is already done to _pending_requests to test that it is skipped
-    done_future = asyncio.get_event_loop().create_future()
-    done_future.set_result(None)
-    protocol._pending_requests[2] = _PendingRequest(future=done_future)
-
     # Start a send_and_receive to create a pending future
     send_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
     await asyncio.sleep(0.01)  # Ensure the send_and_receive has started
-    assert protocol._pending_requests[unit_id]
+    assert protocol._pending_request is not None
     protocol._timed_out_requests[3] = pdu
     # Now simulate connection lost
     protocol.connection_lost(None)
     assert len(protocol._timed_out_requests) == 0
+    assert protocol._pending_request is None
 
     with pytest.raises(ModbusConnectionError, match=r"Connection lost before response was received\."):
         await send_task
@@ -993,16 +951,18 @@ async def test_pending_future_already_done(
     # If we get here without exceptions, the test passes
 
 
-async def test_send_and_receive_previous_request_timeout(
+async def test_send_and_receive_serialized_by_bus_lock(
     mock_transport: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test waiting for previous request that times out (lines 329-330)."""
-    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=0.1)
+    """Test that concurrent send_and_receive calls are serialized by the bus lock."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=1.0)
     protocol.connection_made(mock_transport)
 
-    pdu = _DummyPDU()
-    unit_id = 1
+    pdu1 = _DummyPDU()
+    pdu2 = _DummyPDU()
+    unit_id_1 = 1
+    unit_id_2 = 2
 
     class DummyPduClass:
         @staticmethod
@@ -1012,79 +972,27 @@ async def test_send_and_receive_previous_request_timeout(
     monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
     protocol._last_frame_ended_at = time.monotonic() - 10
 
-    # Directly test the code path by mocking a pending future that will timeout
-    mock_future: asyncio.Future[Any] = asyncio.Future()
-    protocol._pending_requests[unit_id] = _PendingRequest(future=mock_future, pdu=pdu)
+    resp1 = bytes([unit_id_1, pdu1.function_code, 0x05])
+    resp1_frame = resp1 + calculate_crc16(resp1)
 
-    # Now when we call send_and_receive, it should wait for the mock_future
-    # which will timeout
-    response_data = b"\x05"
-    payload = bytes([unit_id, pdu.function_code]) + response_data
-    crc = calculate_crc16(payload)
-    response_adu = payload + crc
+    resp2 = bytes([unit_id_2, pdu2.function_code, 0x06])
+    resp2_frame = resp2 + calculate_crc16(resp2)
 
-    async def send_after_delay() -> None:
-        await asyncio.sleep(0.15)  # After the timeout
-        protocol.data_received(response_adu)
-
-    with patch("tmodbus.transport.async_rtu.logger") as log:
-        send_task = asyncio.create_task(send_after_delay())
-
-        # This should log about timeout while waiting for the mock_future
-        result = await protocol.send_and_receive(unit_id, pdu)
-        await send_task
-
-        # Should have logged about timeout
-        assert any("timed out" in str(call) for call in log.debug.call_args_list)
-        assert result[0] == "decoded"
-
-
-async def test_send_and_receive_previous_request_failed(
-    mock_transport: MagicMock,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Test waiting for previous request that has failed."""
-    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=0.1)
-    protocol.connection_made(mock_transport)
-
-    pdu = _DummyPDU()
-    unit_id = 1
-
-    class DummyPduClass:
-        @staticmethod
-        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
-            return 1
-
-    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
-    protocol._last_frame_ended_at = time.monotonic() - 10
-
-    # Directly test the code path by mocking a pending future that has failed
-    mock_future: asyncio.Future[Any] = asyncio.Future()
-    protocol._pending_requests[unit_id] = _PendingRequest(future=mock_future, pdu=pdu)
-
-    # Now when we call send_and_receive, it should wait for the mock_future
-    # which will timeout
-    response_data = b"\x05"
-    payload = bytes([unit_id, pdu.function_code]) + response_data
-    crc = calculate_crc16(payload)
-    response_adu = payload + crc
-
-    async def error_after_delay() -> None:
+    async def deliver_responses() -> None:
         await asyncio.sleep(0.01)
-        mock_future.set_exception(RuntimeError("Previous request failed"))
+        protocol.data_received(resp1_frame)
         await asyncio.sleep(0.01)
-        protocol.data_received(response_adu)
+        protocol.data_received(resp2_frame)
 
-    with patch("tmodbus.transport.async_rtu.logger") as log:
-        error_task = asyncio.create_task(error_after_delay())
+    task1 = asyncio.create_task(protocol.send_and_receive(unit_id_1, pdu1))
+    task2 = asyncio.create_task(protocol.send_and_receive(unit_id_2, pdu2))
+    deliv_task = asyncio.create_task(deliver_responses())
 
-        # This should log about timeout while waiting for the mock_future
-        result = await protocol.send_and_receive(unit_id, pdu)
-        await error_task
+    res1, res2 = await asyncio.gather(task1, task2)
+    await deliv_task
 
-        # Should have logged about failed request
-        assert any("failed" in str(call) for call in log.debug.call_args_list)
-        assert result[0] == "decoded"
+    assert res1 == ("decoded", b"\x03\x05")
+    assert res2 == ("decoded", b"\x03\x06")
 
 
 async def test_data_received_cannot_determine_length(
@@ -1200,118 +1108,22 @@ async def test_data_received_insufficient_data(
     await send_request_and_receive_partial()
 
 
-async def test_wait_on_pending_request_no_pending() -> None:
-    """Test _wait_on_pending_request when there's no pending request for the unit_id."""
-    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+async def test_send_and_receive_timeout_resets_pending_request(
+    mock_transport: MagicMock,
+) -> None:
+    """Test that send_and_receive resets _pending_request and stores timed-out PDU on timeout."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
 
-    # Should return immediately when there's no pending request
-    await protocol._wait_on_pending_request(1)
-    # If we get here without blocking, the test passes
+    pdu = _DummyPDU()
+    unit_id = 1
 
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu)
 
-async def test_wait_on_pending_request_already_done() -> None:
-    """Test _wait_on_pending_request when pending request is already done."""
-    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
-
-    # Create a future that's already done
-    done_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
-    done_future.set_result(_ModbusRtuMessage(unit_id=1, pdu_bytes=b"\x03\x00", crc=b"\x00\x00"))
-    protocol._pending_requests[1] = _PendingRequest(future=done_future)
-
-    # Should return immediately when future is already done
-    await protocol._wait_on_pending_request(1)
-    # If we get here without blocking, the test passes
-
-
-async def test_wait_on_pending_request_waits_for_completion(caplog: pytest.LogCaptureFixture) -> None:
-    """Test _wait_on_pending_request waits for pending request to complete successfully."""
-    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=1.0)
-
-    # Create a pending future
-    pending_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = _PendingRequest(future=pending_future)
-
-    # Set up a task to complete the future after a delay
-    async def complete_future() -> None:
-        await asyncio.sleep(0.05)
-        pending_future.set_result(_ModbusRtuMessage(unit_id=1, pdu_bytes=b"\x03\x00", crc=b"\x00\x00"))
-
-    complete_task = asyncio.create_task(complete_future())
-
-    # Should wait for the future to complete
-    with caplog.at_level(logging.DEBUG, logger="tmodbus.transport.async_rtu"):
-        await protocol._wait_on_pending_request(1)
-
-        # Should have logged success
-        assert any("succeeded" in record.message for record in caplog.records)
-
-    await complete_task
-
-
-async def test_wait_on_pending_request_cancelled(caplog: pytest.LogCaptureFixture) -> None:
-    """Test _wait_on_pending_request when pending request is cancelled."""
-    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=1.0)
-
-    # Create a pending future
-    pending_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = _PendingRequest(future=pending_future)
-
-    # Set up a task to cancel the future after a delay
-    async def cancel_future() -> None:
-        await asyncio.sleep(0.05)
-        pending_future.cancel()
-
-    cancel_task = asyncio.create_task(cancel_future())
-
-    # Should wait for the future and handle cancellation
-    with caplog.at_level(logging.DEBUG, logger="tmodbus.transport.async_rtu"):
-        await protocol._wait_on_pending_request(1)
-
-        # Should have logged cancellation
-        assert any("cancelled" in record.message for record in caplog.records)
-
-    await cancel_task
-
-
-async def test_wait_on_pending_request_generic_exception(caplog: pytest.LogCaptureFixture) -> None:
-    """Test _wait_on_pending_request when pending request raises a generic exception."""
-    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=1.0)
-
-    # Create a pending future
-    pending_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = _PendingRequest(future=pending_future)
-
-    # Set up a task to fail the future after a delay
-    async def fail_future() -> None:
-        await asyncio.sleep(0.05)
-        pending_future.set_exception(RuntimeError("Previous request error"))
-
-    fail_task = asyncio.create_task(fail_future())
-
-    # Should wait for the future and handle the exception
-    with caplog.at_level(logging.DEBUG, logger="tmodbus.transport.async_rtu"):
-        await protocol._wait_on_pending_request(1)
-
-        # Should have logged the failure
-        assert any("failed" in record.message for record in caplog.records)
-
-    await fail_task
-
-
-async def test_wait_on_pending_request_timeout_waiting(caplog: pytest.LogCaptureFixture) -> None:
-    """Test _wait_on_pending_request when waiting times out."""
-    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=0.1)
-
-    # Create a pending future that never completes
-    pending_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = _PendingRequest(future=pending_future)
-
-    # Should timeout and log it
-    with caplog.at_level(logging.DEBUG, logger="tmodbus.transport.async_rtu"):
-        await protocol._wait_on_pending_request(1)
-
-        # Should have logged timeout
-        assert any("timed out" in record.message for record in caplog.records)
+    assert protocol._pending_request is None
+    assert protocol._timed_out_requests[unit_id] is pdu
 
 
 async def test_sliding_window_recovers_when_noise_matches_unit_id(
@@ -1423,8 +1235,10 @@ async def test_concurrent_multi_unit_requests_with_sliding_window(
 
     async def simulate_stream() -> None:
         await asyncio.sleep(0.01)
-        # Send noise, then response 2, noise, then response 1
-        protocol.data_received(b"\xff\xaa" + resp2_frame + b"\xee" + resp1_frame)
+        # Send noise, then response 1, noise, then response 2
+        protocol.data_received(b"\xff\xaa" + resp1_frame)
+        await asyncio.sleep(0.01)
+        protocol.data_received(b"\xee" + resp2_frame)
 
     task1 = asyncio.create_task(protocol.send_and_receive(unit_id_1, pdu1))
     task2 = asyncio.create_task(protocol.send_and_receive(unit_id_2, pdu2))
@@ -1437,26 +1251,62 @@ async def test_concurrent_multi_unit_requests_with_sliding_window(
     assert res2 == ("decoded", b"\x03\x0b")
 
 
-async def test_fail_pending_requests_with_errors_branches(mock_transport: MagicMock) -> None:
-    """Test branch conditions in _fail_pending_requests_with_errors."""
+async def test_data_received_fails_pending_request_on_stream_error_when_buffer_exhausted(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that data_received sets exception on _pending_request when CRC or framing errors occur."""
     protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
     protocol.connection_made(mock_transport)
 
-    # 1. When buffer length >= MIN_RTU_RESPONSE_LENGTH, it should return early
-    protocol._buffer = bytearray(b"\x01\x03\x00\x00")
-    protocol._fail_pending_requests_with_errors({1: ValueError("err")})
-
-    # 2. When uid is in buffer, it skips failing the future to wait for rest of frame
-    protocol._buffer = bytearray(b"\x01\x03")
+    pdu = _DummyPDU()
+    unit_id = 1
     fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = _PendingRequest(future=fut)
-    protocol._fail_pending_requests_with_errors({1: ValueError("err")})
-    assert not fut.done()
+    protocol._pending_request = _PendingRequest(unit_id=unit_id, future=fut, pdu=pdu)
 
-    # 3. When pending future is not in pending_requests or is already done
-    protocol._buffer = bytearray(b"")
-    fut.set_result(None)  # already done
-    protocol._fail_pending_requests_with_errors({1: ValueError("err"), 2: ValueError("missing")})
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+
+    # Frame with corrupt CRC followed by no more data for unit_id
+    bad_frame = bytes([unit_id, 0x03, 0x00, 0xFF, 0xFF])
+    protocol.data_received(bad_frame)
+
+    assert fut.done()
+    with pytest.raises(CRCError):
+        fut.result()
+
+
+async def test_data_received_stream_error_keeps_pending_when_unit_id_in_buffer(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that data_received does not fail pending request if unit_id is still in buffer."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+    unit_id = 1
+    fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+    protocol._pending_request = _PendingRequest(unit_id=unit_id, future=fut, pdu=pdu)
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+
+    # Corrupt frame followed by 2 bytes starting with unit_id: b"\x01\x03"
+    bad_frame = bytes([unit_id, 0x03, 0x00, 0xFF, 0xFF])
+    protocol.data_received(bad_frame + bytes([unit_id, 0x03]))
+
+    # Because unit_id 1 is in remaining buffer, future is not failed yet (waits for rest of frame)
+    assert not fut.done()
+    assert protocol._buffer == bytearray(b"\x01\x03")
 
 
 async def test_request_aware_framing_rejects_mismatched_function_code(
@@ -1592,7 +1442,8 @@ async def test_send_and_receive_defensive_function_code_validation(
     async def complete_with_mismatch() -> None:
         await asyncio.sleep(0.01)
         # Directly resolve future with mismatched FC (0x04)
-        pending = protocol._pending_requests[unit_id]
+        assert protocol._pending_request is not None
+        pending = protocol._pending_request
         pending.future.set_result(_ModbusRtuMessage(unit_id=unit_id, pdu_bytes=b"\x04\x00", crc=b"\x00\x00"))
 
     task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
@@ -1780,7 +1631,8 @@ async def test_delayed_response_arriving_during_active_request_different_fc(
         # Deliver late response for request 1 first
         protocol.data_received(delayed_response_1)
         # Active request should still be pending and not failed
-        assert not protocol._pending_requests[unit_id].future.done()
+        assert protocol._pending_request is not None
+        assert not protocol._pending_request.future.done()
         assert unit_id not in protocol._timed_out_requests
 
         # Now deliver real response for request 2
@@ -1885,7 +1737,8 @@ async def test_delayed_exception_response_arriving_during_active_request(
         # Deliver late exception response for request 1
         protocol.data_received(delayed_exc_response)
         # Active request should still be pending (not failed by the delayed exception!)
-        assert not protocol._pending_requests[unit_id].future.done()
+        assert protocol._pending_request is not None
+        assert not protocol._pending_request.future.done()
         assert unit_id not in protocol._timed_out_requests
 
         # Now deliver real response for request 2
@@ -1958,14 +1811,16 @@ async def test_delayed_response_in_chunks_during_active_request(
         protocol.data_received(delayed_response_1[:4])
         # Buffer has 4 bytes (>= MIN_RTU_RESPONSE_LENGTH), protocol determines frame length is 6 and waits
         assert len(protocol._buffer) == 4
-        assert not protocol._pending_requests[unit_id].future.done()
+        assert protocol._pending_request is not None
+        assert not protocol._pending_request.future.done()
         assert unit_id in protocol._timed_out_requests
 
         # Deliver chunk 2 of late response (remaining 2 bytes)
         protocol.data_received(delayed_response_1[4:])
         # Now late response is complete and drained
         assert len(protocol._buffer) == 0
-        assert not protocol._pending_requests[unit_id].future.done()
+        assert protocol._pending_request is not None
+        assert not protocol._pending_request.future.done()
         assert unit_id not in protocol._timed_out_requests
 
         # Now deliver real response for request 2
@@ -1979,4 +1834,37 @@ async def test_delayed_response_in_chunks_during_active_request(
     await deliv_task
 
     assert result == ("decoded", b"\x06\x11\x22")
+    assert len(protocol._buffer) == 0
+
+
+async def test_data_received_falls_back_to_pending_request_pdu_when_future_done(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that data_received uses _pending_request.pdu if future is done but _timed_out_requests not yet set."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+    pdu.function_code = 0x03
+    unit_id = 1
+
+    # Simulate future cancelled/done by asyncio.wait_for timeout before send_and_receive cleans up
+    fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+    fut.cancel()
+    protocol._pending_request = _PendingRequest(unit_id=unit_id, future=fut, pdu=pdu)
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+
+    # Response arrives for the timed-out request
+    resp_payload = bytes([unit_id, pdu.function_code, 0x55])
+    response = resp_payload + calculate_crc16(resp_payload)
+
+    # When data_received processes this, it falls back to _pending_request.pdu and cleanly drains it
+    protocol.data_received(response)
     assert len(protocol._buffer) == 0

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -1308,3 +1308,148 @@ async def test_wait_on_pending_request_timeout_waiting(caplog: pytest.LogCapture
 
         # Should have logged timeout
         assert any("timed out" in record.message for record in caplog.records)
+
+
+async def test_sliding_window_recovers_when_noise_matches_unit_id(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a stray noise byte matching unit_id slides forward and recovers the valid frame."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()  # FC 0x03
+    unit_id = 1
+    response_data = b"\x05"
+    correct_payload = bytes([unit_id, pdu.function_code]) + response_data
+    correct_response = correct_payload + calculate_crc16(correct_payload)
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    # Stream contains: 1 noise byte matching unit_id (0x01), followed by the valid response frame
+    corrupt_stream = bytes([unit_id, 0x01]) + correct_response
+
+    async def simulate_stream() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(corrupt_stream)
+
+    result_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    response_task = asyncio.create_task(simulate_stream())
+
+    result = await result_task
+    await response_task
+
+    assert result[0] == "decoded"
+
+
+async def test_sliding_window_recovers_when_candidate_fails_crc(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that if a candidate frame fails CRC, sliding window recovers a subsequent valid frame."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+    unit_id = 1
+    response_data = b"\x05"
+
+    # Candidate 1: has bad CRC
+    bad_payload = bytes([unit_id, pdu.function_code]) + response_data
+    bad_frame = bad_payload + b"\xff\xff"
+
+    # Candidate 2: valid frame
+    good_payload = bytes([unit_id, pdu.function_code]) + response_data
+    good_frame = good_payload + calculate_crc16(good_payload)
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    async def simulate_stream() -> None:
+        await asyncio.sleep(0.01)
+        # Send bad frame followed immediately by good frame
+        protocol.data_received(bad_frame + good_frame)
+
+    result_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    response_task = asyncio.create_task(simulate_stream())
+
+    result = await result_task
+    await response_task
+
+    assert result[0] == "decoded"
+
+
+async def test_concurrent_multi_unit_requests_with_sliding_window(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test concurrent requests to different unit IDs with interleaved noise bytes."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu1 = _DummyPDU()
+    unit_id_1 = 1
+    pdu2 = _DummyPDU()
+    unit_id_2 = 2
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    resp1 = bytes([unit_id_1, pdu1.function_code, 0x0A])
+    resp1_frame = resp1 + calculate_crc16(resp1)
+
+    resp2 = bytes([unit_id_2, pdu2.function_code, 0x0B])
+    resp2_frame = resp2 + calculate_crc16(resp2)
+
+    async def simulate_stream() -> None:
+        await asyncio.sleep(0.01)
+        # Send noise, then response 2, noise, then response 1
+        protocol.data_received(b"\xff\xaa" + resp2_frame + b"\xee" + resp1_frame)
+
+    task1 = asyncio.create_task(protocol.send_and_receive(unit_id_1, pdu1))
+    task2 = asyncio.create_task(protocol.send_and_receive(unit_id_2, pdu2))
+    stream_task = asyncio.create_task(simulate_stream())
+
+    res1, res2 = await asyncio.gather(task1, task2)
+    await stream_task
+
+    assert res1 == ("decoded", b"\x03\x0a")
+    assert res2 == ("decoded", b"\x03\x0b")
+
+
+async def test_fail_pending_requests_with_errors_branches(mock_transport: MagicMock) -> None:
+    """Test branch conditions in _fail_pending_requests_with_errors."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    # 1. When buffer length >= MIN_RTU_RESPONSE_LENGTH, it should return early
+    protocol._buffer = bytearray(b"\x01\x03\x00\x00")
+    protocol._fail_pending_requests_with_errors({1: ValueError("err")})
+
+    # 2. When uid is in buffer, it skips failing the future to wait for rest of frame
+    protocol._buffer = bytearray(b"\x01\x03")
+    fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+    protocol._pending_requests[1] = fut
+    protocol._fail_pending_requests_with_errors({1: ValueError("err")})
+    assert not fut.done()
+
+    # 3. When pending future is not in pending_requests or is already done
+    protocol._buffer = bytearray(b"")
+    fut.set_result(None)  # already done
+    protocol._fail_pending_requests_with_errors({1: ValueError("err"), 2: ValueError("missing")})

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -12,6 +12,7 @@ import pytest
 import serialx
 from tmodbus.exceptions import (
     CRCError,
+    FunctionCodeError,
     IllegalFunctionError,
     InvalidResponseError,
     ModbusConnectionError,
@@ -23,6 +24,7 @@ from tmodbus.transport.async_rtu import (
     AsyncRtuTransport,
     ModbusRtuProtocol,
     _ModbusRtuMessage,
+    _PendingRequest,
     compute_interframe_delay,
     compute_max_continuous_transmission_delay,
 )
@@ -348,7 +350,7 @@ async def test_send_and_receive_unsupported_function_code(
     result_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
     response_task = asyncio.create_task(simulate_response())
 
-    with pytest.raises(RTUFrameError):
+    with pytest.raises(FunctionCodeError):
         await result_task
     await response_task
 
@@ -740,7 +742,7 @@ async def test_on_connection_lost_pending_futures(mock_serial_connection: tuple[
     # add a future that is already done to _pending_requests to test that it is skipped
     done_future = asyncio.get_event_loop().create_future()
     done_future.set_result(None)
-    protocol._pending_requests[2] = done_future
+    protocol._pending_requests[2] = _PendingRequest(future=done_future)
 
     # Start a send_and_receive to create a pending future
     send_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
@@ -1010,7 +1012,7 @@ async def test_send_and_receive_previous_request_timeout(
 
     # Directly test the code path by mocking a pending future that will timeout
     mock_future: asyncio.Future[Any] = asyncio.Future()
-    protocol._pending_requests[unit_id] = mock_future
+    protocol._pending_requests[unit_id] = _PendingRequest(future=mock_future, pdu=pdu)
 
     # Now when we call send_and_receive, it should wait for the mock_future
     # which will timeout
@@ -1056,7 +1058,7 @@ async def test_send_and_receive_previous_request_failed(
 
     # Directly test the code path by mocking a pending future that has failed
     mock_future: asyncio.Future[Any] = asyncio.Future()
-    protocol._pending_requests[unit_id] = mock_future
+    protocol._pending_requests[unit_id] = _PendingRequest(future=mock_future, pdu=pdu)
 
     # Now when we call send_and_receive, it should wait for the mock_future
     # which will timeout
@@ -1212,7 +1214,7 @@ async def test_wait_on_pending_request_already_done() -> None:
     # Create a future that's already done
     done_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
     done_future.set_result(_ModbusRtuMessage(unit_id=1, pdu_bytes=b"\x03\x00", crc=b"\x00\x00"))
-    protocol._pending_requests[1] = done_future
+    protocol._pending_requests[1] = _PendingRequest(future=done_future)
 
     # Should return immediately when future is already done
     await protocol._wait_on_pending_request(1)
@@ -1225,7 +1227,7 @@ async def test_wait_on_pending_request_waits_for_completion(caplog: pytest.LogCa
 
     # Create a pending future
     pending_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = pending_future
+    protocol._pending_requests[1] = _PendingRequest(future=pending_future)
 
     # Set up a task to complete the future after a delay
     async def complete_future() -> None:
@@ -1250,7 +1252,7 @@ async def test_wait_on_pending_request_cancelled(caplog: pytest.LogCaptureFixtur
 
     # Create a pending future
     pending_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = pending_future
+    protocol._pending_requests[1] = _PendingRequest(future=pending_future)
 
     # Set up a task to cancel the future after a delay
     async def cancel_future() -> None:
@@ -1275,7 +1277,7 @@ async def test_wait_on_pending_request_generic_exception(caplog: pytest.LogCaptu
 
     # Create a pending future
     pending_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = pending_future
+    protocol._pending_requests[1] = _PendingRequest(future=pending_future)
 
     # Set up a task to fail the future after a delay
     async def fail_future() -> None:
@@ -1300,7 +1302,7 @@ async def test_wait_on_pending_request_timeout_waiting(caplog: pytest.LogCapture
 
     # Create a pending future that never completes
     pending_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = pending_future
+    protocol._pending_requests[1] = _PendingRequest(future=pending_future)
 
     # Should timeout and log it
     with caplog.at_level(logging.DEBUG, logger="tmodbus.transport.async_rtu"):
@@ -1445,7 +1447,7 @@ async def test_fail_pending_requests_with_errors_branches(mock_transport: MagicM
     # 2. When uid is in buffer, it skips failing the future to wait for rest of frame
     protocol._buffer = bytearray(b"\x01\x03")
     fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
-    protocol._pending_requests[1] = fut
+    protocol._pending_requests[1] = _PendingRequest(future=fut)
     protocol._fail_pending_requests_with_errors({1: ValueError("err")})
     assert not fut.done()
 
@@ -1453,3 +1455,147 @@ async def test_fail_pending_requests_with_errors_branches(mock_transport: MagicM
     protocol._buffer = bytearray(b"")
     fut.set_result(None)  # already done
     protocol._fail_pending_requests_with_errors({1: ValueError("err"), 2: ValueError("missing")})
+
+
+async def test_request_aware_framing_rejects_mismatched_function_code(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that request-aware framing detects mismatched function code, discards leading byte and recovers."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()  # FC 0x03
+    unit_id = 1
+    response_data = b"\x05"
+
+    # Mismatched reply with FC 0x04 (read input registers) instead of 0x03
+    bad_payload = bytes([unit_id, 0x04]) + response_data
+    bad_frame = bad_payload + calculate_crc16(bad_payload)
+
+    # Valid reply with FC 0x03
+    good_payload = bytes([unit_id, pdu.function_code]) + response_data
+    good_frame = good_payload + calculate_crc16(good_payload)
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    async def simulate_stream() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(bad_frame + good_frame)
+
+    result_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    response_task = asyncio.create_task(simulate_stream())
+
+    result = await result_task
+    await response_task
+
+    assert result[0] == "decoded"
+
+
+async def test_determine_expected_frame_length_subfunction_pdu(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test _determine_expected_frame_length with subfunction PDU and pending_pdu."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    class DummySubPDU(BaseClientPDU[tuple[str, bytes]]):
+        function_code = 0x08  # Diagnostics
+
+        def encode_request(self) -> bytes:
+            return b"\x08\x00\x00\x00\x00"
+
+        def decode_response(self, response: bytes) -> tuple[str, bytes]:
+            return ("decoded", response)
+
+        @classmethod
+        def get_expected_response_data_length(cls, _data: bytes) -> int | None:
+            return 2
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.is_function_code_for_subfunction_pdu", lambda fc: fc == 0x08)
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_subfunction_pdu_class", lambda _fc, _sfc: DummySubPDU)
+
+    pdu = DummySubPDU()
+    protocol._buffer = bytearray(b"\x01\x08\x00\x00")
+    # Less than 6 bytes for subfunction PDU returns None
+    assert protocol._determine_expected_frame_length(pdu) is None
+
+    # With >= 6 bytes returns length (1 + 1 + 2 + 2 = 6)
+    protocol._buffer = bytearray(b"\x01\x08\x00\x00\x00\x00")
+    assert protocol._determine_expected_frame_length(pdu) == 6
+
+
+async def test_determine_expected_frame_length_unknown_fc_without_pending_pdu(
+    mock_transport: MagicMock,
+) -> None:
+    """Test _determine_expected_frame_length raises RTUFrameError when FC is unknown and pending_pdu is None."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    protocol._buffer = bytearray(b"\x01\x65\x00\x00")
+    with pytest.raises(RTUFrameError, match=r"unsupported function code 0x65"):
+        protocol._determine_expected_frame_length(None)
+
+
+async def test_determine_expected_frame_length_custom_fc_with_pending_pdu(
+    mock_transport: MagicMock,
+) -> None:
+    """Test _determine_expected_frame_length uses type(pending_pdu) when FC is not in standard registry."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    class CustomPDU(BaseClientPDU[tuple[str, bytes]]):
+        function_code = 0x65  # Custom FC not in registry
+
+        def encode_request(self) -> bytes:
+            return b"\x65\x00"
+
+        def decode_response(self, response: bytes) -> tuple[str, bytes]:
+            return ("decoded", response)
+
+        @classmethod
+        def get_expected_response_data_length(cls, _data: bytes) -> int | None:
+            return 3
+
+    pdu = CustomPDU()
+    protocol._buffer = bytearray(b"\x01\x65\x00\x00\x00\x00\x00")
+    # 1 (unit) + 1 (fc) + 3 (data) + 2 (crc) = 7
+    assert protocol._determine_expected_frame_length(pdu) == 7
+
+
+def test_modbus_rtu_message_bytes_property() -> None:
+    """Test _ModbusRtuMessage bytes property returns full ADU."""
+    msg = _ModbusRtuMessage(unit_id=1, pdu_bytes=b"\x03\x02\x00\x01", crc=b"\x12\x34")
+    assert msg.bytes == b"\x01\x03\x02\x00\x01\x12\x34"
+
+
+async def test_send_and_receive_defensive_function_code_validation(
+    mock_transport: MagicMock,
+) -> None:
+    """Test defensive function code validation in send_and_receive when future returns mismatched FC."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()  # FC 0x03
+    unit_id = 1
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    async def complete_with_mismatch() -> None:
+        await asyncio.sleep(0.01)
+        # Directly resolve future with mismatched FC (0x04)
+        pending = protocol._pending_requests[unit_id]
+        pending.future.set_result(_ModbusRtuMessage(unit_id=unit_id, pdu_bytes=b"\x04\x00", crc=b"\x00\x00"))
+
+    task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    resolver = asyncio.create_task(complete_with_mismatch())
+
+    with pytest.raises(FunctionCodeError, match=r"Function code mismatch"):
+        await task
+    await resolver

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -748,8 +748,10 @@ async def test_on_connection_lost_pending_futures(mock_serial_connection: tuple[
     send_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
     await asyncio.sleep(0.01)  # Ensure the send_and_receive has started
     assert protocol._pending_requests[unit_id]
+    protocol._timed_out_requests[3] = pdu
     # Now simulate connection lost
     protocol.connection_lost(None)
+    assert len(protocol._timed_out_requests) == 0
 
     with pytest.raises(ModbusConnectionError, match=r"Connection lost before response was received\."):
         await send_task
@@ -1599,3 +1601,382 @@ async def test_send_and_receive_defensive_function_code_validation(
     with pytest.raises(FunctionCodeError, match=r"Function code mismatch"):
         await task
     await resolver
+
+
+async def test_delayed_response_after_timeout_is_cleanly_discarded_using_old_pdu(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that when a request times out, a delayed response is framed and discarded using the old PDU."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+
+    pdu1 = _DummyPDU()
+    unit_id = 1
+    response_data = b"\x05"
+    delayed_payload = bytes([unit_id, pdu1.function_code]) + response_data
+    delayed_response = delayed_payload + calculate_crc16(delayed_payload)
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    # Step 1: Send request 1, which times out because no response arrived in time
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu1)
+
+    # Verify that the timed out PDU is preserved
+    assert protocol._timed_out_requests[unit_id] is pdu1
+
+    # Step 2: Now the delayed response arrives. It should be framed and discarded cleanly.
+    protocol.data_received(delayed_response)
+
+    # Buffer should be completely empty (not containing orphan fragments)
+    assert len(protocol._buffer) == 0
+    assert unit_id not in protocol._timed_out_requests
+
+    # Step 3: Subsequent request should work cleanly without any stale interference
+    pdu2 = _DummyPDU()
+    new_payload = bytes([unit_id, pdu2.function_code, 0x09])
+    new_response = new_payload + calculate_crc16(new_payload)
+
+    async def simulate_new_response() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(new_response)
+
+    task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
+    resp_task = asyncio.create_task(simulate_new_response())
+
+    result = await task
+    await resp_task
+
+    assert result == ("decoded", b"\x03\x09")
+
+
+async def test_try_drain_timed_out_response_branches(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test branch conditions in _try_drain_timed_out_response."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+    unit_id = 1
+
+    # 1. When buffer is too short to determine length (< 2 bytes) -> returns True (wait)
+    protocol._buffer = bytearray(b"\x01")
+    assert protocol._try_drain_timed_out_response(unit_id, pdu) is True
+
+    # 2. When _determine_expected_frame_length raises error -> pops and discards leading byte
+    protocol._buffer = bytearray(b"\x01\x65\x00\x00")
+    protocol._timed_out_requests[unit_id] = pdu
+    assert protocol._try_drain_timed_out_response(unit_id, pdu) is False
+    assert unit_id not in protocol._timed_out_requests
+    assert protocol._buffer == bytearray(b"\x65\x00\x00")
+
+    # 3. When candidate frame has invalid CRC -> del buffer[0] and returns False
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+    protocol._buffer = bytearray(b"\x01\x03\x05\xff\xff")  # bad CRC
+    protocol._timed_out_requests[unit_id] = pdu
+    assert protocol._try_drain_timed_out_response(unit_id, pdu) is False
+    assert protocol._buffer == bytearray(b"\x03\x05\xff\xff")  # Leading 0x01 was deleted
+
+
+async def test_delayed_response_drained_in_chunks(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a delayed response arriving in chunks waits for complete frame and drains it."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+    unit_id = 1
+    protocol._timed_out_requests[unit_id] = pdu
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 2
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+
+    payload = bytes([unit_id, pdu.function_code, 0x00, 0x00])
+    frame = payload + calculate_crc16(payload)
+
+    # Chunk 1: first 4 bytes of 6-byte frame -> waits for full frame
+    protocol.data_received(frame[:4])
+    assert len(protocol._buffer) == 4
+    assert unit_id in protocol._timed_out_requests
+
+    # Chunk 2: remaining 2 bytes -> frame completes, CRC passes, buffer drained
+    protocol.data_received(frame[4:])
+    assert len(protocol._buffer) == 0
+    assert unit_id not in protocol._timed_out_requests
+
+
+async def test_delayed_response_arriving_during_active_request_different_fc(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that when delayed response arrives during active request with different FC, it is drained."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+
+    pdu1 = _DummyPDU()
+    pdu1.function_code = 0x03
+
+    pdu2 = _DummyPDU()
+    pdu2.function_code = 0x06
+
+    unit_id = 1
+
+    class DummyPduClass3:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    class DummyPduClass6:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 2
+
+    def mock_get_pdu_class(fc: int) -> type:
+        if fc == 0x03:
+            return DummyPduClass3
+        if fc == 0x06:
+            return DummyPduClass6
+        msg = f"Unknown FC {fc}"
+        raise ValueError(msg)
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", mock_get_pdu_class)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    # Step 1: Request 1 times out
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu1)
+
+    assert protocol._timed_out_requests[unit_id] is pdu1
+
+    # Step 2: Request 2 is dispatched (FC 0x06) and is active
+    delayed_payload_1 = bytes([unit_id, 0x03, 0xAA])
+    delayed_response_1 = delayed_payload_1 + calculate_crc16(delayed_payload_1)
+
+    resp_payload_2 = bytes([unit_id, 0x06, 0x11, 0x22])
+    response_2 = resp_payload_2 + calculate_crc16(resp_payload_2)
+
+    async def deliver_delayed_then_real_response() -> None:
+        await asyncio.sleep(0.01)
+        # Deliver late response for request 1 first
+        protocol.data_received(delayed_response_1)
+        # Active request should still be pending and not failed
+        assert not protocol._pending_requests[unit_id].future.done()
+        assert unit_id not in protocol._timed_out_requests
+
+        # Now deliver real response for request 2
+        await asyncio.sleep(0.01)
+        protocol.data_received(response_2)
+
+    req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
+    deliv_task = asyncio.create_task(deliver_delayed_then_real_response())
+
+    result = await req2_task
+    await deliv_task
+
+    assert result == ("decoded", b"\x06\x11\x22")
+    assert len(protocol._buffer) == 0
+
+
+async def test_active_request_succeeds_and_clears_stale_timed_out_request(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a successful response to an active request clears stale timed-out tracking."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+
+    pdu1 = _DummyPDU()
+    pdu2 = _DummyPDU()
+    unit_id = 1
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    # Request 1 times out
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu1)
+
+    assert protocol._timed_out_requests[unit_id] is pdu1
+
+    # Request 2 is sent, and its response arrives directly
+    resp_payload = bytes([unit_id, pdu2.function_code, 0x55])
+    response = resp_payload + calculate_crc16(resp_payload)
+
+    async def deliver_response() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(response)
+
+    req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
+    deliv_task = asyncio.create_task(deliver_response())
+
+    result = await req2_task
+    await deliv_task
+
+    assert result == ("decoded", b"\x03\x55")
+    # Verify stale timed-out request tracking was cleared upon successful delivery
+    assert unit_id not in protocol._timed_out_requests
+
+
+async def test_delayed_exception_response_arriving_during_active_request(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that when delayed exception arrives during active request, it is cleanly drained."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+
+    pdu1 = _DummyPDU()
+    pdu1.function_code = 0x03
+
+    pdu2 = _DummyPDU()
+    pdu2.function_code = 0x06
+
+    unit_id = 1
+
+    class DummyPduClass6:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 2
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass6)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    # Step 1: Request 1 (FC 0x03) times out
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu1)
+
+    assert protocol._timed_out_requests[unit_id] is pdu1
+
+    # Step 2: Request 2 (FC 0x06) is sent and active
+    # Late response for Request 1 is an Exception Response (FC 0x83, Exception Code 0x02)
+    delayed_exc_payload = bytes([unit_id, 0x83, 0x02])
+    delayed_exc_response = delayed_exc_payload + calculate_crc16(delayed_exc_payload)
+
+    resp_payload_2 = bytes([unit_id, 0x06, 0x11, 0x22])
+    response_2 = resp_payload_2 + calculate_crc16(resp_payload_2)
+
+    async def deliver_delayed_exc_then_real_response() -> None:
+        await asyncio.sleep(0.01)
+        # Deliver late exception response for request 1
+        protocol.data_received(delayed_exc_response)
+        # Active request should still be pending (not failed by the delayed exception!)
+        assert not protocol._pending_requests[unit_id].future.done()
+        assert unit_id not in protocol._timed_out_requests
+
+        # Now deliver real response for request 2
+        await asyncio.sleep(0.01)
+        protocol.data_received(response_2)
+
+    req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
+    deliv_task = asyncio.create_task(deliver_delayed_exc_then_real_response())
+
+    result = await req2_task
+    await deliv_task
+
+    assert result == ("decoded", b"\x06\x11\x22")
+    assert len(protocol._buffer) == 0
+
+
+async def test_delayed_response_in_chunks_during_active_request(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a delayed response arriving in chunks while a new request is active is waited on and drained."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+
+    pdu1 = _DummyPDU()
+    pdu1.function_code = 0x03
+
+    pdu2 = _DummyPDU()
+    pdu2.function_code = 0x06
+
+    unit_id = 1
+
+    class DummyPduClass3:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 2
+
+    class DummyPduClass6:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 2
+
+    def mock_get_pdu_class(fc: int) -> type:
+        if fc == 0x03:
+            return DummyPduClass3
+        if fc == 0x06:
+            return DummyPduClass6
+        msg = f"Unknown FC {fc}"
+        raise ValueError(msg)
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", mock_get_pdu_class)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    # Step 1: Request 1 (FC 0x03) times out
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu1)
+
+    assert protocol._timed_out_requests[unit_id] is pdu1
+
+    # Step 2: Request 2 (FC 0x06) is sent and active
+    delayed_payload_1 = bytes([unit_id, 0x03, 0xAA, 0xBB])
+    delayed_response_1 = delayed_payload_1 + calculate_crc16(delayed_payload_1)  # 6 bytes
+
+    resp_payload_2 = bytes([unit_id, 0x06, 0x11, 0x22])
+    response_2 = resp_payload_2 + calculate_crc16(resp_payload_2)
+
+    async def deliver_chunks_then_real_response() -> None:
+        await asyncio.sleep(0.01)
+        # Deliver chunk 1 of late response (first 4 bytes of 6-byte frame)
+        protocol.data_received(delayed_response_1[:4])
+        # Buffer has 4 bytes (>= MIN_RTU_RESPONSE_LENGTH), protocol determines frame length is 6 and waits
+        assert len(protocol._buffer) == 4
+        assert not protocol._pending_requests[unit_id].future.done()
+        assert unit_id in protocol._timed_out_requests
+
+        # Deliver chunk 2 of late response (remaining 2 bytes)
+        protocol.data_received(delayed_response_1[4:])
+        # Now late response is complete and drained
+        assert len(protocol._buffer) == 0
+        assert not protocol._pending_requests[unit_id].future.done()
+        assert unit_id not in protocol._timed_out_requests
+
+        # Now deliver real response for request 2
+        await asyncio.sleep(0.01)
+        protocol.data_received(response_2)
+
+    req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
+    deliv_task = asyncio.create_task(deliver_chunks_then_real_response())
+
+    result = await req2_task
+    await deliv_task
+
+    assert result == ("decoded", b"\x06\x11\x22")
+    assert len(protocol._buffer) == 0


### PR DESCRIPTION
Hardens and streamlines the Async RTU and ASCII serial transport layers against stream noise, concurrency collisions, and delayed responses on half-duplex buses.

### Key Changes
- **Half-Duplex Bus Serialization**: Added `asyncio.Lock` to strictly serialize physical bus transactions and simplified in-flight request tracking across both RTU and ASCII clients.
- **Sliding-Window Resynchronization (RTU)**: Implemented sliding-window byte discard on corrupt CRC or framing errors to recover subsequent valid frames in noisy streams.
- **Request-Aware Framing (RTU)**: Integrated PDU-aware expected response length resolution into the stream parser.
- **Delayed Response Draining (RTU & ASCII)**: Added per-unit timed-out request tracking to cleanly drain delayed responses (normal and exception) without corrupting subsequent requests.