### PR TITLE
fix(utils): make OrderAwareStruct reordering consistent across all struct.Struct APIs

### DIFF
--- a/src/tmodbus/utils/order_aware_struct.py
+++ b/src/tmodbus/utils/order_aware_struct.py
@@ -50,6 +50,7 @@ Example:
 
 import re
 import struct
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
@@ -103,13 +104,33 @@ class OrderAwareStruct(struct.Struct):
         # Parse value lengths if we need to do any byte reordering
         # Only need transformation if not standard ABCD (word_order="big", byte_order="big")
         if word_order != "big" or byte_order != "big":
+            if not format or format[0] not in "<>!=":
+                # Native alignment would make the parsed value lengths disagree with the
+                # actual field layout, silently skipping the reordering.
+                msg = "word/byte reordering requires an explicit byte-order prefix ('<', '>', '!' or '=')"
+                raise ValueError(msg)
+
             self._value_lengths = OrderAwareStruct.parse_format_lengths(format)
+
+            # Reordering is applied per value, so every multi-byte value must map onto
+            # whole 16-bit registers. Otherwise the swap would smear bytes across values.
+            offset = 0
+            for length in self._value_lengths:
+                if length > 1 and (offset % 2 != 0 or length % 2 != 0):
+                    msg = (
+                        f"format {format!r} has a {length}-byte value at byte offset {offset}: "
+                        "multi-byte values must align to whole registers to apply word/byte reordering"
+                    )
+                    raise ValueError(msg)
+                offset += length
 
     @staticmethod
     def parse_format_lengths(format_str: str) -> list[int]:
         """Parse a struct format string and return a list of value lengths in bytes."""
-        # Remove byte order character if present
+        # Keep the byte order character: it selects standard vs native sizes
+        prefix = ""
         if format_str and format_str[0] in "@=<>!":
+            prefix = format_str[0]
             format_str = format_str[1:]
 
         # Regex to match format tokens (e.g., '2H', 'f', '10s')
@@ -121,44 +142,31 @@ class OrderAwareStruct(struct.Struct):
                 # 's' and 'p' are special cases: their count indicates the total size in bytes
                 lengths.append(count)
             else:
-                size = struct.calcsize(code)
+                size = struct.calcsize(prefix + code)
                 lengths.extend([size] * count)
 
         return lengths
 
     def _swap_word_order(self, data: "ReadableBuffer") -> bytes:
-        """Swap the word/byte order of the data based on word_order and byte_order settings."""
+        """Swap the word/byte order of each multi-register value based on the settings."""
         if not self._value_lengths:
             # ABCD byte order (standard), no need to swap
             return bytes(data)
 
-        # Apply byte order transformations
+        # Apply byte order transformation per value; single-register and sub-register
+        # values are never reordered. The constructor guarantees every multi-byte value
+        # is register-aligned.
         start_idx = 0
         swapped_data = bytearray(data)
 
-        current_length = 0
-
         for length in self._value_lengths:
-            current_length += length
-            if current_length % 2 != 0:
-                # we need an even number of bytes to swap registers
-                continue
-
-            if current_length == BYTES_PER_REGISTER:
-                # nothing to swap for single-register values
-                start_idx += current_length
-                current_length = 0
-                continue
-
-            # Apply byte order transformation for multi-register values
-            swapped_data[start_idx : start_idx + current_length] = self._apply_byte_order(
-                swapped_data[start_idx : start_idx + current_length],
-                word_order=self.word_order,
-                byte_order=self.byte_order,
-            )
-
-            start_idx += current_length
-            current_length = 0
+            if length > BYTES_PER_REGISTER:
+                swapped_data[start_idx : start_idx + length] = self._apply_byte_order(
+                    swapped_data[start_idx : start_idx + length],
+                    word_order=self.word_order,
+                    byte_order=self.byte_order,
+                )
+            start_idx += length
 
         return bytes(swapped_data)
 
@@ -233,11 +241,39 @@ class OrderAwareStruct(struct.Struct):
         region = memoryview(buffer)[offset : offset + self.size]
         return super().unpack(self._swap_word_order(region))
 
+    def iter_unpack(self, buffer: "ReadableBuffer") -> Iterator[tuple[Any, ...]]:
+        """Unpack each struct-sized chunk of buffer with word order consideration."""
+        if not self._value_lengths:
+            return super().iter_unpack(buffer)
+
+        view = memoryview(buffer)
+        if len(view) % self.size != 0:
+            msg = f"iterative unpacking requires a buffer of a multiple of {self.size} bytes"
+            raise struct.error(msg)
+
+        return (self.unpack(view[i : i + self.size]) for i in range(0, len(view), self.size))
+
     def pack(self, *args: Any) -> bytes:
         """Pack values into bytes with word order consideration."""
         return self._swap_word_order(super().pack(*args))
 
     def pack_into(self, buffer: "WriteableBuffer", offset: int, *args: Any) -> None:
         """Pack values into buffer with word order consideration."""
-        packed_data = self._swap_word_order(super().pack(*args))
-        buffer[offset : offset + len(packed_data)] = packed_data  # type: ignore[index]
+        view = memoryview(buffer)
+        # Mirror struct.Struct.pack_into: bounds-check instead of resizing the buffer,
+        # and resolve negative offsets from the buffer end.
+        if offset < 0:
+            if offset + self.size > 0:
+                msg = f"no space to pack {self.size} bytes at offset {offset}"
+                raise struct.error(msg)
+
+            if offset + len(view) < 0:
+                msg = f"offset {offset} out of range for {len(view)}-byte buffer"
+                raise struct.error(msg)
+
+            offset += len(view)
+        elif offset + self.size > len(view):
+            msg = f"pack_into requires a buffer of at least {offset + self.size} bytes for packing {self.size} bytes at offset {offset} (actual buffer size is {len(view)})"  # noqa: E501
+            raise struct.error(msg)
+
+        view[offset : offset + self.size] = self._swap_word_order(super().pack(*args))

--- a/tests/utils/test_order_aware_struct.py
+++ b/tests/utils/test_order_aware_struct.py
@@ -14,6 +14,36 @@ def test_init_odd_size_raises() -> None:
 
 
 @pytest.mark.parametrize(
+    "format_str",
+    [
+        ">bIb",  # I starts at odd offset 1
+        ">BHB",  # H starts at odd offset 1
+        ">bHb",  # H starts at odd offset 1
+        ">3sb",  # odd-sized string cannot map onto whole registers
+    ],
+)
+def test_init_unaligned_value_raises(format_str: str) -> None:
+    """Test that values straddling register boundaries raise when reordering is configured."""
+    with pytest.raises(ValueError, match="align to whole registers"):
+        OrderAwareStruct(format_str, word_order="little")
+
+
+def test_init_unaligned_value_allowed_without_reordering() -> None:
+    """Test that plain big/big structs still accept any register-sized format."""
+    s = OrderAwareStruct(">bIb")
+    assert s.pack(1, 0x0A0B0C0D, 2) == b"\x01\x0a\x0b\x0c\x0d\x02"
+
+
+def test_init_no_byte_order_prefix_raises() -> None:
+    """Test that prefix-less (native alignment) formats raise when reordering is configured."""
+    for format_str in ["BI", "@BI"]:
+        with pytest.raises(ValueError, match="byte-order prefix"):
+            OrderAwareStruct(format_str, word_order="little")
+    # Plain big/big still accepts native formats
+    assert OrderAwareStruct("BI").size == struct.calcsize("BI")
+
+
+@pytest.mark.parametrize(
     ("format_str", "word_order", "value", "expected_bytes"),
     [
         # Single register (2 bytes) - no swapping needed
@@ -135,6 +165,47 @@ def test_roundtrip(
     assert unpacked == values
 
 
+@pytest.mark.parametrize(
+    ("word_order", "byte_order", "data", "expected_values"),
+    [
+        # Two consecutive 32-bit values 0x0A0B0C0D, 0x01020304 on the wire:
+        # ABCD
+        ("big", "big", b"\x0a\x0b\x0c\x0d\x01\x02\x03\x04", (0x0A0B0C0D, 0x01020304)),
+        # BADC
+        ("big", "little", b"\x0b\x0a\x0d\x0c\x02\x01\x04\x03", (0x0A0B0C0D, 0x01020304)),
+        # CDAB
+        ("little", "big", b"\x0c\x0d\x0a\x0b\x03\x04\x01\x02", (0x0A0B0C0D, 0x01020304)),
+        # DCBA
+        ("little", "little", b"\x0d\x0c\x0b\x0a\x04\x03\x02\x01", (0x0A0B0C0D, 0x01020304)),
+    ],
+)
+def test_iter_unpack(
+    word_order: Literal["big", "little"],
+    byte_order: Literal["big", "little"],
+    data: bytes,
+    expected_values: tuple[int, ...],
+) -> None:
+    """Test that iter_unpack applies the same reordering as unpack to every chunk."""
+    s = OrderAwareStruct(">I", word_order=word_order, byte_order=byte_order)
+    assert tuple(v for (v,) in s.iter_unpack(data)) == expected_values
+    # Each chunk must decode identically to unpack
+    assert [s.unpack(data[i : i + 4]) for i in range(0, len(data), 4)] == list(s.iter_unpack(data))
+
+
+def test_iter_unpack_multi_value_format() -> None:
+    """Test iter_unpack with a multi-value format."""
+    s = OrderAwareStruct(">HI", word_order="little")
+    data = s.pack(0x0102, 0x0A0B0C0D) + s.pack(0x0304, 0x01020304)
+    assert list(s.iter_unpack(data)) == [(0x0102, 0x0A0B0C0D), (0x0304, 0x01020304)]
+
+
+def test_iter_unpack_wrong_length_raises() -> None:
+    """Test that iter_unpack raises eagerly on a buffer that is not a multiple of size."""
+    s = OrderAwareStruct(">I", word_order="little")
+    with pytest.raises(struct.error, match="multiple of 4 bytes"):
+        s.iter_unpack(b"\x00" * 6)
+
+
 def test_unpack_from() -> None:
     """Test unpack_from with offset."""
     s = OrderAwareStruct(">I", word_order="big")
@@ -190,6 +261,41 @@ def test_pack_into() -> None:
     buffer = bytearray(8)
     s.pack_into(buffer, 2, 0x0A0B0C0D)
     assert buffer == b"\x00\x00\x0c\x0d\x0a\x0b\x00\x00"
+
+
+def test_pack_into_too_small_buffer_raises() -> None:
+    """Test pack_into raises struct.error instead of growing an undersized buffer."""
+    s = OrderAwareStruct(">I", word_order="little")
+    buffer = bytearray(2)
+    with pytest.raises(struct.error, match="pack_into requires a buffer of at least 4 bytes"):
+        s.pack_into(buffer, 0, 0x0A0B0C0D)
+    assert len(buffer) == 2
+    with pytest.raises(struct.error, match="at least 8 bytes for packing 4 bytes at offset 4"):
+        s.pack_into(bytearray(6), 4, 0x0A0B0C0D)
+
+
+def test_pack_into_negative_offset() -> None:
+    """Test pack_into resolves valid negative offsets from the buffer end, like stdlib."""
+    s = OrderAwareStruct(">I", word_order="little")
+    buffer = bytearray(8)
+    s.pack_into(buffer, -6, 0x0A0B0C0D)
+    assert buffer == b"\x00\x00\x0c\x0d\x0a\x0b\x00\x00"
+
+
+def test_pack_into_negative_offset_no_space() -> None:
+    """Test pack_into raises when a negative offset leaves no room for the value."""
+    s = OrderAwareStruct(">I", word_order="little")
+    buffer = bytearray(8)
+    with pytest.raises(struct.error, match="no space to pack 4 bytes at offset -2"):
+        s.pack_into(buffer, -2, 0x0A0B0C0D)
+    assert buffer == bytearray(8)
+
+
+def test_pack_into_negative_offset_out_of_range() -> None:
+    """Test pack_into raises when a negative offset exceeds the buffer start."""
+    s = OrderAwareStruct(">I", word_order="little")
+    with pytest.raises(struct.error, match="offset -9 out of range for 8-byte buffer"):
+        s.pack_into(bytearray(8), -9, 0x0A0B0C0D)
 
 
 @pytest.mark.parametrize(
@@ -360,6 +466,11 @@ def test_byte_order_multiple_values() -> None:
     s_abcd = OrderAwareStruct(">HI", word_order="big", byte_order="big")
     packed_abcd = s_abcd.pack(0x0102, 0x0A0B0C0D)
     assert packed_abcd == b"\x01\x02\x0a\x0b\x0c\x0d"
+
+    # BADC: word_order="big", byte_order="little"
+    s_badc = OrderAwareStruct(">HI", word_order="big", byte_order="little")
+    packed_badc = s_badc.pack(0x0102, 0x0A0B0C0D)
+    assert packed_badc == b"\x01\x02\x0b\x0a\x0d\x0c"
 
     # CDAB: word_order="little", byte_order="big"
     s_cdab = OrderAwareStruct(">HI", word_order="little", byte_order="big")


### PR DESCRIPTION
# Proposed Changes

`OrderAwareStruct` is documented as a drop-in `struct.Struct` replacement that applies Modbus word/byte reordering, but several paths silently bypassed or corrupted the reordering. This PR fixes all of them. The recently optimized BADC fast path is untouched.

- **`iter_unpack` skipped reordering entirely.** It was inherited from `struct.Struct` un-overridden, so for CDAB `">I"` the same buffer decoded to `0x0a0b0c0d` via `unpack` but `0x0c0d0a0b` via `iter_unpack`. It now applies the same reordering to every struct-sized chunk, and raises the stdlib-style `struct.error` eagerly when the buffer length is not a multiple of `size`.
- **`pack_into` grew undersized buffers and mishandled negative offsets.** Slice assignment made a 2-byte `bytearray` silently grow to 4 (stdlib raises `struct.error`) and inserted bytes at negative offsets instead of overwriting. It now mirrors `struct.Struct.pack_into`: bounds-check with `struct.error` on a too-small buffer, and negative offsets resolve from the buffer end with the same error cases and messages as stdlib (verified against CPython for the too-small, no-space, and out-of-range paths).
- **Value grouping smeared bytes across distinct values.** Values straddling a register boundary were merged into one swap group, so `OrderAwareStruct(">bIb", word_order="little")` mixed the two int8 values into the int32's words, and `">BHB"` applied a 4-byte swap across three values — round-trippable through the same object, but meaningless wire data. Swapping is now well-defined per value: each multi-byte value's own bytes are reordered in place. Formats where a value starts at an odd byte offset or has odd size > 1 (so it cannot map onto whole 16-bit registers) raise `ValueError` at construction when a reordering `word_order`/`byte_order` is configured. Plain big/big still accepts any register-sized format.
- **Prefix-less formats silently never reordered.** A format like `"BI"` uses native alignment, so the parsed field lengths disagreed with `self.size` and the swap silently never applied. Constructing with a reordering configuration now requires an explicit byte-order prefix (`<`, `>`, `!` or `=`) and raises `ValueError` otherwise. As part of this, `parse_format_lengths` now passes the prefix through to `struct.calcsize`, so codes with different native and standard sizes (e.g. `l`) parse to their actual field length.

**Behavior tightening:** the last two fixes turn silent data corruption into `ValueError` at construction. Code that constructed a reordering `OrderAwareStruct` with an unaligned or prefix-less format was already producing corrupt wire data; it now fails fast instead.

Tests: new known-wire-bytes and round-trip tests for `iter_unpack` across ABCD/BADC/CDAB/DCBA, stdlib-parity tests for `pack_into` bounds and negative offsets, and construction-error tests for unaligned and prefix-less formats. Existing literal-byte expectations for `">f"`, `">I"`, `">Q"`, `">HH"` and multi-value register-aligned formats (`">HI"`, `">HIQ"`, `">bbI"`, ...) are unchanged and still pass, guarding that wire bytes for valid formats are identical to before.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
