### PR TITLE
fix(transport): serial timing, cancellation tracking, and server lifecycle hardening

### DIFF
--- a/src/tmodbus/server/async_ascii.py
+++ b/src/tmodbus/server/async_ascii.py
@@ -79,6 +79,9 @@ class AsyncAsciiServer(AsyncBaseServer):
 
     async def start(self) -> None:
         """Start the server using serialx's async connection."""
+        if self._running:
+            return
+
         reader, writer = await open_serial_connection(url=self.port, baudrate=self.baudrate, **self.serial_kwargs)
         self._reader = reader
         self._writer = writer
@@ -231,10 +234,13 @@ class AsyncAsciiServer(AsyncBaseServer):
         try:
             while self._running and self._reader:
                 try:
-                    # Read at least 1 byte
-                    data = await self._reader.read(1)
+                    # Read whatever is available (at least 1 byte)
+                    data = await self._reader.read(256)
                     if not data:
-                        continue
+                        # EOF: the serial stream is gone (e.g. USB adapter unplugged)
+                        logger.warning("Serial stream EOF on %s; stopping ASCII server loop", self.port)
+                        self._running = False
+                        break
                     buffer.extend(data)
 
                     while True:

--- a/src/tmodbus/server/async_rtu.py
+++ b/src/tmodbus/server/async_rtu.py
@@ -83,6 +83,9 @@ class AsyncRtuServer(AsyncBaseServer):
 
     async def start(self) -> None:
         """Start the server using serialx's async connection."""
+        if self._running:
+            return
+
         reader, writer = await open_serial_connection(url=self.port, baudrate=self.baudrate, **self.serial_kwargs)
         self._reader = reader
         self._writer = writer
@@ -254,10 +257,13 @@ class AsyncRtuServer(AsyncBaseServer):
         try:
             while self._running and self._reader:
                 try:
-                    # Read at least 1 byte
-                    data = await self._reader.read(1)
+                    # Read whatever is available (at least 1 byte)
+                    data = await self._reader.read(256)
                     if not data:
-                        continue
+                        # EOF: the serial stream is gone (e.g. USB adapter unplugged)
+                        logger.warning("Serial stream EOF on %s; stopping RTU server loop", self.port)
+                        self._running = False
+                        break
                     # Record time for each received byte to observe actual bus activity
                     self._last_recv_time = asyncio.get_running_loop().time()
                     buffer.extend(data)

--- a/src/tmodbus/server/async_rtu_over_tcp.py
+++ b/src/tmodbus/server/async_rtu_over_tcp.py
@@ -82,6 +82,9 @@ class AsyncRtuOverTcpServer(AsyncBaseServer):
 
     async def start(self) -> None:
         """Start the server."""
+        if self._server is not None:
+            return
+
         self._server = await asyncio.start_server(
             self.handle_client,
             self.host,
@@ -102,8 +105,10 @@ class AsyncRtuOverTcpServer(AsyncBaseServer):
         """Start the server and block until cancelled."""
         await self.start()
         assert self._server is not None
-        async with self._server:
-            await self._server.serve_forever()
+        # Suppress cancellation per the AsyncBaseServer contract
+        with contextlib.suppress(asyncio.CancelledError):
+            async with self._server:
+                await self._server.serve_forever()
 
     def _parse_frame_length(self, buffer: bytearray) -> int | None:
         """Parse expected total frame length from buffer, or return None if not enough data.

--- a/src/tmodbus/server/async_tcp.py
+++ b/src/tmodbus/server/async_tcp.py
@@ -128,6 +128,9 @@ class AsyncTcpServer(AsyncBaseServer):
 
     async def start(self) -> None:
         """Start the server."""
+        if self._server is not None:
+            return
+
         self._server = await asyncio.start_server(
             self.handle_client,
             self.host,
@@ -152,8 +155,10 @@ class AsyncTcpServer(AsyncBaseServer):
         """Start the server and block until cancelled."""
         await self.start()
         assert self._server is not None
-        async with self._server:
-            await self._server.serve_forever()
+        # Suppress cancellation per the AsyncBaseServer contract
+        with contextlib.suppress(asyncio.CancelledError):
+            async with self._server:
+                await self._server.serve_forever()
 
     async def _handle_single_request(
         self,

--- a/src/tmodbus/server/async_udp.py
+++ b/src/tmodbus/server/async_udp.py
@@ -79,8 +79,8 @@ class AsyncUdpServer(AsyncBaseServer):
         try:
             await self._serve_forever_future
         except asyncio.CancelledError:
+            # Suppress cancellation per the AsyncBaseServer contract
             await self.stop()
-            raise
 
     @property
     def sockets(self) -> list[Any]:

--- a/src/tmodbus/transport/async_ascii.py
+++ b/src/tmodbus/transport/async_ascii.py
@@ -209,12 +209,13 @@ class ModbusAsciiProtocol(asyncio.Protocol):
             except TimeoutError as e:
                 # Save PDU for timed-out request so any delayed response can be discarded cleanly
                 self._timed_out_requests[unit_id] = pdu
-                logger.exception(
-                    "Response timeout for unit %d after %.2f seconds. Cancelling read future.", unit_id, self.timeout
-                )
-                read_future.cancel()
                 msg = f"Response timeout after {self.timeout} seconds"
                 raise TimeoutError(msg) from e
+            except asyncio.CancelledError:
+                # Caller cancelled while the request was on the wire: track it like a
+                # timeout so a delayed response is not treated as garbage.
+                self._timed_out_requests[unit_id] = pdu
+                raise
             finally:
                 self._pending_request = None
 
@@ -260,13 +261,21 @@ class ModbusAsciiProtocol(asyncio.Protocol):
             )
             del self._buffer[:start_pos]
 
-    def _handle_inactive_unit_data(self, unit_id: int, base_function_code: int) -> None:
+    def _handle_inactive_unit_data(self, unit_id: int, base_function_code: int, raw: bytes) -> None:
         """Handle data for a unit ID with no active request."""
         timed_out_pdu = self._timed_out_requests.get(unit_id)
         if timed_out_pdu is None and self._pending_request is not None and self._pending_request.unit_id == unit_id:
             timed_out_pdu = self._pending_request.pdu
 
         if timed_out_pdu is not None and base_function_code == (timed_out_pdu.function_code & FUNCTION_CODE_MASK):
+            # Only clear tracking when the LRC validates (mirrors RTU's CRC check):
+            # a corrupted frame must not consume the tracking for the real delayed response.
+            if not validate_ascii_frame(raw):
+                logger.warning(
+                    "LRC validation failed for delayed response on unit %d. Discarding frame, keeping tracking.",
+                    unit_id,
+                )
+                return
             logger.info(
                 "Received delayed response (FC 0x%02X) for timed-out unit %d. Discarding.",
                 base_function_code,
@@ -279,6 +288,45 @@ class ModbusAsciiProtocol(asyncio.Protocol):
             "Received frame for unit %d with no pending request. Discarding frame.",
             unit_id,
         )
+
+    def _try_discard_delayed_matching_frame(
+        self,
+        unit_id: int,
+        base_function_code: int,
+        raw: bytes,
+        pending: _PendingRequest,
+    ) -> bool:
+        """Discard a delayed response for a timed-out request arriving during an active request.
+
+        Returns:
+            True if the frame was consumed (discarded), False if it belongs to the active request.
+
+        """
+        if base_function_code == (pending.pdu.function_code & FUNCTION_CODE_MASK):
+            return False
+
+        timed_out_pdu = self._timed_out_requests.get(unit_id)
+        if timed_out_pdu is None or base_function_code != (timed_out_pdu.function_code & FUNCTION_CODE_MASK):
+            return False
+
+        # Only clear tracking when the LRC validates (mirrors RTU's CRC check):
+        # a corrupted frame must not consume the tracking for the real delayed response.
+        if not validate_ascii_frame(raw):
+            logger.warning(
+                "LRC validation failed for delayed response on unit %d. Discarding frame, keeping tracking.",
+                unit_id,
+            )
+            return True
+
+        logger.info(
+            "Received delayed response (FC 0x%02X) for previous timed-out request on unit %d during "
+            "active request (FC 0x%02X). Discarding.",
+            base_function_code,
+            unit_id,
+            pending.pdu.function_code,
+        )
+        self._timed_out_requests.pop(unit_id, None)
+        return True
 
     def data_received(self, data: bytes) -> None:
         """Handle data received event."""
@@ -330,30 +378,14 @@ class ModbusAsciiProtocol(asyncio.Protocol):
             has_active_request = pending is not None and pending.unit_id == unit_id and not pending.future.done()
 
             if not has_active_request:
-                self._handle_inactive_unit_data(unit_id, base_function_code)
+                self._handle_inactive_unit_data(unit_id, base_function_code, raw)
                 continue
 
             assert pending is not None
 
             # Active request is present. Check if incoming frame belongs to active request or timed-out request.
-            active_expected_fc = pending.pdu.function_code & FUNCTION_CODE_MASK
-            if base_function_code != active_expected_fc:
-                timed_out_pdu = self._timed_out_requests.get(unit_id)
-                if timed_out_pdu is not None and base_function_code == (
-                    timed_out_pdu.function_code & FUNCTION_CODE_MASK
-                ):
-                    logger.info(
-                        "Received delayed response (FC 0x%02X) for previous timed-out request on unit %d during "
-                        "active request (FC 0x%02X). Discarding.",
-                        base_function_code,
-                        unit_id,
-                        pending.pdu.function_code,
-                    )
-                    self._timed_out_requests.pop(unit_id, None)
-                    continue
-
-            # Frame matches active request (or mismatch to be handled downstream)
-            self._timed_out_requests.pop(unit_id, None)
+            if self._try_discard_delayed_matching_frame(unit_id, base_function_code, raw, pending):
+                continue
 
             if not validate_ascii_frame(raw):
                 # The unit id is also part of the raw frame, so in theory it is possible that the LRC is caused by
@@ -367,6 +399,9 @@ class ModbusAsciiProtocol(asyncio.Protocol):
 
                 pending.future.set_exception(LRCError(response_bytes=frame))
                 continue
+
+            # Frame matches active request (or mismatch to be handled downstream) and passed the LRC check
+            self._timed_out_requests.pop(unit_id, None)
 
             # Deliver response to pending request
             pending.future.set_result(

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -400,6 +400,11 @@ class ModbusRtuProtocol(asyncio.Protocol):
                 self._timed_out_requests[unit_id] = pdu
                 msg = f"Response timeout after {self.timeout} seconds"
                 raise TimeoutError(msg) from e
+            except asyncio.CancelledError:
+                # Caller cancelled while the request was on the wire: track it like a
+                # timeout so a delayed response is not treated as garbage.
+                self._timed_out_requests[unit_id] = pdu
+                raise
             finally:
                 self._pending_request = None
 
@@ -645,6 +650,9 @@ class ModbusRtuProtocol(asyncio.Protocol):
         """
         self._buffer.extend(data)
         log_raw_traffic("recv", data)
+        # Received bytes are bus activity too: restart the 3.5-char silence clock so the
+        # next request keeps the inter-frame delay from the end of a received frame.
+        self._last_frame_ended_at = time.monotonic()
 
         last_error: Exception | None = None
 

--- a/src/tmodbus/transport/async_rtu_over_tcp.py
+++ b/src/tmodbus/transport/async_rtu_over_tcp.py
@@ -71,7 +71,7 @@ class AsyncRtuOverTcpTransport(AsyncBaseTransport):
             ValueError: When parameters are invalid
 
         """
-        if not 0 < port < 65535:
+        if not 0 < port <= 65535:
             msg = "Port must be an integer between 1-65535."
             raise ValueError(msg)
         if timeout <= 0:

--- a/src/tmodbus/transport/async_tcp.py
+++ b/src/tmodbus/transport/async_tcp.py
@@ -73,7 +73,7 @@ class AsyncTcpTransport(AsyncBaseTransport):
             TypeError: When parameter types are incorrect
 
         """
-        if not 0 < port < 65535:
+        if not 0 < port <= 65535:
             msg = "Port must be an integer between 1-65535."
             raise ValueError(msg)
         if timeout <= 0:

--- a/src/tmodbus/transport/async_udp.py
+++ b/src/tmodbus/transport/async_udp.py
@@ -68,7 +68,7 @@ class AsyncUdpTransport(AsyncBaseTransport):
             TypeError: When parameter types are incorrect
 
         """
-        if not 0 < port < 65535:
+        if not 0 < port <= 65535:
             msg = "Port must be an integer between 1-65535."
             raise ValueError(msg)
         if timeout <= 0:

--- a/tests/server/test_async_ascii.py
+++ b/tests/server/test_async_ascii.py
@@ -1,6 +1,7 @@
 """Tests for tmodbus/server/async_ascii.py."""
 
 import asyncio
+import logging
 from collections.abc import Iterator
 from typing import cast
 from unittest.mock import patch
@@ -303,6 +304,37 @@ async def test_ascii_server_raw_traffic_logging() -> None:
         mock_log.assert_any_call("recv", b":01", is_error=True)
 
 
+async def test_ascii_server_start_twice() -> None:
+    """Test starting the server twice returns early without reopening the port."""
+    router = ModbusRequestRouter()
+    server = AsyncAsciiServer(port="/dev/ttyUSB0", handler=router)
+    await server.start()
+    reader = server._reader
+    await server.start()
+    assert server._reader is reader
+    await server.stop()
+
+
+async def test_ascii_server_exits_on_eof(caplog: pytest.LogCaptureFixture) -> None:
+    """EOF from the serial stream ends the serve loop instead of busy-looping."""
+    router = ModbusRequestRouter()
+    server = AsyncAsciiServer(port="/dev/ttyUSB0", handler=router)
+    await server.start()
+
+    mock_serial_inst = cast("MockSerial", server._reader)
+    assert mock_serial_inst is not None
+    assert server._task is not None
+
+    with caplog.at_level(logging.WARNING):
+        await mock_serial_inst.read_queue.put(b"")
+        await asyncio.sleep(0.05)
+
+    assert server._task.done()
+    assert "EOF" in caplog.text
+
+    await server.stop()
+
+
 async def test_ascii_server_double_stop_and_serve_forever() -> None:
     """Test serve_forever and double stop on AsyncAsciiServer."""
     router = ModbusRequestRouter()
@@ -334,10 +366,6 @@ async def test_ascii_server_edge_cases() -> None:
 
     mock_serial_inst = cast("MockSerial", server._reader)
     assert mock_serial_inst is not None
-
-    # Test "if not data: continue" in ASCII serve loop
-    await mock_serial_inst.read_queue.put(b"")
-    await asyncio.sleep(0.02)
 
     # Test ASCII buffer overflow (> 513 bytes)
     await mock_serial_inst.read_queue.put(b"A" * 515)

--- a/tests/server/test_async_rtu.py
+++ b/tests/server/test_async_rtu.py
@@ -1,6 +1,7 @@
 """Tests for tmodbus/server/async_rtu.py."""
 
 import asyncio
+import logging
 from collections.abc import Iterator
 from typing import cast
 from unittest.mock import patch
@@ -211,6 +212,37 @@ async def test_rtu_server_raw_traffic_logging() -> None:
         mock_log.assert_any_call("recv", b"\x01\x03", is_error=True)
 
 
+async def test_rtu_server_start_twice() -> None:
+    """Test starting the server twice returns early without reopening the port."""
+    router = ModbusRequestRouter()
+    server = AsyncRtuServer(port="/dev/ttyUSB0", handler=router)
+    await server.start()
+    reader = server._reader
+    await server.start()
+    assert server._reader is reader
+    await server.stop()
+
+
+async def test_rtu_server_exits_on_eof(caplog: pytest.LogCaptureFixture) -> None:
+    """EOF from the serial stream ends the serve loop instead of busy-looping."""
+    router = ModbusRequestRouter()
+    server = AsyncRtuServer(port="/dev/ttyUSB0", handler=router)
+    await server.start()
+
+    mock_serial_inst = cast("MockSerial", server._reader)
+    assert mock_serial_inst is not None
+    assert server._task is not None
+
+    with caplog.at_level(logging.WARNING):
+        await mock_serial_inst.read_queue.put(b"")
+        await asyncio.sleep(0.05)
+
+    assert server._task.done()
+    assert "EOF" in caplog.text
+
+    await server.stop()
+
+
 async def test_rtu_server_double_stop_and_serve_forever() -> None:
     """Test serve_forever and double stop on AsyncRtuServer."""
     router = ModbusRequestRouter()
@@ -247,10 +279,6 @@ async def test_rtu_server_edge_cases() -> None:  # noqa: PLR0915
 
     mock_serial_inst = cast("MockSerial", server._reader)
     assert mock_serial_inst is not None
-
-    # Test "if not data: continue" in RTU serve loop
-    await mock_serial_inst.read_queue.put(b"")
-    await asyncio.sleep(0.02)
 
     # Fragmented frame transmission: send only 2 bytes initially (hits "else: return None" in length parsing)
     await mock_serial_inst.read_queue.put(b"\x01\x03")

--- a/tests/server/test_async_rtu_over_tcp.py
+++ b/tests/server/test_async_rtu_over_tcp.py
@@ -189,6 +189,13 @@ async def test_rtu_over_tcp_server_raw_traffic_logging(rtu_over_tcp_server: Asyn
         mock_log.assert_any_call("recv", b"\x01\x03", is_error=True)
 
 
+async def test_rtu_over_tcp_server_start_twice(rtu_over_tcp_server: AsyncRtuOverTcpServer) -> None:
+    """Test starting the server twice returns early without rebinding."""
+    server_obj = rtu_over_tcp_server._server
+    await rtu_over_tcp_server.start()  # Already started by fixture
+    assert rtu_over_tcp_server._server is server_obj
+
+
 async def test_rtu_over_tcp_server_double_stop_and_serve_forever() -> None:
     """Test serve_forever and double stop on AsyncRtuOverTcpServer."""
     router = ModbusRequestRouter()
@@ -196,9 +203,9 @@ async def test_rtu_over_tcp_server_double_stop_and_serve_forever() -> None:
     await rtu_tcp.stop()  # Stop before starting
     task = asyncio.create_task(rtu_tcp.serve_forever())
     await asyncio.sleep(0.05)
+    # Cancellation is suppressed internally per the AsyncBaseServer contract
     task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    await task
     await rtu_tcp.stop()  # Second stop
 
 

--- a/tests/server/test_async_tcp.py
+++ b/tests/server/test_async_tcp.py
@@ -199,6 +199,13 @@ async def test_tcp_server_abrupt_disconnect(tcp_server: AsyncTcpServer) -> None:
         await writer.wait_closed()
 
 
+async def test_tcp_server_start_twice(tcp_server: AsyncTcpServer) -> None:
+    """Test starting the server twice returns early without rebinding."""
+    server_obj = tcp_server._server
+    await tcp_server.start()  # Already started by fixture
+    assert tcp_server._server is server_obj
+
+
 async def test_tcp_server_double_stop(tcp_server: AsyncTcpServer) -> None:
     """Test that stop() can be called multiple times safely."""
     await tcp_server.stop()
@@ -216,9 +223,9 @@ async def test_tcp_server_serve_forever() -> None:
     assert server._server is not None
     assert server._server.is_serving()
 
+    # Cancellation is suppressed internally per the AsyncBaseServer contract
     task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    await task
     await server.stop()
 
 

--- a/tests/server/test_async_udp.py
+++ b/tests/server/test_async_udp.py
@@ -197,9 +197,9 @@ async def test_udp_server_serve_forever_cancelled() -> None:
     task = asyncio.create_task(server.serve_forever())
     await asyncio.sleep(0.05)
     assert len(server.sockets) > 0
+    # Cancellation is suppressed internally per the AsyncBaseServer contract
     task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    await task
     assert len(server.sockets) == 0
 
 

--- a/tests/transport/test_async_ascii.py
+++ b/tests/transport/test_async_ascii.py
@@ -1433,3 +1433,170 @@ async def test_connection_lost_sets_exception_on_pending_request(
     await connection_task
     assert protocol._pending_request is None
     assert len(protocol._timed_out_requests) == 0
+
+
+async def test_cancelled_request_is_tracked_and_delayed_response_discarded(
+    mock_transport: MagicMock,
+) -> None:
+    """A cancelled in-flight request is tracked so its delayed response is discarded cleanly."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=1.0)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    pdu1 = _DummyPDU()
+    unit_id = 1
+
+    # Step 1: request is cancelled while in flight
+    task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu1))
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert protocol._pending_request is None
+    assert protocol._timed_out_requests[unit_id] is pdu1
+
+    # Step 2: the delayed response is discarded and clears the tracking
+    delayed_frame = build_ascii_frame(unit_id, b"\x03\x02\x00\x55")
+    protocol.data_received(delayed_frame)
+    assert len(protocol._buffer) == 0
+    assert unit_id not in protocol._timed_out_requests
+
+    # Step 3: next request succeeds without stale interference
+    pdu2 = _DummyPDU()
+    response = build_ascii_frame(unit_id, b"\x03\x02\x00\x66")
+
+    async def deliver_response() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(response)
+
+    task2 = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
+    deliv_task = asyncio.create_task(deliver_response())
+    result = await task2
+    await deliv_task
+
+    assert result == ("decoded", b"\x03\x02\x00\x66")
+
+
+async def test_corrupt_delayed_frame_keeps_timed_out_tracking(
+    mock_transport: MagicMock,
+) -> None:
+    """A corrupted (bad LRC) frame must not clear the tracking for the real delayed response."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    pdu = _DummyPDU()
+    unit_id = 1
+
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu)
+    assert protocol._timed_out_requests[unit_id] is pdu
+
+    good_frame = build_ascii_frame(unit_id, b"\x03\x02\x00\x55")
+    corrupt_frame = good_frame.replace(b"0055", b"0056")  # data changed, LRC now invalid
+
+    protocol.data_received(corrupt_frame)
+    assert protocol._timed_out_requests[unit_id] is pdu  # tracking kept
+
+    protocol.data_received(good_frame)
+    assert unit_id not in protocol._timed_out_requests
+
+
+async def test_corrupt_delayed_frame_during_active_request_keeps_tracking(
+    mock_transport: MagicMock,
+) -> None:
+    """A corrupted delayed frame during an active request keeps tracking and the active request alive."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    pdu1 = _DummyPDU()
+    pdu1.function_code = 0x03
+
+    pdu2 = _DummyPDU()
+    pdu2.function_code = 0x06
+
+    unit_id = 1
+
+    # Step 1: Request 1 (FC 0x03) times out
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu1)
+    assert protocol._timed_out_requests[unit_id] is pdu1
+
+    # Step 2: Request 2 (FC 0x06) is sent and active
+    good_delayed_1 = build_ascii_frame(unit_id, b"\x03\x02\xaa\xbb")
+    corrupt_delayed_1 = good_delayed_1.replace(b"AABB", b"AABC")  # data changed, LRC now invalid
+    real_frame_2 = build_ascii_frame(unit_id, b"\x06\x00\x01\x11\x22")
+
+    async def deliver_frames() -> None:
+        await asyncio.sleep(0.01)
+        # Corrupt delayed frame: discarded, tracking retained, active request unaffected
+        protocol.data_received(corrupt_delayed_1)
+        assert protocol._pending_request is not None
+        assert not protocol._pending_request.future.done()
+        assert protocol._timed_out_requests[unit_id] is pdu1
+
+        # Real delayed frame clears the tracking
+        protocol.data_received(good_delayed_1)
+        assert unit_id not in protocol._timed_out_requests
+        assert not protocol._pending_request.future.done()
+
+        # Deliver real response for request 2
+        await asyncio.sleep(0.01)
+        protocol.data_received(real_frame_2)
+
+    req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
+    deliv_task = asyncio.create_task(deliver_frames())
+
+    result = await req2_task
+    await deliv_task
+
+    assert result == ("decoded", b"\x06\x00\x01\x11\x22")
+    assert len(protocol._buffer) == 0
+
+
+async def test_lrc_error_on_active_request_keeps_timed_out_tracking(
+    mock_transport: MagicMock,
+) -> None:
+    """An LRC failure on the active request's frame must not clear timed-out tracking."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=1.0)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    stale_pdu = _DummyPDU()
+    unit_id = 1
+    protocol._timed_out_requests[unit_id] = stale_pdu
+
+    pdu = _DummyPDU()
+    corrupt_frame = build_ascii_frame(unit_id, b"\x03\x02\x00\x55").replace(b"0055", b"0056")
+
+    async def deliver_corrupt() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(corrupt_frame)
+
+    task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    deliv_task = asyncio.create_task(deliver_corrupt())
+    with pytest.raises(LRCError):
+        await task
+    await deliv_task
+
+    assert protocol._timed_out_requests[unit_id] is stale_pdu
+
+
+async def test_timeout_does_not_log_error(
+    mock_transport: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A response timeout is routine: no ERROR-level logging, matching RTU."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    with (
+        caplog.at_level(logging.ERROR, logger="tmodbus.transport.async_ascii"),
+        pytest.raises(TimeoutError),
+    ):
+        await protocol.send_and_receive(1, _DummyPDU())
+
+    assert not caplog.records

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -1868,3 +1868,112 @@ async def test_data_received_falls_back_to_pending_request_pdu_when_future_done(
     # When data_received processes this, it falls back to _pending_request.pdu and cleanly drains it
     protocol.data_received(response)
     assert len(protocol._buffer) == 0
+
+
+async def test_next_request_waits_interframe_delay_after_received_response(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A received response restarts the inter-frame silence clock for the next request."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, interframe_delay=0.1)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+    unit_id = 1
+    payload = bytes([unit_id, pdu.function_code, 0x05])
+    response_adu = payload + calculate_crc16(payload)
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    async def simulate_response() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(response_adu)
+
+    task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    resp_task = asyncio.create_task(simulate_response())
+    await task
+    await resp_task
+
+    # data_received stamped the end of the received frame (not the primed value)
+    response_received_at = protocol._last_frame_ended_at
+    assert time.monotonic() - response_received_at < 5
+
+    write_times: list[float] = []
+    request_written = asyncio.Event()
+
+    def record_write(_data: bytes) -> None:
+        write_times.append(time.monotonic())
+        request_written.set()
+
+    mock_transport.write.side_effect = record_write
+
+    async def simulate_second_response() -> None:
+        await request_written.wait()
+        protocol.data_received(response_adu)
+
+    task2 = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    resp2_task = asyncio.create_task(simulate_second_response())
+    await task2
+    await resp2_task
+
+    # The second request must wait out the inter-frame delay measured from the received response
+    assert write_times[0] - response_received_at >= 0.1 - 0.001
+
+
+async def test_cancelled_request_is_tracked_and_delayed_response_drained(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled in-flight request is tracked so its delayed response is drained cleanly."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=1.0)
+    protocol.connection_made(mock_transport)
+
+    pdu1 = _DummyPDU()
+    unit_id = 1
+    delayed_payload = bytes([unit_id, pdu1.function_code, 0x05])
+    delayed_response = delayed_payload + calculate_crc16(delayed_payload)
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    # Step 1: request is cancelled while in flight
+    task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu1))
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert protocol._pending_request is None
+    assert protocol._timed_out_requests[unit_id] is pdu1
+
+    # Step 2: the delayed response is framed and discarded cleanly
+    protocol.data_received(delayed_response)
+    assert len(protocol._buffer) == 0
+    assert unit_id not in protocol._timed_out_requests
+
+    # Step 3: next request succeeds without stale interference
+    pdu2 = _DummyPDU()
+    new_payload = bytes([unit_id, pdu2.function_code, 0x09])
+    new_response = new_payload + calculate_crc16(new_payload)
+
+    async def simulate_new_response() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(new_response)
+
+    task2 = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
+    resp_task = asyncio.create_task(simulate_new_response())
+    result = await task2
+    await resp_task
+
+    assert result == ("decoded", b"\x03\x09")

--- a/tests/transport/test_async_rtu_over_tcp.py
+++ b/tests/transport/test_async_rtu_over_tcp.py
@@ -51,6 +51,11 @@ class TestAsyncRtuOverTcpTransportInit:
         with pytest.raises(ValueError, match="Port must be an integer between 1-65535"):
             AsyncRtuOverTcpTransport("192.168.1.100", port=65536)
 
+    def test_init_with_max_port(self) -> None:
+        """Test initialization with port 65535 is accepted."""
+        transport = AsyncRtuOverTcpTransport("192.168.1.100", port=65535)
+        assert transport.port == 65535
+
     def test_init_with_invalid_timeout(self) -> None:
         """Test initialization with invalid timeout raises ValueError."""
         with pytest.raises(ValueError, match="Timeout must be a positive number"):

--- a/tests/transport/test_async_tcp.py
+++ b/tests/transport/test_async_tcp.py
@@ -24,10 +24,15 @@ async def test_invalid_constructor_args() -> None:
     """Test that invalid constructor arguments raise ValueError."""
     with pytest.raises(ValueError, match=r"Port must be .*"):
         AsyncTcpTransport("host", port=0)
+    with pytest.raises(ValueError, match=r"Port must be .*"):
+        AsyncTcpTransport("host", port=65536)
     with pytest.raises(ValueError, match=r"Timeout must .*"):
         AsyncTcpTransport("host", timeout=0)
     with pytest.raises(ValueError, match=r"Connect timeout must .*"):
         AsyncTcpTransport("host", connect_timeout=0)
+
+    # Port 65535 is valid
+    assert AsyncTcpTransport("host", port=65535).port == 65535
 
 
 async def test_open_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/transport/test_async_udp.py
+++ b/tests/transport/test_async_udp.py
@@ -30,10 +30,15 @@ async def test_invalid_constructor_args() -> None:
     """Test that invalid constructor arguments raise ValueError."""
     with pytest.raises(ValueError, match=r"Port must be .*"):
         AsyncUdpTransport("host", port=0)
+    with pytest.raises(ValueError, match=r"Port must be .*"):
+        AsyncUdpTransport("host", port=65536)
     with pytest.raises(ValueError, match=r"Timeout must .*"):
         AsyncUdpTransport("host", timeout=0)
     with pytest.raises(ValueError, match=r"Connect timeout must .*"):
         AsyncUdpTransport("host", connect_timeout=0)
+
+    # Port 65535 is valid
+    assert AsyncUdpTransport("host", port=65535).port == 65535
 
 
 async def test_open_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# Proposed Changes

A set of transport and server correctness fixes, each with tests mirroring the existing suite patterns.

- **RTU inter-frame gap is now enforced after received frames.** `_last_frame_ended_at` was only stamped after our own writes, so no 3.5-character silence was inserted between receiving a response and sending the next request — violating the timing contract described in the module docstring. `data_received` now restarts the silence clock, so successful responses, drained delayed responses, and discarded garbage all reset it. Known limitation (out of scope here): the stamp is taken when `write()` returns rather than when the bytes finish transmitting, so at low baud rates the write-side stamp can still be slightly early.
- **Cancellation is tracked like a timeout.** If the caller cancelled `send_and_receive` (outer `asyncio.wait_for` or task cancellation), the in-flight request was untracked and its delayed response was later treated as garbage, which could desynchronize the buffer for the next request. RTU and ASCII now register the PDU in `_timed_out_requests` on `asyncio.CancelledError` before re-raising, so the delayed response is framed and discarded cleanly.
- **Port validation off-by-one.** `0 < port < 65535` rejected the valid port 65535 while the message says "between 1-65535". Fixed to `<= 65535` in the TCP, UDP, and RTU-over-TCP transports.
- **ASCII validates the LRC before clearing timed-out-request tracking.** The tracking was popped on a function-code match alone, so a corrupted frame could consume it and leave the real delayed response to be treated as garbage. ASCII now only clears tracking for frames whose LRC validates, mirroring RTU's CRC-first approach.
- **ASCII response timeout no longer logged as an error.** A routine response timeout was logged with `logger.exception` (ERROR + traceback) and redundantly cancelled the read future; RTU does neither for the same event. ASCII now matches RTU.
- **Serial servers no longer busy-loop at 100% CPU on EOF.** At stream EOF (e.g. USB adapter unplug) `StreamReader.read()` returns `b""` immediately forever; the RTU/ASCII serve loops treated that as "no data yet" and spun. EOF now logs a warning and exits the serve loop cleanly. While here, the loops read up to 256 bytes per await instead of 1 byte per event-loop iteration (`read()` returns whatever is available; the frame parsers already handle multi-byte chunks).
- **`start()` is now idempotent on all servers.** The base class documents that calling `start()` a second time must not raise, but only the UDP server guarded it; TCP, RTU, ASCII, and RTU-over-TCP bound or opened again and leaked the previous server/port. All servers now return early when already started, with double-start tests mirroring the existing UDP one.

**Behavior changes:** `serve_forever()` on the TCP, UDP, and RTU-over-TCP servers now suppresses `asyncio.CancelledError` internally, as the `AsyncBaseServer` contract documents ("callers can simply `await server.serve_forever()` inside a task and cancel the task to stop the server"). The RTU/ASCII servers already behaved this way; TCP and UDP propagated the cancellation and their tests enshrined it. Code that relied on `CancelledError` propagating out of `serve_forever()` after cancelling the task will now see a clean return instead. The affected tests were updated to the documented contract.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
