### PR TITLE
perf: optimize RTU framing and register packing hot paths

### DIFF
--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -166,7 +166,7 @@ class ReadHoldingRegistersPDU(BasePDU[list[int]]):
         """
         response_bytes = self.raw_pdu.decode_response(response)
 
-        return [*struct.unpack(f">{'H' * (len(response_bytes) // 2)}", response_bytes)]
+        return [*struct.unpack(f">{len(response_bytes) // 2}H", response_bytes)]
 
     @classmethod
     def decode_request(cls, request: bytes) -> Self:
@@ -204,7 +204,7 @@ class ReadHoldingRegistersPDU(BasePDU[list[int]]):
             Bytes representation of the Read Holding Registers response PDU.
 
         """
-        data = struct.pack(f">{'H' * len(value)}", *value)
+        data = struct.pack(f">{len(value)}H", *value)
         return struct.pack(">BB", self.function_code, len(data)) + data
 
 
@@ -515,7 +515,7 @@ class WriteMultipleRegistersPDU(BasePDU[int]):
 
         self.values = values
 
-        self.raw_pdu = RawWriteMultipleRegistersPDU(start_address, struct.pack(f">{'H' * len(values)}", *values))
+        self.raw_pdu = RawWriteMultipleRegistersPDU(start_address, struct.pack(f">{len(values)}H", *values))
 
     def encode_request(self) -> bytes:
         """Convert PDU to bytes.
@@ -558,7 +558,7 @@ class WriteMultipleRegistersPDU(BasePDU[int]):
         """
         raw = RawWriteMultipleRegistersPDU.decode_request(request)
         # Convert content bytes to list of ints
-        values = list(struct.unpack(f">{'H' * (len(raw.content) // 2)}", raw.content))
+        values = list(struct.unpack(f">{len(raw.content) // 2}H", raw.content))
         try:
             return cls(raw.start_address, values)
         except ValueError as e:
@@ -764,7 +764,7 @@ class ReadWriteMultipleRegistersPDU(BasePDU[list[int]]):
 
         """
         write_byte_count = len(self.write_values) * 2
-        write_data = struct.pack(f">{'H' * len(self.write_values)}", *self.write_values)
+        write_data = struct.pack(f">{len(self.write_values)}H", *self.write_values)
 
         return (
             self.REQUEST_HEADER_STRUCT.pack(
@@ -812,7 +812,7 @@ class ReadWriteMultipleRegistersPDU(BasePDU[list[int]]):
             raise InvalidResponseError(msg, response_bytes=response)
 
         response_bytes = response[2:]  # Extract the data part of the response
-        return [*struct.unpack(f">{'H' * (len(response_bytes) // 2)}", response_bytes)]
+        return [*struct.unpack(f">{len(response_bytes) // 2}H", response_bytes)]
 
     @classmethod
     def decode_request(cls, request: bytes) -> Self:
@@ -855,7 +855,7 @@ class ReadWriteMultipleRegistersPDU(BasePDU[list[int]]):
             msg = f"Invalid data length: expected {write_byte_count}, got {len(content)}"
             raise InvalidRequestError(msg, request_bytes=request)
 
-        write_values = list(struct.unpack(f">{'H' * (write_quantity)}", content))
+        write_values = list(struct.unpack(f">{write_quantity}H", content))
         try:
             return cls(
                 read_start_address=read_start_address,
@@ -885,4 +885,4 @@ class ReadWriteMultipleRegistersPDU(BasePDU[list[int]]):
                 msg = f"Invalid read value {val} on index {idx}: must be between 0 and 65535"
                 raise ValueError(msg)
 
-        return struct.pack(f">BB{'H' * len(value)}", self.function_code, len(value) * 2, *value)
+        return struct.pack(f">BB{len(value)}H", self.function_code, len(value) * 2, *value)

--- a/src/tmodbus/transport/async_ascii.py
+++ b/src/tmodbus/transport/async_ascii.py
@@ -195,7 +195,7 @@ class ModbusAsciiProtocol(asyncio.Protocol):
                 self._last_frame_ended_at = time.monotonic()
                 return broadcast_response
 
-            read_future: asyncio.Future[_ModbusAsciiMessage] = asyncio.get_event_loop().create_future()
+            read_future: asyncio.Future[_ModbusAsciiMessage] = asyncio.get_running_loop().create_future()
             self._pending_request = _PendingRequest(unit_id=unit_id, future=read_future, pdu=pdu)
 
             self.transport.write(request_adu)

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -385,7 +385,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
                 self._last_frame_ended_at = time.monotonic()
                 return broadcast_response
 
-            read_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_event_loop().create_future()
+            read_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_running_loop().create_future()
             self._pending_request = _PendingRequest(unit_id=unit_id, future=read_future, pdu=pdu)
 
             self.transport.write(request_adu)
@@ -452,6 +452,21 @@ class ModbusRtuProtocol(asyncio.Protocol):
         )
         del self._buffer[:discard_count]
 
+    def _resync_discard_length(self) -> int:
+        """Get the number of leading bytes to discard to resynchronize after a bad frame.
+
+        Skips ahead to the next byte matching an expected unit id, so a garbage burst is
+        dropped in one slice instead of one byte per pass through the receive loop.
+        """
+        expected_unit_ids: set[int] = set(self._timed_out_requests.keys())
+        if self._pending_request is not None and not self._pending_request.future.done():
+            expected_unit_ids.add(self._pending_request.unit_id)
+
+        for i in range(1, len(self._buffer)):
+            if self._buffer[i] in expected_unit_ids:
+                return i
+        return 1  # no plausible frame start ahead; drop only the leading byte
+
     def _determine_expected_frame_length(self, pending_pdu: BaseClientPDU[Any] | None = None) -> int | None:
         """Determine expected frame length based on current buffer contents.
 
@@ -497,7 +512,10 @@ class ModbusRtuProtocol(asyncio.Protocol):
                     msg = f"Cannot frame response with unsupported function code {function_code:#04x}"
                     raise RTUFrameError(msg, response_bytes=bytes(self._buffer)) from e
 
-            expected_response_data_length = pdu_class.get_expected_response_data_length(bytes(self._buffer[2:]))
+            # memoryview avoids an intermediate bytearray copy on every incoming chunk
+            expected_response_data_length = pdu_class.get_expected_response_data_length(
+                bytes(memoryview(self._buffer)[2:])
+            )
 
             if expected_response_data_length is None:
                 # the PDU class reported that it cannot yet determine the length of this response
@@ -539,13 +557,13 @@ class ModbusRtuProtocol(asyncio.Protocol):
             expected_total_frame_length = self._determine_expected_frame_length(timed_out_pdu)
         except (RTUFrameError, FunctionCodeError):
             self._timed_out_requests.pop(unit_id, None)
-            del self._buffer[0]
+            del self._buffer[: self._resync_discard_length()]
             return False
 
         if expected_total_frame_length is None or len(self._buffer) < expected_total_frame_length:
             return True  # Wait for full delayed frame
 
-        candidate_frame = bytes(self._buffer[:expected_total_frame_length])
+        candidate_frame = bytes(memoryview(self._buffer)[:expected_total_frame_length])
         if validate_crc16(candidate_frame):
             del self._buffer[:expected_total_frame_length]
             self._timed_out_requests.pop(unit_id, None)
@@ -555,7 +573,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
                 candidate_frame.hex(" ").upper(),
             )
         else:
-            del self._buffer[0]
+            del self._buffer[: self._resync_discard_length()]
         return False
 
     def _validate_and_deliver_frame(
@@ -565,7 +583,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
         pending_future: asyncio.Future[_ModbusRtuMessage],
     ) -> Exception | None:
         """Extract, validate, and deliver a complete candidate frame."""
-        candidate_frame = bytes(self._buffer[:expected_length])
+        candidate_frame = bytes(memoryview(self._buffer)[:expected_length])
         if validate_crc16(candidate_frame):
             del self._buffer[:expected_length]
             pdu_bytes = candidate_frame[1:-2]  # Remove address and CRC
@@ -580,13 +598,14 @@ class ModbusRtuProtocol(asyncio.Protocol):
             )
             return None
 
+        discard_length = self._resync_discard_length()
         logger.warning(
-            "CRC validation failed for candidate frame (%d bytes: %s). Discarding leading byte %s to resynchronize.",
+            "CRC validation failed for candidate frame (%d bytes: %s). Discarding %d byte(s) to resynchronize.",
             len(candidate_frame),
             candidate_frame.hex(" ").upper(),
-            self._buffer[0:1].hex(" ").upper(),
+            discard_length,
         )
-        del self._buffer[0]
+        del self._buffer[:discard_length]
         return CRCError(response_bytes=candidate_frame)
 
     def _try_drain_delayed_matching_response(

--- a/src/tmodbus/transport/async_tcp.py
+++ b/src/tmodbus/transport/async_tcp.py
@@ -257,7 +257,7 @@ class ModbusTcpProtocol(asyncio.Protocol):
         request_frame = mbap_header + request_pdu_bytes
 
         # 3. Async send request
-        read_future: asyncio.Future[_ModbusMessage] = asyncio.get_event_loop().create_future()
+        read_future: asyncio.Future[_ModbusMessage] = asyncio.get_running_loop().create_future()
         self._pending_requests[current_transaction_id] = read_future
 
         self.transport.write(request_frame)

--- a/src/tmodbus/transport/async_udp.py
+++ b/src/tmodbus/transport/async_udp.py
@@ -236,7 +236,7 @@ class ModbusUdpProtocol(asyncio.DatagramProtocol):
 
         request_frame = mbap_header + request_pdu_bytes
 
-        read_future: asyncio.Future[_ModbusMessage] = asyncio.get_event_loop().create_future()
+        read_future: asyncio.Future[_ModbusMessage] = asyncio.get_running_loop().create_future()
         self._pending_requests[current_transaction_id] = read_future
 
         self.transport.sendto(request_frame)

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -1350,6 +1350,46 @@ async def test_request_aware_framing_rejects_mismatched_function_code(
     assert result[0] == "decoded"
 
 
+async def test_large_garbage_burst_resynchronizes(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a large garbage burst before the response is discarded and the frame still parses."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()  # FC 0x03
+    unit_id = 1
+    response_data = b"\x05"
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    good_payload = bytes([unit_id, pdu.function_code]) + response_data
+    good_frame = good_payload + calculate_crc16(good_payload)
+
+    # Garbage burst: implausible bytes, then many false frame starts for unit 1 that never pass CRC
+    garbage = b"\xff\xfe\xfd" * 500 + bytes([unit_id, pdu.function_code, 0xAA, 0xBB, 0xCC]) * 500
+
+    async def simulate_stream() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(garbage + good_frame)
+
+    result_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    response_task = asyncio.create_task(simulate_stream())
+
+    result = await result_task
+    await response_task
+
+    assert result == ("decoded", b"\x03\x05")
+    assert len(protocol._buffer) == 0
+
+
 async def test_determine_expected_frame_length_subfunction_pdu(
     mock_transport: MagicMock,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
# Proposed Changes

Behavior-preserving performance improvements to the hot receive and encode paths.

- **RTU resynchronization is no longer O(n²) on garbage bursts.** After a CRC failure or framing error, the protocol used to delete one buffer byte at a time and re-run full frame-length determination for every byte. It now scans ahead for the next byte that can plausibly start an expected frame (same criteria `_discard_garbage_data` already uses) and deletes the whole garbage prefix in one slice. When no plausible start is found, it still drops only the leading byte, so the observable resync behavior is unchanged. Added a test that a multi-kilobyte garbage burst — including repeated false frame starts for the expected unit id — still resynchronizes and delivers the real response.
- **Fewer buffer copies per received chunk.** `bytes(self._buffer[2:])` and `bytes(self._buffer[:n])` each copied the buffer twice (bytearray slice, then bytes). These now go through `memoryview`, halving the bytes copied every time a chunk arrives while a frame is still incomplete. Fully eliminating the remaining copy would require widening the public `get_expected_response_data_length(data: bytes)` signature to accept a buffer type, which I deliberately did not do.
- **Allocation-free struct formats.** Eight sites in `holding_registers.py` built format strings as `f">{'H' * n}"`, allocating an n-character string per call. They now use the equivalent repeat-count form `f">{n}H"`, matching the style already used in `fifo.py`.
- **`asyncio.get_running_loop()` instead of the deprecated `get_event_loop()`** in the four async transports (RTU, ASCII, TCP, UDP). All call sites run inside the event loop, so this is the documented correct replacement.

The existing test suite passes unchanged; one new test was added for the garbage-burst resync.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
