### PR TITLE
fix(pdu): validate malformed responses and answer malformed requests with Illegal Data Value

### DIFF
--- a/src/tmodbus/pdu/device.py
+++ b/src/tmodbus/pdu/device.py
@@ -3,7 +3,6 @@
 cfr. section 6.21 of the Modbus Application Protocol Specification V1.1b3
 """
 
-import logging
 import struct
 from dataclasses import dataclass
 from enum import IntEnum
@@ -13,8 +12,6 @@ from tmodbus.const import FunctionCode
 from tmodbus.exceptions import FunctionCodeError, InvalidRequestError, InvalidResponseError
 
 from .base import BaseSubFunctionPDU
-
-logger = logging.getLogger(__name__)
 
 
 class ObjectName(IntEnum):
@@ -190,6 +187,7 @@ class ReadDeviceIdentificationPDU(BaseSubFunctionPDU[ReadDeviceIdentificationRes
             raise InvalidResponseError(msg, response_bytes=response) from e
 
         objects: dict[int, bytes] = {}
+        parsed_objects = 0
         offset = response_header_struct.size
         while offset < len(response):
             try:
@@ -198,11 +196,16 @@ class ReadDeviceIdentificationPDU(BaseSubFunctionPDU[ReadDeviceIdentificationRes
                 msg = "Truncated object header in Read Device Identification response"
                 raise InvalidResponseError(msg, response_bytes=response) from e
             offset += 2
+            if offset + obj_length > len(response):
+                msg = "Truncated object value in Read Device Identification response"
+                raise InvalidResponseError(msg, response_bytes=response)
             objects[obj_id] = response[offset : offset + obj_length]
+            parsed_objects += 1
             offset += obj_length
 
-        if offset != len(response):
-            logger.warning("Response has %d extra bytes", len(response) - offset)
+        if parsed_objects != number_of_objects:
+            msg = f"Expected {number_of_objects} objects, received {parsed_objects}"
+            raise InvalidResponseError(msg, response_bytes=response)
 
         return ReadDeviceIdentificationResponse(
             device_id_code=device_id_code,
@@ -242,7 +245,7 @@ class ReadDeviceIdentificationPDU(BaseSubFunctionPDU[ReadDeviceIdentificationRes
 
         if sub_function_code != cls.sub_function_code:
             msg = f"Expected sub-function code {cls.sub_function_code}, got {data[0]}"
-            raise InvalidResponseError(msg, response_bytes=data)
+            raise FunctionCodeError(msg, response_bytes=data)
 
         offset = response_header_struct.size
 

--- a/src/tmodbus/pdu/fifo.py
+++ b/src/tmodbus/pdu/fifo.py
@@ -140,6 +140,14 @@ class ReadFifoQueuePDU(BasePDU[list[int]]):
             msg = f"Byte count {byte_count} does not match actual data length {len(data) - 3}."
             raise InvalidResponseError(msg, response_bytes=data)
 
+        if byte_count % 2 != 0:
+            msg = f"Byte count {byte_count} must be even."
+            raise InvalidResponseError(msg, response_bytes=data)
+
+        if fifo_count > 31:
+            msg = f"FIFO count {fifo_count} out of range (0-31)."
+            raise InvalidResponseError(msg, response_bytes=data)
+
         values_count = (byte_count // 2) - 1
         values = list(struct.unpack(f">{values_count}H", data[response_header_struct.size :]))
 

--- a/src/tmodbus/pdu/file.py
+++ b/src/tmodbus/pdu/file.py
@@ -154,6 +154,11 @@ class ReadFileRecordPDU(BasePDU[list[bytes]]):
                 )
                 raise InvalidResponseError(msg, response_bytes=response)
 
+            # The length includes the reference type byte plus N registers, so it must be odd (and at least 1).
+            if file_response_length % 2 == 0:
+                msg = f"Invalid file response length {file_response_length}: must be odd"
+                raise InvalidResponseError(msg, response_bytes=response)
+
             data_start = offset + 2  # move past length and reference type
             data_end = data_start + file_response_length - 1  # reference type is included in length
 
@@ -164,6 +169,10 @@ class ReadFileRecordPDU(BasePDU[list[bytes]]):
             records.append(response[data_start:data_end])
 
             offset = data_end
+
+        if len(records) != len(self.requests):
+            msg = f"Expected {len(self.requests)} file records, received {len(records)}"
+            raise InvalidResponseError(msg, response_bytes=response)
 
         return records
 
@@ -258,15 +267,16 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
             if not (0 <= len(record.data) <= 0xFFFF):
                 msg = "Record data length must be between 0 and 65535 bytes."
                 raise ValueError(msg)
+            if len(record.data) % 2 != 0:
+                msg = "Record data length cannot be odd; each register is 2 bytes."
+                raise ValueError(msg)
 
         if not self.file_records:
             msg = "At least one file record is required."
             raise ValueError(msg)
 
-        # Each record is a 7-byte header plus its data, padded up to an even length.
-        byte_count = sum(
-            SUB_REQUEST_STRUCT.size + len(record.data) + (len(record.data) % 2) for record in self.file_records
-        )
+        # Each record is a 7-byte header plus its data.
+        byte_count = sum(SUB_REQUEST_STRUCT.size + len(record.data) for record in self.file_records)
         if byte_count > MAX_WRITE_FILE_RECORD_BYTE_COUNT:
             msg = (
                 f"Write File Record request byte count {byte_count} exceeds the "

--- a/src/tmodbus/server/async_ascii.py
+++ b/src/tmodbus/server/async_ascii.py
@@ -8,13 +8,13 @@ from typing import Any, Literal
 
 from serialx import open_serial_connection
 
-from tmodbus.const import BROADCAST_UNIT_ID, EXCEPTION_RESPONSE_BIT
+from tmodbus.const import BROADCAST_UNIT_ID
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.lrc import calculate_lrc, validate_lrc
 from tmodbus.utils.raw_traffic_logger import format_bytes
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
 
-from .base import AsyncBaseServer, get_server_pdu_class
+from .base import AsyncBaseServer, build_decode_error_response, get_server_pdu_class
 from .handler import ModbusHandler, handle_modbus_request, handler_supports_unit_id
 
 logger = logging.getLogger(__name__)
@@ -47,6 +47,7 @@ class AsyncAsciiServer(AsyncBaseServer):
              _get_pdu_class() / decode_request()
                       │
                       ├───[ decoding fails ]──────────────────► responds with IllegalFunction
+                      │                                         or IllegalDataValue
                       └───[ Happy Path ]──────────────────────► routes, encodes response,
                                                                 calculates LRC & writes
 
@@ -198,7 +199,7 @@ class AsyncAsciiServer(AsyncBaseServer):
             request_pdu = pdu_class.decode_request(pdu_bytes)
         except (ValueError, InvalidRequestError) as e:
             logger.warning("Invalid request: %s", e)
-            response_pdu_bytes = bytes([function_code | EXCEPTION_RESPONSE_BIT, 0x01])
+            response_pdu_bytes = build_decode_error_response(function_code, e)
             is_error = True
         else:
             response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)

--- a/src/tmodbus/server/async_rtu.py
+++ b/src/tmodbus/server/async_rtu.py
@@ -8,13 +8,13 @@ from typing import Any, Literal
 
 from serialx import open_serial_connection
 
-from tmodbus.const import BROADCAST_UNIT_ID, EXCEPTION_RESPONSE_BIT
+from tmodbus.const import BROADCAST_UNIT_ID
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.crc import calculate_crc16, validate_crc16
 from tmodbus.utils.raw_traffic_logger import format_bytes
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
 
-from .base import AsyncBaseServer, get_server_pdu_class_from_buffer
+from .base import AsyncBaseServer, build_decode_error_response, get_server_pdu_class_from_buffer
 from .handler import ModbusHandler, handle_modbus_request, handler_supports_unit_id
 
 logger = logging.getLogger(__name__)
@@ -49,7 +49,7 @@ class AsyncRtuServer(AsyncBaseServer):
                       ├───[ validate_crc16() fails ]──────────► returns "processed" (skips frame, continues loop)
                       │
                       └──► _handle_frame()
-                                ├───[ PDU.decode_request() fails ]──► responds with IllegalFunction
+                                ├───[ PDU.decode_request() fails ]──► responds with IllegalDataValue
                                 └───[ Happy Path ]──────────────────► routes, encodes response & writes
                                                                       (returns "processed")
 
@@ -167,7 +167,7 @@ class AsyncRtuServer(AsyncBaseServer):
             request_pdu = pdu_class.decode_request(pdu_bytes)
         except (ValueError, InvalidRequestError) as e:
             logger.warning("Invalid request: %s", e)
-            response_pdu_bytes = bytes([function_code | EXCEPTION_RESPONSE_BIT, 0x01])
+            response_pdu_bytes = build_decode_error_response(function_code, e)
             is_error = True
         else:
             response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)

--- a/src/tmodbus/server/async_rtu_over_tcp.py
+++ b/src/tmodbus/server/async_rtu_over_tcp.py
@@ -12,7 +12,7 @@ from tmodbus.utils.crc import calculate_crc16, validate_crc16
 from tmodbus.utils.raw_traffic_logger import format_bytes
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
 
-from .base import AsyncBaseServer, get_server_pdu_class_from_buffer
+from .base import AsyncBaseServer, build_decode_error_response, get_server_pdu_class_from_buffer
 from .handler import ModbusHandler, handle_modbus_request, handler_supports_unit_id
 
 logger = logging.getLogger(__name__)
@@ -153,7 +153,7 @@ class AsyncRtuOverTcpServer(AsyncBaseServer):
                 request_pdu = pdu_class.decode_request(pdu_bytes)
             except (ValueError, InvalidRequestError) as e:
                 logger.warning("Invalid request from %s: %s", addr, e)
-                response_pdu_bytes = bytes([function_code | EXCEPTION_RESPONSE_BIT, 0x01])
+                response_pdu_bytes = build_decode_error_response(function_code, e)
                 is_error = True
             else:
                 response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)

--- a/src/tmodbus/server/async_tcp.py
+++ b/src/tmodbus/server/async_tcp.py
@@ -12,7 +12,7 @@ from tmodbus.const import EXCEPTION_RESPONSE_BIT, ExceptionCode
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
 
-from .base import AsyncBaseServer, get_server_pdu_class
+from .base import AsyncBaseServer, build_decode_error_response, get_server_pdu_class
 from .handler import AnyModbusHandler, RequestContext, handle_modbus_request, handler_supports_unit_id
 from .security import extract_client_cert, extract_modbus_role
 
@@ -79,7 +79,7 @@ class AsyncTcpServer(AsyncBaseServer):
              PDU.decode_request()
                       │
                       ├───[ Malformed Request ]
-                      │   (InvalidRequestError) ──► Responds with IllegalFunction ──► [ Continue Loop ] (returns True)
+                      │   (InvalidRequestError) ──► Responds with IllegalDataValue ──► [ Continue Loop ] (returns True)
                       ▼
             handle_modbus_request()  ────► routes to ModbusHandler/router
                       │                   (injects cert_info if handler declares it)
@@ -220,9 +220,7 @@ class AsyncTcpServer(AsyncBaseServer):
                 request_pdu = raw_pdu_class.decode_request(pdu_bytes)
             except (ValueError, InvalidRequestError) as e:
                 logger.warning("Invalid request from %s: %s", addr, e)
-                # Cannot respond if we don't even know the function code properly, or if unsupported
-                # We might reply with IllegalFunction if we at least have function_code
-                response_pdu_bytes = bytes([function_code | EXCEPTION_RESPONSE_BIT, 0x01])  # ILLEGAL_FUNCTION
+                response_pdu_bytes = build_decode_error_response(function_code, e)
                 is_error = True
             else:
                 response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler, context=context)

--- a/src/tmodbus/server/async_udp.py
+++ b/src/tmodbus/server/async_udp.py
@@ -10,7 +10,7 @@ from tmodbus.const import EXCEPTION_RESPONSE_BIT, ExceptionCode
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
 
-from .base import AsyncBaseServer, get_server_pdu_class
+from .base import AsyncBaseServer, build_decode_error_response, get_server_pdu_class
 from .handler import AnyModbusHandler, RequestContext, handle_modbus_request, handler_supports_unit_id
 
 logger = logging.getLogger(__name__)
@@ -162,7 +162,7 @@ class ModbusUdpServerProtocol(asyncio.DatagramProtocol):
                     request_pdu = raw_pdu_class.decode_request(pdu_bytes)
                 except (ValueError, InvalidRequestError) as e:
                     logger.warning("Invalid request from %s: %s", addr, e)
-                    response_pdu_bytes = bytes([function_code | EXCEPTION_RESPONSE_BIT, 0x01])  # ILLEGAL_FUNCTION
+                    response_pdu_bytes = build_decode_error_response(function_code, e)
                     is_error = True
                 else:
                     context = RequestContext(peer_addr=addr)

--- a/src/tmodbus/server/base.py
+++ b/src/tmodbus/server/base.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
+from tmodbus.const import EXCEPTION_RESPONSE_BIT, ExceptionCode
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.pdu import (
     BaseClientPDU,
@@ -92,6 +93,28 @@ def get_server_pdu_class_from_buffer(buffer: bytearray) -> type[BasePDU[Any]] | 
         raise ValueError(msg)
 
     return pdu_class
+
+
+def build_decode_error_response(function_code: int, error: Exception) -> bytes:
+    """Build the exception-response PDU for a request that failed to decode.
+
+    ``InvalidRequestError`` means the function code is supported but the request
+    data is malformed, so per the Modbus specification the server answers
+    ILLEGAL_DATA_VALUE.  Any other error means the (sub-)function code itself is
+    unknown or unsupported, which is answered with ILLEGAL_FUNCTION.
+
+    Args:
+        function_code: Function code of the offending request.
+        error: The exception raised while resolving or decoding the request.
+
+    Returns:
+        The two-byte exception-response PDU.
+
+    """
+    exception_code = (
+        ExceptionCode.ILLEGAL_DATA_VALUE if isinstance(error, InvalidRequestError) else ExceptionCode.ILLEGAL_FUNCTION
+    )
+    return bytes([function_code | EXCEPTION_RESPONSE_BIT, exception_code])
 
 
 class AsyncBaseServer(ABC):

--- a/tests/pdu/test_device.py
+++ b/tests/pdu/test_device.py
@@ -1,10 +1,9 @@
 """Tests for device.py - Read Device Identification PDU."""
 
-import logging
 import struct
 
 import pytest
-from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
+from tmodbus.exceptions import FunctionCodeError, InvalidRequestError, InvalidResponseError
 from tmodbus.pdu import ReadDeviceIdentificationResponse
 from tmodbus.pdu.device import (
     ConformityLevel,
@@ -232,8 +231,8 @@ class TestReadDeviceIdentificationPDU:
         assert result.objects[0x03] == b"http://vendor.com"
         assert result.objects[0x04] == b"ProductName!"
 
-    def test_decode_response_extra_bytes_warning(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Test decoding response triggers warning when object length extends past response end."""
+    def test_decode_response_truncated_object_value(self) -> None:
+        """An object whose claimed length extends past the response end raises InvalidResponseError."""
         pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)
 
         response = struct.pack(
@@ -247,18 +246,30 @@ class TestReadDeviceIdentificationPDU:
             0x01,
         )
         # Add an object with length 10 but only provide 5 bytes of data
-        # This makes offset jump to 7 + 2 + 10 = 19, but response is only 7 + 2 + 5 = 14 bytes
         response += struct.pack(">BB", 0x00, 10) + b"Short"
 
-        with caplog.at_level(logging.WARNING):
-            result = pdu.decode_response(response)
+        with pytest.raises(InvalidResponseError, match=r"Truncated object value"):
+            pdu.decode_response(response)
 
-        # The warning is logged when offset != len(response)
-        # In this case, offset = 19 > len(response) = 14, so warning logged
-        assert "Response has" in caplog.text
-        assert "extra bytes" in caplog.text
-        # The object will contain only the 5 bytes that were actually present
-        assert result.objects == {0x00: b"Short"}
+    def test_decode_response_object_count_mismatch(self) -> None:
+        """A response whose object count differs from the advertised count raises InvalidResponseError."""
+        pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)
+
+        response = struct.pack(
+            ">BBBBBBB",
+            0x2B,
+            0x0E,
+            0x01,
+            0x01,
+            0x00,
+            0x00,
+            0x02,  # Claims two objects
+        )
+        # But only one object follows
+        response += struct.pack(">BB", 0x00, 6) + b"Vendor"
+
+        with pytest.raises(InvalidResponseError, match=r"Expected 2 objects, received 1"):
+            pdu.decode_response(response)
 
     def test_decode_response_all_conformity_levels(self) -> None:
         """Test decoding response with different conformity levels."""
@@ -327,10 +338,10 @@ class TestReadDeviceIdentificationPDUGetExpectedResponseDataLength:
         assert result is None
 
     def test_invalid_sub_function_code(self) -> None:
-        """Test with invalid sub-function code."""
+        """A sub-function code mismatch raises FunctionCodeError so the RTU framing loop can recover."""
         # Sub-function code should be 0x0E, but provide 0x0F
         data = struct.pack(">BBBBBB", 0x0F, 0x01, 0x01, 0x00, 0x00, 0x00)
-        with pytest.raises(Exception, match=r"Expected sub-function code"):
+        with pytest.raises(FunctionCodeError, match=r"Expected sub-function code"):
             ReadDeviceIdentificationPDU.get_expected_response_data_length(data)
 
     def test_zero_objects(self) -> None:

--- a/tests/pdu/test_fifo.py
+++ b/tests/pdu/test_fifo.py
@@ -208,6 +208,22 @@ class TestReadFifoQueuePDU:
         with pytest.raises(InvalidResponseError, match=r"Byte count 8 does not match actual data length 6"):
             pdu.decode_response(response_data)
 
+    def test_decode_response_odd_byte_count(self) -> None:
+        """An odd byte count raises InvalidResponseError, not a raw struct.error."""
+        pdu = ReadFifoQueuePDU(address=0x04DE)
+        # Byte count 5 matches the frame length but cannot hold whole registers
+        response_data = b"\x18\x00\x05\x00\x01\x01\xb8\x12"
+        with pytest.raises(InvalidResponseError, match=r"Byte count 5 must be even"):
+            pdu.decode_response(response_data)
+
+    def test_decode_response_fifo_count_out_of_range(self) -> None:
+        """A FIFO count above 31 raises InvalidResponseError (encode enforces the same limit)."""
+        pdu = ReadFifoQueuePDU(address=0x04DE)
+        # FIFO count 32 with 32 matching values: byte count = 2 + 32*2 = 66
+        response_data = b"\x18\x00\x42\x00\x20" + b"\x00\x01" * 32
+        with pytest.raises(InvalidResponseError, match=r"FIFO count 32 out of range \(0-31\)"):
+            pdu.decode_response(response_data)
+
     def test_decode_response_count_mismatch(self) -> None:
         """Test decoding response where FIFO count doesn't match number of values."""
         pdu = ReadFifoQueuePDU(address=0x04DE)

--- a/tests/pdu/test_file.py
+++ b/tests/pdu/test_file.py
@@ -214,6 +214,47 @@ class TestReadFileRecordPDU:
         with pytest.raises(InvalidResponseError, match="Invalid reference type"):
             pdu.decode_response(response)
 
+    def test_decode_response_zero_file_response_length(self) -> None:
+        """A file response length of 0 is rejected (spec minimum is 1: the reference type byte)."""
+        requests = [FileRecordRequest(file_number=4, record_number=1, record_length=2)]
+        pdu = ReadFileRecordPDU(requests)
+
+        # File response length 0 would rewind the parsing offset
+        response = b"\x14\x06\x00\x06\x0d\xfe\x00\x20"
+        with pytest.raises(InvalidResponseError, match="must be odd"):
+            pdu.decode_response(response)
+
+    def test_decode_response_even_file_response_length(self) -> None:
+        """An even file response length is rejected (must be 1 reference type byte + 2N data bytes)."""
+        requests = [FileRecordRequest(file_number=4, record_number=1, record_length=2)]
+        pdu = ReadFileRecordPDU(requests)
+
+        response = b"\x14\x06\x04\x06\x0d\xfe\x00\x20"
+        with pytest.raises(InvalidResponseError, match="must be odd"):
+            pdu.decode_response(response)
+
+    def test_decode_response_record_count_mismatch(self) -> None:
+        """A response with fewer records than requested raises InvalidResponseError."""
+        requests = [
+            FileRecordRequest(file_number=4, record_number=1, record_length=2),
+            FileRecordRequest(file_number=4, record_number=8, record_length=1),
+        ]
+        pdu = ReadFileRecordPDU(requests)
+
+        # Only one record for a two-record request
+        response = b"\x14\x06\x05\x06\x0d\xfe\x00\x20"
+        with pytest.raises(InvalidResponseError, match="Expected 2 file records, received 1"):
+            pdu.decode_response(response)
+
+    def test_decode_response_empty_records(self) -> None:
+        """A zero-record response for a one-record request raises InvalidResponseError."""
+        requests = [FileRecordRequest(file_number=4, record_number=1, record_length=2)]
+        pdu = ReadFileRecordPDU(requests)
+
+        response = b"\x14\x00"
+        with pytest.raises(InvalidResponseError, match="Expected 1 file records, received 0"):
+            pdu.decode_response(response)
+
     def test_encode_response_even_length_record(self) -> None:
         """Test encode_response does not pad even-length records."""
         requests = [FileRecordRequest(file_number=4, record_number=1, record_length=2)]
@@ -322,8 +363,8 @@ class TestReadFileRecordPDU:
         requests = [FileRecordRequest(file_number=4, record_number=1, record_length=2)]
         pdu = ReadFileRecordPDU(requests)
 
-        # Says 4 bytes of data but only provides 2 (file_response_length = 0x06 means 4 bytes of data)
-        response = b"\x14\x04\x06\x06\x0d\xfe"  # Missing 2 bytes of data
+        # Says 4 bytes of data but only provides 2 (file_response_length = 0x05 means 4 bytes of data)
+        response = b"\x14\x04\x05\x06\x0d\xfe"  # Missing 2 bytes of data
 
         with pytest.raises(InvalidResponseError, match="Not enough data"):
             pdu.decode_response(response)
@@ -335,7 +376,7 @@ class TestReadFileRecordPDU:
 
         # Valid response data but with offset mismatch at the end
         # Byte count indicates 10 bytes, causing offset != end_offset
-        response = b"\x14\x0a\x06\x06\x0d\xfe\x00\x20\x06\x06\x0d\xfe"
+        response = b"\x14\x0a\x05\x06\x0d\xfe\x00\x20\x05\x07\x0d\xfe"
 
         with pytest.raises(InvalidResponseError, match=r"(Failed to unpack|Invalid reference type).*"):
             pdu.decode_response(response)
@@ -410,12 +451,11 @@ class TestWriteFileRecordPDU:
         assert encoded[0] == 0x15  # function code
         assert encoded[1] == 20  # byte count
 
-    def test_encode_request_odd_length_data(self) -> None:
-        """Odd-length payloads are rejected because registers are 2 bytes."""
+    def test_odd_length_data_rejected(self) -> None:
+        """Odd-length payloads are rejected at construction because registers are 2 bytes."""
         records = [FileRecord(file_number=1, record_number=0, data=b"\x00\x01\x02")]
-        pdu = WriteFileRecordPDU(file_records=records)
         with pytest.raises(ValueError, match="Record data length cannot be odd"):
-            pdu.encode_request()
+            WriteFileRecordPDU(file_records=records)
 
     def test_validation_file_number_invalid(self) -> None:
         """Test that invalid file numbers raise ValueError."""

--- a/tests/pdu/test_file.py
+++ b/tests/pdu/test_file.py
@@ -612,6 +612,14 @@ class TestWriteFileRecordPDU:
         expected = b"\x15\x0b\x06\x00\x04\x00\x07\x00\x02\x06\xaf\x04\xbe"
         assert encoded == expected
 
+    def test_encode_response_odd_length_data_rejected(self) -> None:
+        """Odd-length payloads are rejected when encoding response."""
+        records = [FileRecord(file_number=4, record_number=7, data=b"\x06\xaf\x04\xbe")]
+        pdu = WriteFileRecordPDU(file_records=records)
+        odd_records = [FileRecord(file_number=1, record_number=0, data=b"\x00\x01\x02")]
+        with pytest.raises(ValueError, match="Record data length cannot be odd"):
+            pdu.encode_response(odd_records)
+
     def test_decode_request_valid(self) -> None:
         """Test decode_request with valid request data."""
         # Valid request from spec example

--- a/tests/server/test_async_ascii.py
+++ b/tests/server/test_async_ascii.py
@@ -391,6 +391,9 @@ async def test_ascii_server_edge_cases() -> None:
     await asyncio.sleep(0.05)
     # Write calls: 1 (missing sub) + 1 (good sub) + 1 (bad sub) + 1 (invalid param) = 4
     assert len(mock_serial_inst.write_calls) == 4
+    # Malformed request with a supported function code: IllegalDataValue (0x03)
+    # bin_data = b"\x01\x83\x03", LRC = 0x79
+    assert mock_serial_inst.write_calls[3] == b":01830379\r\n"
     mock_serial_inst.write_calls.clear()
 
     # 1. Serial port read exception in loop (run while loop is still active!)

--- a/tests/server/test_async_rtu.py
+++ b/tests/server/test_async_rtu.py
@@ -293,7 +293,7 @@ async def test_rtu_server_edge_cases() -> None:  # noqa: PLR0915
     # and pdu_invalid_param (IllegalDataValue), so 2 write calls.
     assert len(mock_serial_inst.write_calls) == 2
     assert mock_serial_inst.write_calls[0] == b"\x01\xab\x01\x9e\xf0"
-    assert mock_serial_inst.write_calls[1] == b"\x01\x83\x01\x80\xf0"
+    assert mock_serial_inst.write_calls[1] == b"\x01\x83\x03\x01\x31"
     mock_serial_inst.write_calls.clear()
 
     # 1. Serial port read exception in loop (run while loop is still active!)

--- a/tests/server/test_async_rtu_over_tcp.py
+++ b/tests/server/test_async_rtu_over_tcp.py
@@ -304,6 +304,7 @@ async def test_rtu_over_tcp_server_edge_cases() -> None:  # noqa: PLR0915
         await writer.drain()
         resp = await reader.readexactly(5)  # unit(1)+fc|0x80(1)+err(1)+crc(2)
         assert resp[1] == 0x83
+        assert resp[2] == 0x03  # ILLEGAL_DATA_VALUE
     finally:
         writer.close()
         with contextlib.suppress(ConnectionError):

--- a/tests/server/test_async_tcp.py
+++ b/tests/server/test_async_tcp.py
@@ -168,6 +168,27 @@ async def test_tcp_server_unsupported_function_code(tcp_server: AsyncTcpServer) 
         await writer.wait_closed()
 
 
+async def test_tcp_server_malformed_request(tcp_server: AsyncTcpServer) -> None:
+    """Test that a malformed request with a supported function code returns ILLEGAL_DATA_VALUE."""
+    port = get_server_port(tcp_server)
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+    try:
+        # Read Holding Registers (0x03) with quantity = 0 raises InvalidRequestError in decode_request
+        mbap = struct.pack(">HHHB", 2, 0, 6, 1)
+        pdu = b"\x03\x00\x00\x00\x00"
+        writer.write(mbap + pdu)
+        await writer.drain()
+
+        await reader.readexactly(7)
+        resp_pdu = await reader.readexactly(2)
+        assert resp_pdu == b"\x83\x03"  # 0x03 | 0x80 = 0x83, exception = 0x03
+
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
 async def test_tcp_server_abrupt_disconnect(tcp_server: AsyncTcpServer) -> None:
     """Test that server handles client disconnecting abruptly during header read cleanly."""
     port = get_server_port(tcp_server)
@@ -235,12 +256,12 @@ async def test_tcp_server_subfunction_pdu_errors(tcp_server: AsyncTcpServer) -> 
         writer.write(mbap + pdu)
         await writer.drain()
 
-        # Should receive response: IllegalFunction (0x01)
+        # Truncated request for a supported function code: IllegalDataValue (0x03)
         await reader.readexactly(7)
         resp_pdu = await reader.readexactly(2)
-        assert resp_pdu == b"\xab\x01"  # 0x2b | 0x80 = 0xab
+        assert resp_pdu == b"\xab\x03"  # 0x2b | 0x80 = 0xab
 
-        # Send invalid sub-function code (e.g. 0)
+        # Send invalid sub-function code (e.g. 0): IllegalFunction (0x01)
         mbap = struct.pack(">HHHB", 5, 0, 3, 1)
         pdu = b"\x2b\x00"
         writer.write(mbap + pdu)

--- a/tests/server/test_async_udp.py
+++ b/tests/server/test_async_udp.py
@@ -168,6 +168,31 @@ async def test_udp_server_unsupported_function_code(udp_server: AsyncUdpServer) 
         transport.close()
 
 
+async def test_udp_server_malformed_request(udp_server: AsyncUdpServer) -> None:
+    """Test that a malformed request with a supported function code returns ILLEGAL_DATA_VALUE."""
+    port = get_server_port(udp_server)
+    loop = asyncio.get_running_loop()
+
+    transport, protocol = await loop.create_datagram_endpoint(UdpClientProtocol, remote_addr=("127.0.0.1", port))
+
+    try:
+        # Read Holding Registers (0x03) with quantity = 0 raises InvalidRequestError in decode_request
+        mbap = struct.pack(">HHHB", 3, 0, 6, 1)
+        pdu = b"\x03\x00\x00\x00\x00"
+        frame = mbap + pdu
+
+        transport.sendto(frame)
+
+        resp = await asyncio.wait_for(protocol.future, timeout=1.0)
+
+        resp_pdu = resp[7:]
+        # Illegal data value exception response: 0x03 | 0x80 = 0x83, exception = 0x03
+        assert resp_pdu == b"\x83\x03"
+
+    finally:
+        transport.close()
+
+
 async def test_udp_server_start_twice(udp_server: AsyncUdpServer) -> None:
     """Test starting the server twice returns early."""
     await udp_server.start()  # Already started by fixture


### PR DESCRIPTION
# Proposed Changes

This PR closes a set of decode-validation gaps where responses or requests from a misbehaving or hostile peer were silently accepted, or crashed with the wrong exception type.

Client-side PDU decoding:

- **Read Device Identification (0x2B/0x0E)**: `get_expected_response_data_length` now raises `FunctionCodeError` on a sub-function code mismatch, matching the base class. It raised `InvalidResponseError`, which the RTU framing loop does not catch, so a corrupted MEI byte escaped the loop instead of being handled as a frame error. `decode_response` now rejects truncated object payloads (a response claiming a 16-byte object but carrying 2 bytes previously returned the 2 bytes silently) and rejects responses whose parsed object count differs from the advertised `number_of_objects`. The old trailing "extra bytes" warning (which could log a negative count) is gone; these cases are now hard errors.
- **Read File Record (0x14)**: `decode_response` now rejects a file response length that is zero or even. The spec minimum is 1 (the reference-type byte is included) and a valid length is always 1 + 2N. A zero length previously produced an empty record and rewound the parsing offset by one byte, misaligning everything after it. The parsed record count is now also checked against the request, so a zero-record response for a one-record request no longer returns `[]` silently.
- **Write File Record (0x15)**: `__post_init__` now rejects odd-length record data. Construction previously accepted it (the byte-count formula even budgeted for padding), but `_encode` raised `ValueError` and no padding was ever applied, so `encode_request()` blew up on a PDU that had validated fine. Record data is register-based per the spec, so rejecting at construction is the consistent behavior; auto-padding odd data to a full register was the alternative, but silently altering user payloads seemed worse than an early error.
- **Read FIFO Queue (0x18)**: `decode_response` now raises `InvalidResponseError` instead of leaking a raw `struct.error` for an odd byte count, and rejects a FIFO count above 31 (the same limit `encode_response` already enforces).

Server transports (TCP, UDP, RTU, ASCII, RTU-over-TCP):

- A malformed request with a **known** function code (`InvalidRequestError` from `decode_request`) is now answered with ILLEGAL_DATA_VALUE (0x03) as the Modbus specification requires. ILLEGAL_FUNCTION (0x01) is kept only for genuinely unknown or unsupported (sub-)function codes. A shared `build_decode_error_response` helper in `server/base.py` makes all five transports behave identically.

Each fix comes with tests mirroring the existing suites in `tests/pdu/` and `tests/server/`.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
