### PR TITLE
fix(security): require cryptography>=47.0 for asn1.decode_der

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ Changelog = "https://github.com/wlcrs/tmodbus/releases"
 [project.optional-dependencies]
 
 async-serial = ["serialx"]
-security = ["cryptography>=38.0"]
+security = ["cryptography>=47.0"]
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/uv.lock
+++ b/uv.lock
@@ -1360,7 +1360,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cryptography", marker = "extra == 'security'", specifier = ">=38.0" },
+    { name = "cryptography", marker = "extra == 'security'", specifier = ">=47.0" },
     { name = "serialx", marker = "extra == 'async-serial'" },
     { name = "tenacity", specifier = ">=8.2.0,!=8.4.0" },
 ]


### PR DESCRIPTION
# Proposed Changes

Bump the `security` extra's minimum to `cryptography>=47.0`. `extract_modbus_role` in `src/tmodbus/server/security.py` imports `cryptography.hazmat.asn1` and calls `asn1.decode_der`, which was only added in cryptography 47.0.0. The previous pin (`>=38.0`) allowed versions where role extraction fails on every TLS connection: in 38–45 the `cryptography.hazmat.asn1` module does not exist, so the import raises and is re-raised with the misleading message that cryptography is not installed (even though it is); in 46.x the module exists but has no `decode_der`, producing an uncaught `AttributeError`. The pin now matches what the code actually requires. `uv.lock` is refreshed to match (the locked version, 49.0.0, already satisfies the new bound).

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
