### PR TITLE
fix(server): import serialx lazily so tmodbus.server works without the async-serial extra

### DIFF
--- a/src/tmodbus/server/async_ascii.py
+++ b/src/tmodbus/server/async_ascii.py
@@ -6,8 +6,6 @@ import logging
 from functools import partial
 from typing import Any, Literal
 
-from serialx import open_serial_connection
-
 from tmodbus.const import BROADCAST_UNIT_ID, EXCEPTION_RESPONSE_BIT
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.lrc import calculate_lrc, validate_lrc
@@ -79,6 +77,15 @@ class AsyncAsciiServer(AsyncBaseServer):
 
     async def start(self) -> None:
         """Start the server using serialx's async connection."""
+        try:
+            from serialx import open_serial_connection  # noqa: PLC0415
+        except ImportError as e:
+            msg = (
+                "The 'serialx' package is required for AsyncAsciiServer."
+                " Install with 'pip install tmodbus[async-serial]'"
+            )
+            raise ImportError(msg) from e
+
         reader, writer = await open_serial_connection(url=self.port, baudrate=self.baudrate, **self.serial_kwargs)
         self._reader = reader
         self._writer = writer

--- a/src/tmodbus/server/async_rtu.py
+++ b/src/tmodbus/server/async_rtu.py
@@ -6,8 +6,6 @@ import logging
 from functools import partial
 from typing import Any, Literal
 
-from serialx import open_serial_connection
-
 from tmodbus.const import BROADCAST_UNIT_ID, EXCEPTION_RESPONSE_BIT
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.crc import calculate_crc16, validate_crc16
@@ -83,6 +81,14 @@ class AsyncRtuServer(AsyncBaseServer):
 
     async def start(self) -> None:
         """Start the server using serialx's async connection."""
+        try:
+            from serialx import open_serial_connection  # noqa: PLC0415
+        except ImportError as e:
+            msg = (
+                "The 'serialx' package is required for AsyncRtuServer. Install with 'pip install tmodbus[async-serial]'"
+            )
+            raise ImportError(msg) from e
+
         reader, writer = await open_serial_connection(url=self.port, baudrate=self.baudrate, **self.serial_kwargs)
         self._reader = reader
         self._writer = writer

--- a/tests/server/test_async_ascii.py
+++ b/tests/server/test_async_ascii.py
@@ -56,7 +56,7 @@ def patch_serial() -> Iterator[type[MockSerial]]:
         inst = MockSerial(url or "", baudrate=baudrate, **kwargs)
         return inst, inst
 
-    with patch("tmodbus.server.async_ascii.open_serial_connection", new=fake_open_serial_connection):
+    with patch("serialx.open_serial_connection", new=fake_open_serial_connection):
         yield MockSerial
 
 

--- a/tests/server/test_async_rtu.py
+++ b/tests/server/test_async_rtu.py
@@ -56,7 +56,7 @@ def patch_serial() -> Iterator[type[MockSerial]]:
         inst = MockSerial(url or "", baudrate=baudrate, **kwargs)
         return inst, inst
 
-    with patch("tmodbus.server.async_rtu.open_serial_connection", new=fake_open_serial_connection):
+    with patch("serialx.open_serial_connection", new=fake_open_serial_connection):
         yield MockSerial
 
 

--- a/tests/server/test_serialx_optional.py
+++ b/tests/server/test_serialx_optional.py
@@ -1,0 +1,35 @@
+"""Tests that tmodbus.server works without the optional serialx package."""
+
+import importlib
+import sys
+from collections.abc import Iterator
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def server_without_serialx() -> Iterator[ModuleType]:
+    """Reimport tmodbus.server with serialx blocked."""
+    with patch.dict(sys.modules):
+        for name in list(sys.modules):
+            if name == "serialx" or name.startswith(("serialx.", "tmodbus")):
+                del sys.modules[name]
+        sys.modules["serialx"] = None  # type: ignore[assignment]  # make `import serialx` fail
+        yield importlib.import_module("tmodbus.server")
+
+
+async def test_import_and_tcp_server_without_serialx(server_without_serialx: ModuleType) -> None:
+    """Importing tmodbus.server and using AsyncTcpServer works without serialx."""
+    server = server_without_serialx.AsyncTcpServer("localhost", server_without_serialx.ModbusRequestRouter(), port=0)
+    await server.start()
+    await server.stop()
+
+
+@pytest.mark.parametrize("class_name", ["AsyncRtuServer", "AsyncAsciiServer"])
+async def test_serial_server_start_without_serialx(server_without_serialx: ModuleType, class_name: str) -> None:
+    """Starting a serial server without serialx raises a helpful ImportError."""
+    server = getattr(server_without_serialx, class_name)("/dev/ttyUSB0", server_without_serialx.ModbusRequestRouter())
+    with pytest.raises(ImportError, match=r"pip install tmodbus\[async-serial\]"):
+        await server.start()


### PR DESCRIPTION
# Proposed Changes

`import tmodbus.server` currently fails with an ImportError on a plain `pip install tmodbus`, because `server/async_rtu.py` and `server/async_ascii.py` import `serialx` at module level and `server/__init__.py` imports both unconditionally. This breaks every documented example, such as `from tmodbus.server import AsyncTcpServer`, unless the optional `async-serial` extra is installed.

This PR moves the `serialx` import into `start()` of the RTU and ASCII servers, mirroring the lazy-import pattern already used by the client transports. Importing `tmodbus.server` and running TCP/UDP servers now works without `serialx`. Starting a serial server without it raises a clear ImportError that tells the user to run `pip install tmodbus[async-serial]`.

Tests cover both sides: `tmodbus.server` imports and an `AsyncTcpServer` starts and stops with `serialx` blocked, and starting `AsyncRtuServer` or `AsyncAsciiServer` without `serialx` raises the helpful error. The existing RTU/ASCII server test fixtures now patch `serialx.open_serial_connection` directly, matching the transport tests.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
