### PR TITLE
fix(server): close the connection cleanly when TLS certificate parsing fails

### DIFF
--- a/src/tmodbus/server/async_tcp.py
+++ b/src/tmodbus/server/async_tcp.py
@@ -61,6 +61,7 @@ class AsyncTcpServer(AsyncBaseServer):
                       ▼
              handle_client()
                       │ (extracts client certificate from TLS peer cert, once per conn)
+                      ├───[ Cert/role parse failure ]─────────► [ Terminate Connection ]
                       │ (reads 7-byte MBAP header)
                       ├───[ IncompleteReadError ]─────────────► [ Terminate Connection ]
                       ▼
@@ -244,20 +245,25 @@ class AsyncTcpServer(AsyncBaseServer):
         addr = writer.get_extra_info("peername")
         logger.info("Client connected: %s", addr)
 
-        # Extract TLS client certificate once per connection (R-30).
-        # Returns None for plain TCP connections or if the client sent no cert.
-        client_cert = extract_client_cert(writer)
-        if client_cert is not None:
-            role = extract_modbus_role(client_cert)
-            logger.debug(
-                "TLS client cert: subject=%s role=%s",
-                client_cert.subject.rfc4514_string(),
-                role,
-            )
-
-        context = RequestContext(peer_addr=addr, client_cert=client_cert)
-
         try:
+            # Extract TLS client certificate once per connection (R-30).
+            # Returns None for plain TCP connections or if the client sent no cert.
+            # Kept inside the try so a parse failure cannot leak the socket.
+            try:
+                client_cert = extract_client_cert(writer)
+                if client_cert is not None:
+                    role = extract_modbus_role(client_cert)
+                    logger.debug(
+                        "TLS client cert: subject=%s role=%s",
+                        client_cert.subject.rfc4514_string(),
+                        role,
+                    )
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Could not process TLS client certificate from %s, closing connection: %s", addr, e)
+                return
+
+            context = RequestContext(peer_addr=addr, client_cert=client_cert)
+
             while await self._handle_single_request(reader, writer, addr, context):
                 pass
         except asyncio.IncompleteReadError:

--- a/src/tmodbus/server/security.py
+++ b/src/tmodbus/server/security.py
@@ -72,6 +72,9 @@ MODBUS_ROLE_OID: str = "1.3.6.1.4.1.50316.802.1"
 #: Standard IANA port number for Modbus/TCP Security (mbaps).
 MODBUS_SECURITY_PORT: int = 802
 
+#: DER content bytes of :data:`MODBUS_ROLE_OID` (base-128 encoded arcs).
+_MODBUS_ROLE_OID_DER: bytes = bytes.fromhex("2b0601040183890c862201")
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers and extraction
@@ -115,6 +118,45 @@ def extract_client_cert(writer: asyncio.StreamWriter) -> x509.Certificate | None
     return x509.load_der_x509_certificate(der_cert)
 
 
+def _read_der_tlv(data: bytes, pos: int) -> tuple[int, bytes, int]:
+    """Read one DER TLV at *pos*; return (tag, value, position after the TLV)."""
+    tag = data[pos]
+    length = data[pos + 1]
+    pos += 2
+    if length & 0x80:
+        num_len_bytes = length & 0x7F
+        length = int.from_bytes(data[pos : pos + num_len_bytes], "big")
+        pos += num_len_bytes
+    return tag, data[pos : pos + length], pos + length
+
+
+def _first_role_extension_value(cert: x509.Certificate) -> bytes | None:
+    """Scan the TBSCertificate DER for the first Modbus role extension value.
+
+    Used when ``cert.extensions`` refuses to parse a certificate with
+    duplicate extensions; per R-65 the first occurrence wins.
+    """
+    _, tbs, _ = _read_der_tlv(cert.tbs_certificate_bytes, 0)
+    pos = 0
+    while pos < len(tbs):
+        tag, value, pos = _read_der_tlv(tbs, pos)
+        if tag != 0xA3:  # [3] EXPLICIT Extensions
+            continue
+        _, ext_list, _ = _read_der_tlv(value, 0)  # SEQUENCE OF Extension
+        ext_pos = 0
+        while ext_pos < len(ext_list):
+            _, ext, ext_pos = _read_der_tlv(ext_list, ext_pos)
+            oid_tag, oid, value_pos = _read_der_tlv(ext, 0)
+            if oid_tag != 0x06 or oid != _MODBUS_ROLE_OID_DER:  # OBJECT IDENTIFIER
+                continue
+            tag, ext_value, value_pos = _read_der_tlv(ext, value_pos)
+            if tag == 0x01:  # optional critical BOOLEAN
+                _, ext_value, _ = _read_der_tlv(ext, value_pos)
+            return ext_value  # OCTET STRING contents: the DER-encoded role
+        return None
+    return None
+
+
 def extract_modbus_role(cert: x509.Certificate) -> str | None:
     """Extract the Modbus role (OID ``1.3.6.1.4.1.50316.802.1``) from an x.509 certificate.
 
@@ -128,7 +170,8 @@ def extract_modbus_role(cert: x509.Certificate) -> str | None:
         cert: The client's parsed :class:`cryptography.x509.Certificate`.
 
     Returns:
-        The extracted role string, or ``None`` if not found.
+        The extracted role string, or ``None`` if not found or if the
+        extension value is not a valid DER UTF8String.
 
     """
     try:
@@ -142,12 +185,25 @@ def extract_modbus_role(cert: x509.Certificate) -> str | None:
         raise ImportError(msg) from e
 
     modbus_oid = x509.ObjectIdentifier(MODBUS_ROLE_OID)
+    raw_value: bytes | None
     try:
         role_ext = cert.extensions.get_extension_for_oid(modbus_oid)
+    except x509.ExtensionNotFound:
+        return None
+    except x509.DuplicateExtension:
+        # cryptography refuses to parse certificates with duplicate extensions;
+        # per R-65 use the first occurrence, found by scanning the raw DER.
+        raw_value = _first_role_extension_value(cert)
+        if raw_value is None:
+            return None
+    else:
         if isinstance(role_ext.value, x509.UnrecognizedExtension):
-            raw_value: bytes = role_ext.value.value
+            raw_value = role_ext.value.value
         else:
             raw_value = getattr(role_ext.value, "value", b"")
+
+    try:
         return asn1.decode_der(str, raw_value).strip()
-    except x509.ExtensionNotFound:
+    except ValueError:
+        logger.warning("Ignoring malformed Modbus role extension in client certificate")
         return None

--- a/tests/server/test_async_tcp_security.py
+++ b/tests/server/test_async_tcp_security.py
@@ -19,6 +19,7 @@ from tmodbus.server.handler import _handler_accepts_context
 from tmodbus.server.security import (
     MODBUS_ROLE_OID,
     MODBUS_SECURITY_PORT,
+    _first_role_extension_value,
     extract_client_cert,
     extract_modbus_role,
 )
@@ -36,7 +37,7 @@ try:
     from cryptography.hazmat import asn1
     from cryptography.hazmat.primitives import hashes, serialization
     from cryptography.hazmat.primitives.asymmetric import rsa
-    from cryptography.x509.oid import NameOID
+    from cryptography.x509.oid import ExtensionOID, NameOID
 
     CRYPTOGRAPHY_AVAILABLE = True
 except ImportError:
@@ -789,3 +790,87 @@ async def test_extract_modbus_role_cryptography_missing() -> None:
         pytest.raises(ImportError, match="The 'cryptography' package is required"),
     ):
         extract_modbus_role(mock_cert)
+
+
+def test_extract_modbus_role_duplicate_extension_critical() -> None:
+    """extract_modbus_role handles duplicate role extension when the first one is marked critical."""
+    key = _make_key()
+    ca_key = _make_key()
+    ca_cert = _make_ca_cert(ca_key)
+
+    role_bytes = b"Admin"
+    asn1_value = bytes([0x0C, len(role_bytes)]) + role_bytes
+
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "TestCritDup")]))
+        .issuer_name(ca_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(_NOW)
+        .not_valid_after(_NOW + _VALIDITY)
+    )
+    builder._extensions = [
+        x509.Extension(
+            oid=_MODBUS_OID,
+            critical=True,
+            value=x509.UnrecognizedExtension(_MODBUS_OID, asn1_value),
+        ),
+        x509.Extension(
+            oid=_MODBUS_OID,
+            critical=False,
+            value=x509.UnrecognizedExtension(_MODBUS_OID, b"\x0c\x04User"),
+        ),
+    ]
+    cert = builder.sign(ca_key, hashes.SHA256())
+    assert extract_modbus_role(cert) == "Admin"
+
+
+def test_extract_modbus_role_duplicate_non_modbus_extension() -> None:
+    """extract_modbus_role returns None when duplicate extensions exist but none are Modbus role."""
+    key = _make_key()
+    ca_key = _make_key()
+    ca_cert = _make_ca_cert(ca_key)
+
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "TestDupSAN")]))
+        .issuer_name(ca_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(_NOW)
+        .not_valid_after(_NOW + _VALIDITY)
+    )
+    builder._extensions = [
+        x509.Extension(
+            oid=ExtensionOID.SUBJECT_ALTERNATIVE_NAME,
+            critical=False,
+            value=x509.SubjectAlternativeName([x509.DNSName("example1.com")]),
+        ),
+        x509.Extension(
+            oid=ExtensionOID.SUBJECT_ALTERNATIVE_NAME,
+            critical=False,
+            value=x509.SubjectAlternativeName([x509.DNSName("example2.com")]),
+        ),
+    ]
+    cert = builder.sign(ca_key, hashes.SHA256())
+    assert extract_modbus_role(cert) is None
+
+
+def test_first_role_extension_value_no_extensions() -> None:
+    """_first_role_extension_value returns None when certificate has no extensions."""
+    key = _make_key()
+    ca_key = _make_key()
+    ca_cert = _make_ca_cert(ca_key)
+
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "TestNoExt")]))
+        .issuer_name(ca_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(_NOW)
+        .not_valid_after(_NOW + _VALIDITY)
+    )
+    cert = builder.sign(ca_key, hashes.SHA256())
+    assert _first_role_extension_value(cert) is None

--- a/tests/server/test_async_tcp_security.py
+++ b/tests/server/test_async_tcp_security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import datetime
 import ipaddress
 import ssl
@@ -86,6 +87,7 @@ def _make_end_cert(  # noqa: PLR0913, PLR0917
     cn: str,
     role: str | None = None,
     ips: list[str] | None = None,
+    raw_role_values: list[bytes] | None = None,
 ) -> x509.Certificate:
     """Create a CA-signed end-entity certificate, optionally with a Modbus role extension."""
     name = x509.Name(
@@ -121,6 +123,21 @@ def _make_end_cert(  # noqa: PLR0913, PLR0917
             critical=False,
         )
 
+    if raw_role_values:
+        # CertificateBuilder rejects duplicate extensions; inject them directly
+        # to simulate a non-compliant client certificate. (R-65)
+        builder._extensions = [
+            *builder._extensions,
+            *(
+                x509.Extension(
+                    oid=_MODBUS_OID,
+                    critical=False,
+                    value=x509.UnrecognizedExtension(_MODBUS_OID, value),
+                )
+                for value in raw_role_values
+            ),
+        ]
+
     return builder.sign(ca_key, hashes.SHA256())
 
 
@@ -155,6 +172,20 @@ def pki(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
     client_key = _make_key()
     client_cert_with_role = _make_end_cert(client_key, ca_cert, ca_key, "TestClient", role="Operator")
     client_cert_no_role = _make_end_cert(client_key, ca_cert, ca_key, "TestClientNoRole")
+    client_cert_dup_role = _make_end_cert(
+        client_key,
+        ca_cert,
+        ca_key,
+        "TestClientDupRole",
+        raw_role_values=[b"\x0c\x08Operator", b"\x0c\x08Observer"],
+    )
+    client_cert_bad_role = _make_end_cert(
+        client_key,
+        ca_cert,
+        ca_key,
+        "TestClientBadRole",
+        raw_role_values=[b"\x02\x01\x01"],  # INTEGER, not a UTF8String
+    )
 
     files: dict[str, Path] = {
         "ca_cert": tmp / "ca.crt",
@@ -162,6 +193,8 @@ def pki(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
         "server_key": tmp / "server.key",
         "client_cert_with_role": tmp / "client_role.crt",
         "client_cert_no_role": tmp / "client_norole.crt",
+        "client_cert_dup_role": tmp / "client_duprole.crt",
+        "client_cert_bad_role": tmp / "client_badrole.crt",
         "client_key": tmp / "client.key",
     }
     files["ca_cert"].write_bytes(_cert_to_pem(ca_cert))
@@ -169,6 +202,8 @@ def pki(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
     files["server_key"].write_bytes(_key_to_pem(server_key))
     files["client_cert_with_role"].write_bytes(_cert_to_pem(client_cert_with_role))
     files["client_cert_no_role"].write_bytes(_cert_to_pem(client_cert_no_role))
+    files["client_cert_dup_role"].write_bytes(_cert_to_pem(client_cert_dup_role))
+    files["client_cert_bad_role"].write_bytes(_cert_to_pem(client_cert_bad_role))
     files["client_key"].write_bytes(_key_to_pem(client_key))
 
     return files
@@ -435,6 +470,72 @@ async def test_tls_server_cert_no_role(
     assert extract_modbus_role(client_cert) is None
 
 
+async def test_tls_server_cert_duplicate_role_uses_first(
+    tls_server_with_rbac: tuple[AsyncTcpServer, list[RequestContext | None]],
+    pki: dict[str, Path],
+) -> None:
+    """Cert with duplicate role extensions is served; the first occurrence is used (R-65)."""
+    server, captured = tls_server_with_rbac
+
+    resp = await _send_read_holding_registers(
+        _port(server),
+        _make_client_ssl_ctx(pki, cert_key="client_cert_dup_role"),
+    )
+    assert resp == b"\x03\x02\x12\x34"
+
+    assert len(captured) == 1
+    context = captured[0]
+    assert context is not None
+    client_cert = context.client_cert
+    assert client_cert is not None
+    assert extract_modbus_role(client_cert) == "Operator"
+
+
+async def test_tls_server_cert_malformed_role_handled(
+    tls_server_with_rbac: tuple[AsyncTcpServer, list[RequestContext | None]],
+    pki: dict[str, Path],
+) -> None:
+    """Cert with a malformed DER role value is served with role=None, no unhandled exception."""
+    server, captured = tls_server_with_rbac
+
+    resp = await _send_read_holding_registers(
+        _port(server),
+        _make_client_ssl_ctx(pki, cert_key="client_cert_bad_role"),
+    )
+    assert resp == b"\x03\x02\x12\x34"
+
+    assert len(captured) == 1
+    context = captured[0]
+    assert context is not None
+    client_cert = context.client_cert
+    assert client_cert is not None
+    assert extract_modbus_role(client_cert) is None
+
+
+async def test_tls_server_cert_processing_failure_closes_connection(
+    tls_server: AsyncTcpServer,
+    pki: dict[str, Path],
+) -> None:
+    """An unexpected cert processing error closes the connection instead of leaking the socket."""
+    with patch(
+        "tmodbus.server.async_tcp.extract_modbus_role",
+        side_effect=ValueError("boom"),
+    ):
+        reader, writer = await asyncio.open_connection(
+            "127.0.0.1",
+            _port(tls_server),
+            ssl=_make_client_ssl_ctx(pki),
+        )
+        try:
+            # Server must close the connection without a response.
+            data = await asyncio.wait_for(reader.read(1), timeout=5)
+            assert data == b""
+        finally:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
+
 async def test_tls_server_rbac_reject(pki: dict[str, Path]) -> None:
     """Handler raises IllegalFunctionError when role is unauthorized (R-31)."""
     router = ModbusRequestRouter()
@@ -665,14 +766,19 @@ async def test_extract_modbus_role_not_found() -> None:
 
 
 async def test_extract_modbus_role_malformed_asn1() -> None:
-    """extract_modbus_role propagates ValueError when the OID extension is malformed."""
+    """extract_modbus_role returns None when the OID extension value is malformed."""
     mock_cert = MagicMock(spec=x509.Certificate)
     mock_ext = MagicMock()
     mock_ext.value.value = b"\x02\x01\x01"  # non-string tag to trigger ValueError in decode_der
     mock_cert.extensions.get_extension_for_oid.return_value = mock_ext
 
-    with pytest.raises(ValueError, match="error parsing asn1 value"):
-        extract_modbus_role(mock_cert)
+    assert extract_modbus_role(mock_cert) is None
+
+
+async def test_extract_modbus_role_duplicate_extension_uses_first(pki: dict[str, Path]) -> None:
+    """extract_modbus_role uses the first occurrence when the role OID is duplicated (R-65)."""
+    cert = x509.load_pem_x509_certificate(pki["client_cert_dup_role"].read_bytes())
+    assert extract_modbus_role(cert) == "Operator"
 
 
 async def test_extract_modbus_role_cryptography_missing() -> None:


### PR DESCRIPTION
# Proposed Changes

`AsyncTcpServer.handle_client` called `extract_client_cert` and `extract_modbus_role` before its `try`/`finally` block. Any exception during certificate or role parsing therefore skipped `writer.close()`: the socket leaked and the client never got a response. This is reachable with real inputs: a client certificate whose Modbus role extension contains malformed DER raises `ValueError` from `asn1.decode_der`, a certificate with duplicate role OID extensions raises `x509.DuplicateExtension`, and a TLS server with client certificates but without the `cryptography` package raises `ImportError` on every connection.

This PR moves the extraction inside the `try` with its own `except`: a parse failure now logs a warning and the connection is closed cleanly by the existing `finally`. The flow diagram in the class docstring gained the new error branch. `AsyncRtuOverTcpServer` was checked for the same pattern; it does no certificate extraction, so it needs no change.

`extract_modbus_role` is also brought in line with its docstring, which promises that per R-65 "only the first occurrence of the OID extension is used". The code used `cert.extensions.get_extension_for_oid`, but `cryptography` raises `DuplicateExtension` as soon as `cert.extensions` is accessed on a certificate with duplicated extensions — there is no library API that tolerates them. The function now catches `DuplicateExtension` and falls back to a small DER scan of the TBSCertificate to return the first role extension value; the normal single-extension path is unchanged. A malformed role value (not a valid DER UTF8String) now logs a warning and returns `None` instead of raising, so a hostile or broken certificate can no longer take down a handler that calls `extract_modbus_role` directly.

Tests cover the new behavior end to end: a client cert with duplicate role extensions is served and the first role wins, a cert with a malformed role value is served with role `None`, and an unexpected error during cert processing closes the connection without leaking the socket. The test PKI fixture gained certificates for both non-compliant cases (built by bypassing `CertificateBuilder`'s duplicate check, since it refuses to create such certs).

Deliberately not included: storing the extracted role on `RequestContext` so handlers do not need to call `extract_modbus_role` themselves. That is a small API addition and can be a follow-up.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
