### PR TITLE
docs: fix examples, cross-references, and stale branding

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -69,10 +69,6 @@ jobs:
           name: Packages
           path: dist
       - name: Create GitHub Release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: Release ${{ github.ref }}
+          generate_release_notes: true

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -27,6 +27,8 @@ more details.
 
 .. autofunction:: tmodbus.create_async_rtu_over_tcp_client
 
+.. autofunction:: tmodbus.create_async_udp_client
+
 **************
  Client layer
 **************
@@ -93,8 +95,8 @@ When the server responds with an error, tModbus will raise the corresponding sub
 - 0x0B Gateway target device failed to respond:
   :class:`~tmodbus.exceptions.GatewayTargetDeviceFailedToRespondError`.
 
-If an unknown exception code is returned, a generic
-:class:`~tmodbus.exceptions.ModbusResponseError` will be raised.
+If an unknown exception code is returned, an
+:class:`~tmodbus.exceptions.UnknownModbusResponseError` will be raised.
 
 When the server responds with an invalid response, tModbus will raise the corresponding
 subclass of :class:`~tmodbus.exceptions.InvalidResponseError`:

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -25,7 +25,7 @@ The library consists of the following layers:
 
     classDiagram
         class AsyncModbusClient {
-           transport : AsyncModbusTransport
+           transport : AsyncBaseTransport
            unit_id : int
 
            +connect()
@@ -72,7 +72,7 @@ Transport layer
 ===============
 
 The transport layer is implemented in the :mod:`tmodbus.transport` module. It provides
-the :class:`tmodbus.transport.AsyncModbusTransport` base class, which defines the
+the :class:`tmodbus.transport.AsyncBaseTransport` base class, which defines the
 interface for transport implementations.
 
 The specific transport protocols are implemented in the following classes:

--- a/docs/source/batch_reading.rst
+++ b/docs/source/batch_reading.rst
@@ -62,10 +62,11 @@ to control the order of the registers.
 By default, the word order is set to `"big"`, meaning that the first register read will
 be the most significant word.
 
-This library includes an utility class :class:`~tmodbus.utils.OrderAwareStruct` that
-extends `struct.Struct` to handle word order automatically. So even if your device uses
-little-endian word order and/or byte order, you can still use the same struct format
-string as you would for big-endian.
+This library includes an utility class
+:class:`~tmodbus.utils.order_aware_struct.OrderAwareStruct` that extends `struct.Struct`
+to handle word order automatically. So even if your device uses little-endian word order
+and/or byte order, you can still use the same struct format string as you would for
+big-endian.
 
 .. note::
 

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -12,6 +12,7 @@ The following server classes are available:
 - :class:`~tmodbus.server.AsyncRtuServer`: Modbus RTU Server (over serial).
 - :class:`~tmodbus.server.AsyncAsciiServer`: Modbus ASCII Server (over serial).
 - :class:`~tmodbus.server.AsyncRtuOverTcpServer`: Modbus RTU over TCP Server.
+- :class:`~tmodbus.server.AsyncUdpServer`: Modbus UDP Server.
 
 *********************************************
  Recommended Dispatcher: ModbusRequestRouter

--- a/docs/source/vendor_functions.rst
+++ b/docs/source/vendor_functions.rst
@@ -56,7 +56,7 @@ The response PDU has the following format:
       - Challenge (16)
     - - 0x41
       - 0x24
-      - 0x11
+      - 0x10
       - <16 bytes>
 
 Example code:
@@ -83,7 +83,7 @@ To use your custom PDU, you can create an instance of it and pass it to the
 
 
     async def main():
-        async with create_async_tcp_client(host="localhost", port=502) as client:
+        async with create_async_tcp_client(host="localhost", port=502, unit_id=1) as client:
             pdu = LoginRequestChallengePDU()
             response: LoginChallenge = await client.execute(pdu)
             print(f"Received challenge: {response.challenge.hex()}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
 [project.urls]
 HomePage = "https://github.com/wlcrs/tmodbus"
-Documentation = "https://tmodbus.readthedocs.org"
+Documentation = "https://tmodbus.readthedocs.io"
 Repository = "https://github.com/wlcrs/tmodbus"
 Issues = "https://github.com/wlcrs/tmodbus/issues"
 Changelog = "https://github.com/wlcrs/tmodbus/releases"

--- a/src/tmodbus/__init__.py
+++ b/src/tmodbus/__init__.py
@@ -108,10 +108,9 @@ def create_async_rtu_client(  # noqa: PLR0913
     """Create an asynchronous RTU Modbus client with automatic reconnect and request retry functionality.
 
     Args:
-        port: The port number of the Modbus server (default is 502).
+        port: Target serial port (e.g., '/dev/ttyUSB0')
         unit_id: The unit ID to use for requests.
         timeout: Timeout in seconds, default 10.0s
-        connect_timeout: Timeout for establishing connection, default 10.0s
         wait_between_requests: Wait time between requests in seconds (default: 0.0s)
         wait_after_connect: Wait time after connection establishment in seconds (default: 0.0s)
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).
@@ -127,7 +126,7 @@ def create_async_rtu_client(  # noqa: PLR0913
         serialx_options: Additional connection parameters passed to `serialx`
 
     Returns:
-        An instance of AsyncModbusClient configured for TCP transport.
+        An instance of AsyncModbusClient configured for RTU transport.
 
     """
     smart_transport = AsyncSmartTransport(
@@ -166,10 +165,9 @@ def create_async_ascii_client(  # noqa: PLR0913
     """Create an asynchronous ASCII Modbus client with automatic reconnect and request retry functionality.
 
     Args:
-        port: The port number of the Modbus server (default is 502).
+        port: Target serial port (e.g., '/dev/ttyUSB0')
         unit_id: The unit ID to use for requests.
         timeout: Timeout in seconds, default 10.0s
-        connect_timeout: Timeout for establishing connection, default 10.0s
         wait_between_requests: Wait time between requests in seconds (default: 0.0s)
         wait_after_connect: Wait time after connection establishment in seconds (default: 0.0s)
         auto_reconnect: Whether to automatically reconnect on connection loss (default: True).
@@ -185,7 +183,7 @@ def create_async_ascii_client(  # noqa: PLR0913
         serialx_options: Additional connection parameters passed to `serialx`
 
     Returns:
-        An instance of AsyncModbusClient configured for TCP transport.
+        An instance of AsyncModbusClient configured for ASCII transport.
 
     """
     smart_transport = AsyncSmartTransport(

--- a/src/tmodbus/exceptions.py
+++ b/src/tmodbus/exceptions.py
@@ -6,7 +6,7 @@ from .const import ExceptionCode
 
 
 class TModbusError(Exception):
-    """Base exception class for ModbusLink library."""
+    """Base exception class for tModbus library."""
 
 
 class ModbusConnectionError(TModbusError):
@@ -19,7 +19,7 @@ class ModbusConnectionError(TModbusError):
     """The bytes that were read before the connection error occurred. Can be empty."""
 
     def __init__(self, *args: Any, bytes_read: bytes | None = None, **kwargs: Any) -> None:
-        """Initialize RTUFrameError."""
+        """Initialize ModbusConnectionError."""
         super().__init__(*args, **kwargs)
         self.response_bytes = bytes_read or b""
 
@@ -45,7 +45,7 @@ class InvalidResponseError(TModbusError):
     response_bytes: bytes
 
     def __init__(self, *args: Any, response_bytes: bytes, **kwargs: Any) -> None:
-        """Initialize RTUFrameError."""
+        """Initialize InvalidResponseError."""
         super().__init__(*args, **kwargs)
         self.response_bytes = response_bytes
 

--- a/src/tmodbus/transport/async_smart.py
+++ b/src/tmodbus/transport/async_smart.py
@@ -344,7 +344,7 @@ class AsyncSmartTransport(AsyncBaseTransport):
                 )
 
                 msg = (
-                    f"Failed to get a valid response after {attempt.retry_state.attempt_number} attempts"
+                    f"Failed to get a valid response after {attempt.retry_state.attempt_number} attempts "
                     f"over {attempt.retry_state.seconds_since_start} seconds. Last error: {underlying_error_text}"
                 )
 

--- a/src/tmodbus/utils/crc.py
+++ b/src/tmodbus/utils/crc.py
@@ -1,4 +1,4 @@
-"""ModbusLink CRC16 Checksum Utility Module.
+"""tModbus CRC16 Checksum Utility Module.
 
 Provides CRC16 checksum functionality required by Modbus RTU protocol.
 


### PR DESCRIPTION
# Proposed Changes

A batch of documentation and cosmetic fixes ahead of 1.0.0, all verified against the code.

Documentation:

- `vendor_functions.rst`: the "Using your custom PDU" example called `create_async_tcp_client(host="localhost", port=502)` without the required keyword-only `unit_id` argument, so the documented code raised `TypeError` (Sybil misses it because the call sits inside a never-invoked `main()`). Also fixed the response table: the data-length byte for a 16-byte challenge is `0x10`, not `0x11` — the example decoder rejects anything but 16.
- `architecture.rst`: replaced references to the nonexistent `tmodbus.transport.AsyncModbusTransport` with the real base class `AsyncBaseTransport`, in both the prose and the mermaid diagram.
- `batch_reading.rst`: pointed the `OrderAwareStruct` cross-reference at its real path `tmodbus.utils.order_aware_struct.OrderAwareStruct` (`tmodbus.utils` has no re-export; adding one is left to the in-flight PR that does that).
- `api.rst`: documented `create_async_udp_client`, the only factory that was missing; corrected the exceptions section — unknown exception codes raise `UnknownModbusResponseError`, not a generic `ModbusResponseError`.
- `server.rst`: added `AsyncUdpServer` to the list of available servers.

Code cosmetics:

- `create_async_rtu_client` / `create_async_ascii_client` docstrings were TCP copy-paste: `port` was described as "port number of the Modbus server (default is 502)" when it is a serial device path, a phantom `connect_timeout` argument was documented, and the Returns text claimed "configured for TCP transport". Rewritten to match the real signatures.
- Renamed stale "ModbusLink" branding in `exceptions.py` and `utils/crc.py` to tModbus, and fixed two copy-pasted "Initialize RTUFrameError" docstrings inside `ModbusConnectionError` and `InvalidResponseError`.
- `async_smart.py`: added the missing space in the retry-failure message that rendered "attemptsover" (the reconnect sibling message already had it).
- `pyproject.toml`: Documentation URL now points to tmodbus.readthedocs.io (was .org), matching the README and docs index.

CI (separate commit):

- `pypi-publish.yml`: the github-release job used `actions/create-release`, archived and unmaintained since 2021, with a body of just "Release vX.Y.Z". Replaced with `softprops/action-gh-release`, pinned to the full commit SHA for v2.6.2, with `generate_release_notes: true` so releases get real changelogs. Harden-runner and the existing permissions are unchanged.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
