### PR TITLE
fix(pdu): return None from expected-length defaults on short data

### DIFF
--- a/src/tmodbus/pdu/base.py
+++ b/src/tmodbus/pdu/base.py
@@ -57,6 +57,8 @@ class BaseClientPDU[RT](ABC):
         # otherwise, we assume that the first byte of the PDU-part of the response denotes
         # the total length of the PDU.
         # If this is not the case (ex. for function code 0x18), the subclass should override this method.
+        if not data:
+            return None  # length byte not received yet
         return (
             1  # the first byte containing the total length of the PDU
             + data[0]
@@ -88,14 +90,14 @@ class BasePDU[RT](BaseClientPDU[RT]):
         """
 
     @classmethod
-    def get_expected_request_data_length(cls, data: bytes) -> int:
+    def get_expected_request_data_length(cls, data: bytes) -> int | None:
         """Get the expected number of bytes for the data part of the request PDU.
 
         This method should be implemented by subclasses to return the expected
         length of the request based on the specific PDU type.
 
         Returns:
-            Expected length of the request PDU in bytes
+            Expected length of the request PDU in bytes, or None if it cannot be determined yet.
 
         """
         # if a fixed length is defined for the request PDU, return it
@@ -105,6 +107,8 @@ class BasePDU[RT](BaseClientPDU[RT]):
         # otherwise, we assume that the first byte of the PDU-part of the response denotes
         # the total length of the PDU.
         # If this is not the case (ex. for function code 0x18), the subclass should override this method.
+        if not data:
+            return None  # length byte not received yet
         return (
             1  # the first byte containing the total length of the PDU
             + data[0]

--- a/src/tmodbus/server/async_rtu.py
+++ b/src/tmodbus/server/async_rtu.py
@@ -140,6 +140,9 @@ class AsyncRtuServer(AsyncBaseServer):
         else:
             return None
 
+        if expected_data_len is None:
+            return None
+
         expected_total_len = 1 + 1 + expected_data_len + 2  # unit_id + fc + data + crc
         if expected_total_len > MAX_RTU_FRAME_SIZE:
             msg = f"Expected frame size too large: {expected_total_len}"

--- a/src/tmodbus/server/async_rtu_over_tcp.py
+++ b/src/tmodbus/server/async_rtu_over_tcp.py
@@ -122,6 +122,9 @@ class AsyncRtuOverTcpServer(AsyncBaseServer):
         else:
             return None
 
+        if expected_data_len is None:
+            return None
+
         expected_total_len = 1 + 1 + expected_data_len + 2  # unit_id + fc + data + crc
         if expected_total_len > MAX_RTU_FRAME_SIZE:
             msg = f"Expected frame size too large: {expected_total_len}"

--- a/tests/pdu/test_base.py
+++ b/tests/pdu/test_base.py
@@ -45,6 +45,21 @@ class TestBaseClientPDU:
         # First byte is 0x05 (5), so expected length is 1 + 5 = 6
         assert TestPDU.get_expected_response_data_length(b"\x05") == 6
 
+    def test_get_expected_response_data_length_without_data(self) -> None:
+        """Test get_expected_response_data_length returns None when the length byte is missing."""
+
+        class TestPDU(BaseClientPDU[int]):
+            function_code = 0x01
+
+            def encode_request(self) -> bytes:
+                return b""
+
+            def decode_response(self, _response: bytes) -> int:
+                return 0
+
+        # The length byte has not been received yet, so the length cannot be determined
+        assert TestPDU.get_expected_response_data_length(b"") is None
+
 
 class TestBasePDU:
     """Tests for BasePDU."""
@@ -138,6 +153,28 @@ class TestBasePDU:
         assert TestPDU.get_expected_request_data_length(b"\x0a") == 11
         # First byte is 0x03 (3), so expected length is 1 + 3 = 4
         assert TestPDU.get_expected_request_data_length(b"\x03") == 4
+
+    def test_get_expected_request_data_length_without_data(self) -> None:
+        """Test get_expected_request_data_length returns None when the length byte is missing."""
+
+        class TestPDU(BasePDU[int]):
+            function_code = 0x01
+
+            def encode_request(self) -> bytes:
+                return b""
+
+            def decode_response(self, _response: bytes) -> int:
+                return 0
+
+            @classmethod
+            def decode_request(cls, _request: bytes) -> "TestPDU":
+                return cls()
+
+            def encode_response(self, _value: int) -> bytes:
+                return b""
+
+        # The length byte has not been received yet, so the length cannot be determined
+        assert TestPDU.get_expected_request_data_length(b"") is None
 
 
 class TestBaseSubFunctionClientPDU:

--- a/tests/server/test_async_rtu.py
+++ b/tests/server/test_async_rtu.py
@@ -397,3 +397,23 @@ async def test_rtu_server_broadcast() -> None:
     assert len(mock_serial_inst.write_calls) == 0
 
     await server.stop()
+
+
+def test_rtu_server_parse_frame_length_expected_data_len_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that _parse_frame_length returns None when get_expected_request_data_length returns None."""
+    router = ModbusRequestRouter()
+    server = AsyncRtuServer(port="/dev/ttyUSB0", handler=router)
+
+    class DummyPdu:
+        @staticmethod
+        def get_expected_request_data_length(_data: bytes) -> int | None:
+            return None
+
+    monkeypatch.setattr(
+        "tmodbus.server.async_rtu.get_server_pdu_class_from_buffer",
+        lambda _: DummyPdu,
+    )
+    buffer = bytearray(b"\x01\x03\x00")
+    assert server._parse_frame_length(buffer) is None

--- a/tests/server/test_async_rtu_over_tcp.py
+++ b/tests/server/test_async_rtu_over_tcp.py
@@ -432,3 +432,23 @@ async def test_rtu_over_tcp_server_configurable_exception_code() -> None:
 
     finally:
         await server.stop()
+
+
+def test_rtu_over_tcp_server_parse_frame_length_expected_data_len_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that _parse_frame_length returns None when get_expected_request_data_length returns None."""
+    router = ModbusRequestRouter()
+    server = AsyncRtuOverTcpServer(host="127.0.0.1", port=0, handler=router)
+
+    class DummyPdu:
+        @staticmethod
+        def get_expected_request_data_length(_data: bytes) -> int | None:
+            return None
+
+    monkeypatch.setattr(
+        "tmodbus.server.async_rtu_over_tcp.get_server_pdu_class_from_buffer",
+        lambda _: DummyPdu,
+    )
+    buffer = bytearray(b"\x01\x03\x00")
+    assert server._parse_frame_length(buffer) is None

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -235,6 +235,44 @@ async def test_send_and_receive_fifo_queue_framing(
     assert result == [0x01B8, 0x1234]
 
 
+async def test_send_and_receive_chunk_ends_after_function_code(
+    mock_transport: MagicMock,
+) -> None:
+    """Regression: a chunk ending right after the function code must not crash framing.
+
+    With only unit id + function code buffered there is no length byte yet, so the
+    default length logic must report None (wait for more data) instead of raising
+    IndexError inside data_received.
+    """
+    from tmodbus.pdu import ReadHoldingRegistersPDU  # noqa: PLC0415
+
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = ReadHoldingRegistersPDU(start_address=0, quantity=2)
+    unit_id = 1
+    # Response: byte count 0x04, register values 0x0102, 0x0304.
+    response_pdu = bytes.fromhex("03 04 0102 0304".replace(" ", ""))
+    payload = bytes([unit_id]) + response_pdu
+    response_adu = payload + calculate_crc16(payload)
+
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    async def simulate_response() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(response_adu[:2])  # exactly unit id + function code
+        await asyncio.sleep(0.01)
+        protocol.data_received(response_adu[2:])
+
+    result_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    response_task = asyncio.create_task(simulate_response())
+
+    result = await result_task
+    await response_task
+
+    assert result == [0x0102, 0x0304]
+
+
 async def test_send_and_receive_exception_status_framing(
     mock_transport: MagicMock,
 ) -> None:
@@ -1044,6 +1082,17 @@ async def test_determine_expected_frame_length__too_short(
     protocol.connection_made(mock_transport)
 
     protocol._buffer.extend(b"\01")
+    assert protocol._determine_expected_frame_length() is None
+
+
+async def test_determine_expected_frame_length__no_data_after_function_code(
+    mock_transport: MagicMock,
+) -> None:
+    """Only unit id + function code buffered: the length byte is missing, so wait for more data."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    protocol._buffer.extend(bytes.fromhex("01 03"))
     assert protocol._determine_expected_frame_length() is None
 
 


### PR DESCRIPTION
# Proposed Changes

The default `BaseClientPDU.get_expected_response_data_length` documents that it returns `None` when the expected length cannot be determined yet. In practice it raised `IndexError` on empty input, because it read `data[0]` without checking that the length byte had arrived. `ReadCoilsPDU.get_expected_response_data_length(b"")` reproduces it, and every PDU that relies on the default is affected (ReadCoils, ReadDiscreteInputs, ReadHolding/InputRegisters, ReadWriteMultipleRegisters, Read/WriteFileRecord, ReportServerId). The subclasses that override the default (`ReadFifoQueuePDU`, `ReadDeviceIdentificationPDU`) already return `None` correctly.

This matters for framing: the RTU client protocol's `_determine_expected_frame_length` guards only `len(buffer) < 2` before calling the method with `buffer[2:]`, so a buffer holding exactly unit id + function code hands the default an empty byte string, and the framing loop only catches `RTUFrameError`/`FunctionCodeError` — an `IndexError` would escape `data_received`. Today the `data_received` loop's `MIN_RTU_RESPONSE_LENGTH` guard happens to shield that path, but the method breaks its own contract and crashes when called directly with a short buffer.

The fix makes the default return `None` when `data` is empty, matching the documented contract. The request-side default `get_expected_request_data_length` had the identical flaw, so it gets the identical fix; its return type widens to `int | None` and the two RTU server framers now treat `None` as "wait for more data", consistent with their existing short-buffer handling. Subclass overrides are untouched.

Tests cover the PDU-level contract (empty data returns `None` for both response and request defaults), the framing helper with a buffer holding exactly unit id + function code (previously `IndexError`), and end-to-end chunked delivery where an RTU response arrives split right after the function code.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
