### PR TITLE
fix(server): count only positional parameters when detecting context-aware handlers

### DIFF
--- a/src/tmodbus/server/handler.py
+++ b/src/tmodbus/server/handler.py
@@ -53,13 +53,19 @@ type RouterHandler = Callable[[int, Any], Awaitable[Any]]
 
 @functools.cache
 def _is_context_aware(fn: Any) -> bool:
-    """Return ``True`` if *fn* accepts at least three positional arguments."""
+    """Return ``True`` if *fn* can accept a third positional argument."""
     try:
         sig = inspect.signature(fn)
     except (ValueError, TypeError):
         return False
-    else:
-        return len(sig.parameters) >= 3
+    positional = 0
+    for param in sig.parameters.values():
+        if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD):
+            positional += 1
+        elif param.kind is param.VAR_POSITIONAL:
+            # *args can absorb the context argument
+            return True
+    return positional >= 3
 
 
 def _handler_accepts_context(fn: Any) -> TypeIs[ContextAwareModbusHandler]:

--- a/tests/server/test_handler.py
+++ b/tests/server/test_handler.py
@@ -227,6 +227,49 @@ async def test_router_ctx_parameter_name_passing() -> None:
     assert captured[0].peer_addr == ("127.0.0.1", 12345)
 
 
+async def test_router_keyword_only_param_not_context_aware() -> None:
+    """Test that a two-positional handler with an extra keyword-only parameter dispatches plainly."""
+    router = ModbusRequestRouter()
+
+    @router.register(ReadHoldingRegistersPDU)
+    async def handle_read(_unit_id: int, _request: ReadHoldingRegistersPDU, *, log: Any = None) -> list[int]:
+        _ = log
+        return [42]
+
+    req = ReadHoldingRegistersPDU(start_address=0, quantity=1)
+    assert await router(1, req) == [42]
+
+
+async def test_router_var_keyword_param_not_context_aware() -> None:
+    """Test that a two-positional handler with **kwargs dispatches plainly."""
+    router = ModbusRequestRouter()
+
+    @router.register(ReadHoldingRegistersPDU)
+    async def handle_read(_unit_id: int, _request: ReadHoldingRegistersPDU, **kwargs: Any) -> list[int]:
+        assert not kwargs
+        return [42]
+
+    req = ReadHoldingRegistersPDU(start_address=0, quantity=1)
+    assert await router(1, req) == [42]
+
+
+async def test_router_var_positional_is_context_aware() -> None:
+    """Test that a handler with *args receives the context as a positional argument."""
+    router = ModbusRequestRouter()
+    captured: list[RequestContext | None] = []
+
+    @router.register(ReadHoldingRegistersPDU)
+    async def handle_read(_unit_id: int, _request: ReadHoldingRegistersPDU, *args: Any) -> list[int]:
+        captured.append(args[0])
+        return [42]
+
+    ctx = RequestContext(peer_addr=("127.0.0.1", 12345))
+    req = ReadHoldingRegistersPDU(start_address=0, quantity=1)
+    await router(1, req, context=ctx)
+
+    assert captured == [ctx]
+
+
 def test_handler_supports_unit_id_plain() -> None:
     """Test handler_supports_unit_id with a plain function/callable."""
 


### PR DESCRIPTION
# Proposed Changes

`_is_context_aware` in `src/tmodbus/server/handler.py` decided whether a registered handler accepts a third `context` argument via `len(sig.parameters) >= 3`, which counts every parameter kind. A handler like `async def h(unit_id, request, *, log=None)` or `async def h(unit_id, request, **kwargs)` was misclassified as context-aware, got called with a third positional argument, and raised `TypeError` — which `handle_modbus_request` turned into a `SERVER_DEVICE_FAILURE` (0x83/0x04) exception response for every request, with no diagnostic pointing at the real cause.
The check now counts only parameters that can actually receive a positional argument (`POSITIONAL_ONLY` and `POSITIONAL_OR_KEYWORD`), and treats `*args` as context-aware since it can absorb the third argument. The `functools.cache` on the helper is unchanged.
Tests cover the two misclassified shapes dispatching as plain handlers and `*args` receiving the context; the existing context-passing tests keep covering the `(unit_id, request, context)` shape.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
