### PR TITLE
Tighten RTU resyncing logic by looking for 2 bytes instead of 1

### DIFF
--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -294,7 +294,7 @@ class _PendingRequest:
 
     unit_id: int
     future: asyncio.Future[_ModbusRtuMessage]
-    pdu: BaseClientPDU[Any] | None = None
+    pdu: BaseClientPDU[Any]
 
 
 class ModbusRtuProtocol(asyncio.Protocol):
@@ -426,13 +426,43 @@ class ModbusRtuProtocol(asyncio.Protocol):
             # Return decoded response
             return pdu.decode_response(response.pdu_bytes)
 
+    def _get_expected_headers(self) -> set[bytes]:
+        """Get set of expected 2-byte headers (unit_id + function_code).
+
+        For each active or timed-out request, valid response headers are:
+        - unit_id + base function code
+        - unit_id + exception response function code (base function code | EXCEPTION_RESPONSE_BIT)
+        """
+        headers: set[bytes] = set()
+        for uid, pdu in self._timed_out_requests.items():
+            base_fc = pdu.function_code & FUNCTION_CODE_MASK
+            headers.add(bytes([uid, base_fc]))
+            headers.add(bytes([uid, base_fc | EXCEPTION_RESPONSE_BIT]))
+
+        if self._pending_request is not None and not self._pending_request.future.done():
+            pdu = self._pending_request.pdu
+            base_fc = pdu.function_code & FUNCTION_CODE_MASK
+            headers.add(bytes([self._pending_request.unit_id, base_fc]))
+            headers.add(bytes([self._pending_request.unit_id, base_fc | EXCEPTION_RESPONSE_BIT]))
+
+        return headers
+
+    def _find_next_frame_start(self, start: int, headers: set[bytes]) -> int:
+        """Find the index of the next plausible frame start starting from `start`."""
+        positions = [pos for h in headers if (pos := self._buffer.find(h, start)) != -1]
+        if positions:
+            return min(positions)
+
+        # Check if the very last byte could be the unit_id of a frame whose FC hasn't arrived
+        if len(self._buffer) > start and any(h[0] == self._buffer[-1] for h in headers):
+            return len(self._buffer) - 1
+
+        return len(self._buffer)
+
     def _discard_garbage_data(self) -> None:
         """Discard garbage data from the buffer."""
-        expected_unit_ids: set[int] = set(self._timed_out_requests.keys())
-        if self._pending_request is not None and not self._pending_request.future.done():
-            expected_unit_ids.add(self._pending_request.unit_id)
-
-        if not expected_unit_ids:
+        headers = self._get_expected_headers()
+        if not headers:
             # No pending requests at all - discard everything
             logger.warning(
                 "Received data with no pending requests. Discarding %d bytes: %s",
@@ -442,35 +472,50 @@ class ModbusRtuProtocol(asyncio.Protocol):
             self._buffer.clear()
             return
 
-        # Search for the first byte matching an expected unit_id
-        discard_count = len(self._buffer)
-        for i, byte in enumerate(self._buffer):
-            if byte in expected_unit_ids:
-                discard_count = i
-                break
-
-        discarded = bytes(self._buffer[:discard_count])
-        logger.warning(
-            "Discarding %d byte(s): %s",
-            discard_count,
-            discarded.hex(" ").upper(),
-        )
-        del self._buffer[:discard_count]
+        discard_count = self._find_next_frame_start(0, headers)
+        if discard_count > 0:
+            discarded = bytes(self._buffer[:discard_count])
+            logger.warning(
+                "Discarding %d byte(s): %s",
+                discard_count,
+                discarded.hex(" ").upper(),
+            )
+            del self._buffer[:discard_count]
 
     def _resync_discard_length(self) -> int:
         """Get the number of leading bytes to discard to resynchronize after a bad frame.
 
-        Skips ahead to the next byte matching an expected unit id, so a garbage burst is
-        dropped in one slice instead of one byte per pass through the receive loop.
+        Skips ahead to the next byte sequence matching an expected 2-byte header,
+        so a garbage burst is dropped in one slice instead of one byte per pass
+        through the receive loop.
         """
-        expected_unit_ids: set[int] = set(self._timed_out_requests.keys())
-        if self._pending_request is not None and not self._pending_request.future.done():
-            expected_unit_ids.add(self._pending_request.unit_id)
+        headers = self._get_expected_headers()
+        if not headers:
+            return max(1, len(self._buffer))
 
-        for i in range(1, len(self._buffer)):
-            if self._buffer[i] in expected_unit_ids:
-                return i
-        return 1  # no plausible frame start ahead; drop only the leading byte
+        return max(1, self._find_next_frame_start(1, headers))
+
+    def _validate_function_code(
+        self,
+        function_code: int,
+        pending_pdu: BaseClientPDU[Any] | None,
+    ) -> None:
+        """Validate that the incoming function code matches the expected pending request."""
+        if pending_pdu is None:
+            return
+
+        expected_base_fc = pending_pdu.function_code & FUNCTION_CODE_MASK
+        if function_code & EXCEPTION_RESPONSE_BIT:
+            if (function_code & FUNCTION_CODE_MASK) != expected_base_fc:
+                expected_fc = expected_base_fc | EXCEPTION_RESPONSE_BIT
+                msg = (
+                    f"Function code mismatch for exception response: "
+                    f"expected {expected_fc:#04x}, received {function_code:#04x}"
+                )
+                raise FunctionCodeError(msg, response_bytes=bytes(self._buffer))
+        elif function_code != pending_pdu.function_code:
+            msg = f"Function code mismatch: expected {pending_pdu.function_code:#04x}, received {function_code:#04x}"
+            raise FunctionCodeError(msg, response_bytes=bytes(self._buffer))
 
     def _determine_expected_frame_length(self, pending_pdu: BaseClientPDU[Any] | None = None) -> int | None:
         """Determine expected frame length based on current buffer contents.
@@ -486,16 +531,11 @@ class ModbusRtuProtocol(asyncio.Protocol):
         if len(self._buffer) < 2:
             return None  # Need at least address + function code
         function_code = self._buffer[1]
+        self._validate_function_code(function_code, pending_pdu)
 
         if function_code & EXCEPTION_RESPONSE_BIT:  # Exception response
             expected_total_frame_length = 5  # address + exception FC + exception code + CRC
         else:
-            if pending_pdu is not None and function_code != pending_pdu.function_code:
-                msg = (
-                    f"Function code mismatch: expected {pending_pdu.function_code:#04x}, received {function_code:#04x}"
-                )
-                raise FunctionCodeError(msg, response_bytes=bytes(self._buffer))
-
             # check if we can already determine the expected length with the available data
             try:
                 if not is_function_code_for_subfunction_pdu(function_code):
@@ -701,15 +741,15 @@ class ModbusRtuProtocol(asyncio.Protocol):
             try:
                 expected_total_frame_length = self._determine_expected_frame_length(pending.pdu)
             except (RTUFrameError, FunctionCodeError) as e:
+                discard_length = self._resync_discard_length()
                 logger.warning(
-                    "Framing error for unit %d: %s. Discarding leading byte %s",
+                    "Framing error for unit %d: %s. Discarding %d byte(s) to resynchronize.",
                     unit_id,
                     e,
-                    self._buffer[0:1].hex(" ").upper() if self._buffer else "",
+                    discard_length,
                 )
                 last_error = e
-                if self._buffer:
-                    del self._buffer[0]
+                del self._buffer[:discard_length]
                 continue
 
             if expected_total_frame_length is None or len(self._buffer) < expected_total_frame_length:

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -1563,24 +1563,24 @@ async def test_try_drain_timed_out_response_branches(
     protocol._buffer = bytearray(b"\x01")
     assert protocol._try_drain_timed_out_response(unit_id, pdu) is True
 
-    # 2. When _determine_expected_frame_length raises error -> pops and discards leading byte
+    # 2. When _determine_expected_frame_length raises error -> pops and discards leading garbage slice
     protocol._buffer = bytearray(b"\x01\x65\x00\x00")
     protocol._timed_out_requests[unit_id] = pdu
     assert protocol._try_drain_timed_out_response(unit_id, pdu) is False
     assert unit_id not in protocol._timed_out_requests
-    assert protocol._buffer == bytearray(b"\x65\x00\x00")
+    assert protocol._buffer == bytearray(b"")  # No plausible start ahead; entire slice discarded
 
-    # 3. When candidate frame has invalid CRC -> del buffer[0] and returns False
+    # 3. When candidate frame has invalid CRC -> discards bad frame up to next plausible start
     class DummyPduClass:
         @staticmethod
         def get_expected_response_data_length(_begin_bytes: bytes) -> int:
             return 1
 
     monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
-    protocol._buffer = bytearray(b"\x01\x03\x05\xff\xff")  # bad CRC
+    protocol._buffer = bytearray(b"\x01\x03\x05\xff\xff\x01\x03\x05\xaa\xbb")  # bad frame followed by next candidate
     protocol._timed_out_requests[unit_id] = pdu
     assert protocol._try_drain_timed_out_response(unit_id, pdu) is False
-    assert protocol._buffer == bytearray(b"\x03\x05\xff\xff")  # Leading 0x01 was deleted
+    assert protocol._buffer == bytearray(b"\x01\x03\x05\xaa\xbb")  # Resynchronized to next plausible frame start
 
 
 async def test_delayed_response_drained_in_chunks(
@@ -2017,3 +2017,145 @@ async def test_cancelled_request_is_tracked_and_delayed_response_drained(
     await resp_task
 
     assert result == ("decoded", b"\x03\x09")
+
+
+async def test_resync_skips_matching_unit_id_with_wrong_function_code(
+    mock_transport: MagicMock,
+) -> None:
+    """Test that _resync_discard_length skips embedded unit_id bytes whose following byte is not an expected FC."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()  # FC 0x03
+    unit_id = 1
+    protocol._pending_request = _PendingRequest(
+        unit_id=unit_id,
+        future=asyncio.get_event_loop().create_future(),
+        pdu=pdu,
+    )
+
+    # Buffer starts with bad frame (unit 1, FC 03), followed by false starts:
+    # 01 90 (wrong FC), 01 E1 (wrong FC), 01 00 (wrong FC), 01 0B (wrong FC)
+    # and finally a valid frame: 01 03 05 + CRC
+    valid_payload = bytes([unit_id, pdu.function_code, 0x05])
+    valid_frame = valid_payload + calculate_crc16(valid_payload)
+
+    corrupted_data = (
+        bytes([unit_id, pdu.function_code, 0xFF, 0xFF, 0xFF])  # bad frame at index 0 (len 5)
+        + bytes([unit_id, 0x90, 0x00, 0x00])  # false start 1 (index 5)
+        + bytes([unit_id, 0xE1, 0x03, 0xFF])  # false start 2 (index 9)
+        + bytes([unit_id, 0x00, 0x0F, 0x80])  # false start 3 (index 13)
+        + bytes([unit_id, 0x0B, 0x00, 0x00])  # false start 4 (index 17)
+        + valid_frame  # valid frame starts at index 21
+    )
+
+    protocol._buffer = bytearray(corrupted_data)
+
+    # _resync_discard_length should skip all false starts and return index 21 directly
+    assert protocol._resync_discard_length() == 21
+
+
+async def test_extract_log_real_life_resync_recovery(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test recovery from real-life scenario in extract.log where payload contains multiple 0x01 bytes."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()  # FC 0x03
+    unit_id = 1
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(begin_bytes: bytes) -> int:
+            if not begin_bytes:
+                return 1
+            # In Modbus Read Holding Registers, first data byte is byte count
+            return begin_bytes[0] + 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    # Valid response frame
+    good_payload = bytes([unit_id, pdu.function_code, 0x02, 0x12, 0x34])  # 2 bytes data
+    good_frame = good_payload + calculate_crc16(good_payload)
+
+    # Corrupt frame that fails CRC and contains embedded 0x01 bytes with non-matching function codes
+    corrupt_candidate = (
+        bytes([unit_id, pdu.function_code, 0x08])  # byte count 8 (candidate total length = 1 + 1 + 1 + 8 + 2 = 13)
+        + bytes([0x01, 0x90, 0x00, 0x02, 0x01, 0xE1, 0x03, 0xFF])
+        + b"\x00\x00"  # invalid CRC
+    )
+
+    async def simulate_traffic() -> None:
+        await asyncio.sleep(0.01)
+        protocol.data_received(corrupt_candidate + good_frame)
+
+    task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    sim_task = asyncio.create_task(simulate_traffic())
+
+    result = await task
+    await sim_task
+
+    assert result == ("decoded", b"\x03\x02\x12\x34")
+    assert len(protocol._buffer) == 0
+
+
+async def test_determine_expected_frame_length_exception_fc_mismatch(
+    mock_transport: MagicMock,
+) -> None:
+    """Test that _determine_expected_frame_length rejects exception responses with mismatched function code."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()  # FC 0x03
+    # 0x90 is exception response for FC 0x10, not 0x03 (which expects 0x83)
+    protocol._buffer = bytearray(b"\x01\x90\x02\x00\x00")
+
+    with pytest.raises(FunctionCodeError, match=r"Function code mismatch for exception response"):
+        protocol._determine_expected_frame_length(pdu)
+
+
+async def test_discard_garbage_data_preserves_trailing_unit_id(
+    mock_transport: MagicMock,
+) -> None:
+    """Test that _discard_garbage_data retains trailing single byte matching unit_id when waiting for next chunk."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+    unit_id = 1
+    protocol._pending_request = _PendingRequest(
+        unit_id=unit_id,
+        future=asyncio.get_event_loop().create_future(),
+        pdu=pdu,
+    )
+
+    # Buffer has garbage ending in 0x01 (unit_id) as the very last byte
+    protocol._buffer = bytearray(b"\xff\xfe\xfd\x01")
+    protocol._discard_garbage_data()
+
+    # The 3 leading garbage bytes are discarded, but the trailing 0x01 is preserved
+    assert protocol._buffer == bytearray(b"\x01")
+
+
+async def test_discard_garbage_data_when_buffer_starts_with_valid_header(
+    mock_transport: MagicMock,
+) -> None:
+    """Test that _discard_garbage_data does not discard anything when buffer starts with a valid header."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+    unit_id = 1
+    protocol._pending_request = _PendingRequest(
+        unit_id=unit_id,
+        future=asyncio.get_event_loop().create_future(),
+        pdu=pdu,
+    )
+
+    protocol._buffer = bytearray(b"\x01\x03\x05\xaa\xbb")
+    protocol._discard_garbage_data()
+
+    assert protocol._buffer == bytearray(b"\x01\x03\x05\xaa\xbb")


### PR DESCRIPTION
Instead of just looking for the expected unit-id bytes when resyncing, we now also look at the next byte to check if it contains either the expected function code, or an expected error code. This allows us to skip even more unexpected data.