### PR TITLE
Add support for serial-only PDUs

### DIFF
--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -311,3 +311,90 @@ custom x.509 extension with the Modbus.org Private Enterprise OID
 
 The :func:`~tmodbus.server.security.extract_modbus_role` utility extracts this role
 value. If the extension is absent, it returns ``None``.
+
+*********************************************************************
+ Response Suppression & Listen-Only Mode (Serial Line / Diagnostics)
+*********************************************************************
+
+On Modbus serial networks (RS-485 / RS-232), slave devices can be commanded into
+**Listen-Only Mode** via Diagnostics (Function Code 0x08, Sub-function ``0x0004`` -
+:class:`~tmodbus.pdu.DiagnosticsForceListenOnlyModePDU`).
+
+While in Listen-Only mode, a Modbus device:
+
+1. Continues to process incoming traffic and update internal states or diagnostic
+   counters.
+2. Must **suppress sending any response frames** back over the serial bus.
+3. Resumes normal response transmission only upon receiving a **Restart Communications
+   Option** request (Sub-function ``0x0001`` -
+   :class:`~tmodbus.pdu.DiagnosticsRestartCommunicationsOptionPDU`).
+
+To signal to serial server transports (:class:`~tmodbus.server.AsyncRtuServer`,
+:class:`~tmodbus.server.AsyncAsciiServer`, and
+:class:`~tmodbus.server.AsyncRtuOverTcpServer`) that a response should be suppressed,
+handlers can raise :exc:`~tmodbus.exceptions.SuppressResponseError`.
+
+Sample Handler Implementation
+=============================
+
+Below is a sample handler wrapper class that tracks Listen-Only mode, handles diagnostic
+force/restart PDUs, and suppresses responses for all incoming requests while in
+Listen-Only mode:
+
+.. code-block:: python
+
+    from typing import Any
+    from tmodbus.exceptions import SuppressResponseError
+    from tmodbus.pdu import (
+        BasePDU,
+        DiagnosticsForceListenOnlyModePDU,
+        DiagnosticsRestartCommunicationsOptionPDU,
+        ReadHoldingRegistersPDU,
+    )
+    from tmodbus.server import ModbusRequestRouter
+
+
+    class ListenOnlyAwareHandler:
+        """Handler wrapper that implements Modbus Listen-Only mode state tracking."""
+
+        def __init__(self, inner_router: ModbusRequestRouter) -> None:
+            self.inner_router = inner_router
+            self.listen_only_mode = False
+
+        async def __call__(self, unit_id: int, request: BasePDU[Any]) -> Any:
+            # 1. Handle Force Listen Only Mode (FC08 sub 4)
+            if isinstance(request, DiagnosticsForceListenOnlyModePDU):
+                self.listen_only_mode = True
+                raise SuppressResponseError
+
+            # 2. Handle Restart Communications Option (FC08 sub 1)
+            if isinstance(request, DiagnosticsRestartCommunicationsOptionPDU):
+                self.listen_only_mode = False
+                # Echo data (0x0000 or 0xFF00) back to client
+                return request.data
+
+            # 3. Delegate to standard request router
+            response = await self.inner_router(unit_id, request)
+
+            # 4. If currently in Listen Only mode, suppress response
+            if self.listen_only_mode:
+                raise SuppressResponseError
+
+            # 5. Return the response for normal operation
+            return response
+
+
+    # Setup request router for normal operations
+    router = ModbusRequestRouter()
+
+
+    @router.register(WriteSingleRegisterPDU)
+    async def handle_write_single_register(
+        _unit_id: int, _request: WriteSingleRegisterPDU
+    ) -> int:
+        # Do something useful here
+        return _request.value
+
+
+    # Wrap the router with ListenOnlyAwareHandler
+    handler = ListenOnlyAwareHandler(router)

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -343,13 +343,13 @@ Listen-Only mode:
 
 .. code-block:: python
 
-    from typing import Any
+    from typing import cast
     from tmodbus.exceptions import SuppressResponseError
     from tmodbus.pdu import (
         BasePDU,
         DiagnosticsForceListenOnlyModePDU,
         DiagnosticsRestartCommunicationsOptionPDU,
-        ReadHoldingRegistersPDU,
+        WriteSingleRegisterPDU,
     )
     from tmodbus.server import ModbusRequestRouter
 
@@ -361,7 +361,7 @@ Listen-Only mode:
             self.inner_router = inner_router
             self.listen_only_mode = False
 
-        async def __call__(self, unit_id: int, request: BasePDU[Any]) -> Any:
+        async def __call__[T](self, unit_id: int, request: BasePDU[T]) -> T:
             # 1. Handle Force Listen Only Mode (FC08 sub 4)
             if isinstance(request, DiagnosticsForceListenOnlyModePDU):
                 self.listen_only_mode = True
@@ -371,7 +371,7 @@ Listen-Only mode:
             if isinstance(request, DiagnosticsRestartCommunicationsOptionPDU):
                 self.listen_only_mode = False
                 # Echo data (0x0000 or 0xFF00) back to client
-                return request.data
+                return cast(T, request.data)
 
             # 3. Delegate to standard request router
             response = await self.inner_router(unit_id, request)

--- a/src/tmodbus/client/async_client.py
+++ b/src/tmodbus/client/async_client.py
@@ -28,7 +28,29 @@ from tmodbus.pdu import (
 )
 from tmodbus.pdu.fifo import ReadFifoQueuePDU
 from tmodbus.pdu.holding_registers_struct import HoldingRegisterReadMixin, HoldingRegisterWriteMixin
-from tmodbus.pdu.serial_line import ReportServerIdPDU, ServerIdResponse
+from tmodbus.pdu.serial_line import (
+    CommEventCounterResponse,
+    CommEventLogResponse,
+    DiagnosticsBusCharacterOverrunCountPDU,
+    DiagnosticsBusCommunicationErrorCountPDU,
+    DiagnosticsBusExceptionErrorCountPDU,
+    DiagnosticsBusMessageCountPDU,
+    DiagnosticsChangeAsciiInputDelimiterPDU,
+    DiagnosticsClearCountersAndRegisterPDU,
+    DiagnosticsClearOverrunCounterAndFlagPDU,
+    DiagnosticsDiagnosticRegisterPDU,
+    DiagnosticsForceListenOnlyModePDU,
+    DiagnosticsQueryDataPDU,
+    DiagnosticsRestartCommunicationsOptionPDU,
+    DiagnosticsServerBusyCountPDU,
+    DiagnosticsServerMessageCountPDU,
+    DiagnosticsServerNakCountPDU,
+    DiagnosticsServerNoResponseCountPDU,
+    GetCommEventCounterPDU,
+    GetCommEventLogPDU,
+    ReportServerIdPDU,
+    ServerIdResponse,
+)
 from tmodbus.transport.async_base import AsyncBaseTransport
 
 logger = logging.getLogger(__name__)
@@ -347,6 +369,169 @@ class AsyncModbusClient(HoldingRegisterReadMixin, HoldingRegisterWriteMixin):
 
         """
         return await self.execute(ReportServerIdPDU())
+
+    async def diag_read_query_data(self, data: bytes = b"\x00\x00") -> bytes:
+        """Diagnostics sub-function 0x0000: Return Query Data.
+
+        Args:
+            data: Data bytes to loop back (must be an even number of bytes).
+
+        Returns:
+            The looped back data bytes.
+
+        """
+        return await self.execute(DiagnosticsQueryDataPDU(data=data))
+
+    async def diag_restart_communications_option(
+        self,
+        clear_event_log: bool = False,  # noqa: FBT001, FBT002
+    ) -> bool:
+        """Diagnostics sub-function 0x0001: Restart Communications Option.
+
+        Args:
+            clear_event_log: Whether to clear the communications event log.
+
+        Returns:
+            Boolean status indicating if event log was cleared.
+
+        """
+        return await self.execute(DiagnosticsRestartCommunicationsOptionPDU(clear_event_log=clear_event_log))
+
+    async def diag_read_diagnostic_register(self) -> int:
+        """Diagnostics sub-function 0x0002: Return Diagnostic Register.
+
+        Returns:
+            16-bit diagnostic register value.
+
+        """
+        return await self.execute(DiagnosticsDiagnosticRegisterPDU())
+
+    async def diag_change_ascii_input_delimiter(self, delimiter: int = 0x0A) -> int:
+        """Diagnostics sub-function 0x0003: Change ASCII Input Delimiter.
+
+        Args:
+            delimiter: ASCII delimiter character code (0-255).
+
+        Returns:
+            The delimiter character code.
+
+        """
+        return await self.execute(DiagnosticsChangeAsciiInputDelimiterPDU(delimiter=delimiter))
+
+    async def diag_force_listen_only_mode(self) -> None:
+        """Diagnostics sub-function 0x0004: Force Listen Only Mode."""
+        return await self.execute(DiagnosticsForceListenOnlyModePDU())
+
+    async def diag_clear_counters_and_register(self) -> None:
+        """Diagnostics sub-function 0x000A: Clear Counters and Diagnostic Register."""
+        return await self.execute(DiagnosticsClearCountersAndRegisterPDU())
+
+    async def diag_read_bus_message_count(self) -> int:
+        """Diagnostics sub-function 0x000B: Return Bus Message Count.
+
+        Returns:
+            Total message count.
+
+        """
+        return await self.execute(DiagnosticsBusMessageCountPDU())
+
+    async def diag_read_bus_communication_error_count(self) -> int:
+        """Diagnostics sub-function 0x000C: Return Bus Communication Error Count.
+
+        Returns:
+            CRC error count.
+
+        """
+        return await self.execute(DiagnosticsBusCommunicationErrorCountPDU())
+
+    async def diag_read_bus_exception_error_count(self) -> int:
+        """Diagnostics sub-function 0x000D: Return Bus Exception Error Count.
+
+        Returns:
+            Exception error count.
+
+        """
+        return await self.execute(DiagnosticsBusExceptionErrorCountPDU())
+
+    async def diag_read_server_message_count(self) -> int:
+        """Diagnostics sub-function 0x000E: Return Server Message Count.
+
+        Returns:
+            Server message count.
+
+        """
+        return await self.execute(DiagnosticsServerMessageCountPDU())
+
+    async def diag_read_server_no_response_count(self) -> int:
+        """Diagnostics sub-function 0x000F: Return Server No Response Count.
+
+        Returns:
+            Server no response count.
+
+        """
+        return await self.execute(DiagnosticsServerNoResponseCountPDU())
+
+    async def diag_read_server_nak_count(self) -> int:
+        """Diagnostics sub-function 0x0010: Return Server NAK Count.
+
+        Returns:
+            Server NAK count.
+
+        """
+        return await self.execute(DiagnosticsServerNakCountPDU())
+
+    async def diag_read_server_busy_count(self) -> int:
+        """Diagnostics sub-function 0x0011: Return Server Busy Count.
+
+        Returns:
+            Server busy count.
+
+        """
+        return await self.execute(DiagnosticsServerBusyCountPDU())
+
+    async def diag_read_bus_character_overrun_count(self) -> int:
+        """Diagnostics sub-function 0x0012: Return Bus Character Overrun Count.
+
+        Returns:
+            Character overrun count.
+
+        """
+        return await self.execute(DiagnosticsBusCharacterOverrunCountPDU())
+
+    async def diag_clear_overrun_counter_and_flag(self) -> None:
+        """Diagnostics sub-function 0x0014: Clear Overrun Counter and Flag."""
+        return await self.execute(DiagnosticsClearOverrunCounterAndFlagPDU())
+
+    async def get_comm_event_counter(self) -> CommEventCounterResponse:
+        """Get Comm Event Counter (Function Code 0x0B).
+
+        Returns:
+            An instance of CommEventCounterResponse containing status and event_count.
+
+        Example:
+            .. code-block:: python
+
+                response = await client.get_comm_event_counter()
+                print("Event Count:", response.event_count)
+
+        """
+        return await self.execute(GetCommEventCounterPDU())
+
+    async def get_comm_event_log(self) -> CommEventLogResponse:
+        """Get Comm Event Log (Function Code 0x0C).
+
+        Returns:
+            An instance of CommEventLogResponse containing status, event_count, message_count, and events bytes.
+
+        Example:
+            .. code-block:: python
+
+                response = await client.get_comm_event_log()
+                print("Message Count:", response.message_count)
+                print("Events:", response.events)
+
+        """
+        return await self.execute(GetCommEventLogPDU())
 
     async def read_file_records(
         self,

--- a/src/tmodbus/exceptions.py
+++ b/src/tmodbus/exceptions.py
@@ -9,6 +9,15 @@ class TModbusError(Exception):
     """Base exception class for tModbus library."""
 
 
+class SuppressResponseError(TModbusError):
+    """Exception raised by a server handler to explicitly suppress sending a response frame.
+
+    When caught by the server request handler dispatcher, the server will process the request
+    (e.g., executing side effects or state updates) but will omit sending any response bytes
+    back to the client.
+    """
+
+
 class ModbusConnectionError(TModbusError):
     """Connection error exception.
 

--- a/src/tmodbus/pdu/__init__.py
+++ b/src/tmodbus/pdu/__init__.py
@@ -19,7 +19,33 @@ from .holding_registers import (
     WriteMultipleRegistersPDU,
     WriteSingleRegisterPDU,
 )
-from .serial_line import ReportServerIdPDU, ServerIdResponse
+from .serial_line import (
+    BaseDiagnosticsSubFunctionPDU,
+    CommEventCounterResponse,
+    CommEventLogResponse,
+    DiagnosticsBusCharacterOverrunCountPDU,
+    DiagnosticsBusCommunicationErrorCountPDU,
+    DiagnosticsBusExceptionErrorCountPDU,
+    DiagnosticsBusMessageCountPDU,
+    DiagnosticsChangeAsciiInputDelimiterPDU,
+    DiagnosticsClearCountersAndRegisterPDU,
+    DiagnosticsClearOverrunCounterAndFlagPDU,
+    DiagnosticsDiagnosticRegisterPDU,
+    DiagnosticsForceListenOnlyModePDU,
+    DiagnosticsQueryDataPDU,
+    DiagnosticsRestartCommunicationsOptionPDU,
+    DiagnosticsServerBusyCountPDU,
+    DiagnosticsServerMessageCountPDU,
+    DiagnosticsServerNakCountPDU,
+    DiagnosticsServerNoResponseCountPDU,
+    DiagnosticSubFunction,
+    GetComEventCounterPDU,
+    GetComEventLogPDU,
+    GetCommEventCounterPDU,
+    GetCommEventLogPDU,
+    ReportServerIdPDU,
+    ServerIdResponse,
+)
 
 function_code_to_pdu_map: dict[int, type[BaseClientPDU[Any]]] = {
     FunctionCode.READ_COILS: ReadCoilsPDU,
@@ -29,6 +55,8 @@ function_code_to_pdu_map: dict[int, type[BaseClientPDU[Any]]] = {
     FunctionCode.WRITE_SINGLE_COIL: WriteSingleCoilPDU,
     FunctionCode.WRITE_SINGLE_REGISTER: WriteSingleRegisterPDU,
     FunctionCode.READ_EXCEPTION_STATUS: ReadExceptionStatusPDU,
+    FunctionCode.GET_COM_EVENT_COUNTER: GetCommEventCounterPDU,
+    FunctionCode.GET_COM_EVENT_LOG: GetCommEventLogPDU,
     FunctionCode.WRITE_MULTIPLE_COILS: WriteMultipleCoilsPDU,
     FunctionCode.WRITE_MULTIPLE_REGISTERS: WriteMultipleRegistersPDU,
     FunctionCode.REPORT_SERVER_ID: ReportServerIdPDU,
@@ -40,9 +68,26 @@ function_code_to_pdu_map: dict[int, type[BaseClientPDU[Any]]] = {
 }
 
 sub_function_code_to_pdu_map: dict[int, dict[int, type[BaseSubFunctionClientPDU[Any]]]] = {
+    FunctionCode.DIAGNOSTICS: {
+        DiagnosticsQueryDataPDU.sub_function_code: DiagnosticsQueryDataPDU,
+        DiagnosticsRestartCommunicationsOptionPDU.sub_function_code: DiagnosticsRestartCommunicationsOptionPDU,
+        DiagnosticsDiagnosticRegisterPDU.sub_function_code: DiagnosticsDiagnosticRegisterPDU,
+        DiagnosticsChangeAsciiInputDelimiterPDU.sub_function_code: DiagnosticsChangeAsciiInputDelimiterPDU,
+        DiagnosticsForceListenOnlyModePDU.sub_function_code: DiagnosticsForceListenOnlyModePDU,
+        DiagnosticsClearCountersAndRegisterPDU.sub_function_code: DiagnosticsClearCountersAndRegisterPDU,
+        DiagnosticsBusMessageCountPDU.sub_function_code: DiagnosticsBusMessageCountPDU,
+        DiagnosticsBusCommunicationErrorCountPDU.sub_function_code: DiagnosticsBusCommunicationErrorCountPDU,
+        DiagnosticsBusExceptionErrorCountPDU.sub_function_code: DiagnosticsBusExceptionErrorCountPDU,
+        DiagnosticsServerMessageCountPDU.sub_function_code: DiagnosticsServerMessageCountPDU,
+        DiagnosticsServerNoResponseCountPDU.sub_function_code: DiagnosticsServerNoResponseCountPDU,
+        DiagnosticsServerNakCountPDU.sub_function_code: DiagnosticsServerNakCountPDU,
+        DiagnosticsServerBusyCountPDU.sub_function_code: DiagnosticsServerBusyCountPDU,
+        DiagnosticsBusCharacterOverrunCountPDU.sub_function_code: DiagnosticsBusCharacterOverrunCountPDU,
+        DiagnosticsClearOverrunCounterAndFlagPDU.sub_function_code: DiagnosticsClearOverrunCounterAndFlagPDU,
+    },
     FunctionCode.ENCAPSULATED_INTERFACE_TRANSPORT: {
         ReadDeviceIdentificationPDU.sub_function_code: ReadDeviceIdentificationPDU,
-    }
+    },
 }
 
 
@@ -63,6 +108,13 @@ def register_pdu_class(pdu_class: type[BaseClientPDU[Any]]) -> None:
             raise ValueError(msg)
         if function_code not in sub_function_code_to_pdu_map:
             sub_function_code_to_pdu_map[function_code] = {}
+        # validate that the subfunction code length is the same for all subfunction PDUs
+        elif get_subfunction_code_length(pdu_class.function_code) != pdu_class.sub_function_code_length:
+            msg = (
+                f"Subfunction code length for function code {function_code:#04x} "
+                f"must be {get_subfunction_code_length(function_code)}, but got {pdu_class.sub_function_code_length}"
+            )
+            raise ValueError(msg)
 
         sub_function_code = pdu_class.sub_function_code
 
@@ -138,13 +190,63 @@ def get_subfunction_pdu_class(function_code: int, sub_function_code: int) -> typ
         raise ValueError(msg) from None
 
 
+def get_subfunction_code_length(function_code: int) -> int:
+    """Get the length of the sub-function code for a given function code.
+
+    Args:
+        function_code: Function code
+
+    Returns:
+        Length of the sub-function code
+
+    Raises:
+        ValueError: If function code is not supported
+
+    """
+    try:
+        # Get the first sub-function PDU class for the given function code
+        # and return its sub-function code length.
+        pdu_class = next(iter(sub_function_code_to_pdu_map[function_code].values()))
+    except KeyError:
+        msg = f"Unsupported function code {function_code:#02x}"
+        raise ValueError(msg) from None
+    except StopIteration:
+        msg = f"No sub-function PDU classes registered for function code {function_code:#02x}"
+        raise ValueError(msg) from None
+    else:
+        return pdu_class.sub_function_code_length
+
+
 __all__ = [
     "BaseClientPDU",
+    "BaseDiagnosticsSubFunctionPDU",
     "BasePDU",
     "BaseSubFunctionClientPDU",
     "BaseSubFunctionPDU",
+    "CommEventCounterResponse",
+    "CommEventLogResponse",
+    "DiagnosticSubFunction",
+    "DiagnosticsBusCharacterOverrunCountPDU",
+    "DiagnosticsBusCommunicationErrorCountPDU",
+    "DiagnosticsBusExceptionErrorCountPDU",
+    "DiagnosticsBusMessageCountPDU",
+    "DiagnosticsChangeAsciiInputDelimiterPDU",
+    "DiagnosticsClearCountersAndRegisterPDU",
+    "DiagnosticsClearOverrunCounterAndFlagPDU",
+    "DiagnosticsDiagnosticRegisterPDU",
+    "DiagnosticsForceListenOnlyModePDU",
+    "DiagnosticsQueryDataPDU",
+    "DiagnosticsRestartCommunicationsOptionPDU",
+    "DiagnosticsServerBusyCountPDU",
+    "DiagnosticsServerMessageCountPDU",
+    "DiagnosticsServerNakCountPDU",
+    "DiagnosticsServerNoResponseCountPDU",
     "FileRecord",
     "FileRecordRequest",
+    "GetComEventCounterPDU",
+    "GetComEventLogPDU",
+    "GetCommEventCounterPDU",
+    "GetCommEventLogPDU",
     "MaskWriteRegisterPDU",
     "ReadCoilsPDU",
     "ReadDeviceIdentificationPDU",

--- a/src/tmodbus/pdu/base.py
+++ b/src/tmodbus/pdu/base.py
@@ -13,6 +13,7 @@ class BaseClientPDU[RT](ABC):
 
     function_code: int
     rtu_response_data_length: int | None = None
+    expects_response: bool = True
 
     @abstractmethod
     def encode_request(self) -> bytes:
@@ -122,6 +123,7 @@ class BaseSubFunctionClientPDU[RT](BaseClientPDU[RT]):
     """
 
     sub_function_code: int
+    sub_function_code_length: int = 1
 
     @classmethod
     def get_expected_response_data_length(cls, data: bytes) -> int | None:
@@ -134,57 +136,26 @@ class BaseSubFunctionClientPDU[RT](BaseClientPDU[RT]):
             Expected length of the response PDU in bytes, or None if it cannot be determined yet.
 
         """
-        # Always assume that the first byte of the data-part of the frame contains the sub-function code
-        if data[0] != cls.sub_function_code:
-            msg = f"Expected sub-function code {cls.sub_function_code}, got {data[0]}"
+        if len(data) < cls.sub_function_code_length:
+            return None
+        received_sub_func = int.from_bytes(data[: cls.sub_function_code_length], "big")
+
+        if received_sub_func != cls.sub_function_code:
+            msg = f"Expected sub-function code {cls.sub_function_code}, got {received_sub_func}"
             raise FunctionCodeError(msg, response_bytes=data)
 
         # if a fixed length is defined for the response PDU, return it
         if cls.rtu_response_data_length is not None:
             return cls.rtu_response_data_length
 
-        # otherwise, we assume that the second byte of the data-part of the frame contains the total length of the PDU.
-        return (
-            1  # the first byte containing the sub-function code
-            + 1  # the second byte containing the total length of the PDU
-            + data[1]
-        )
+        # otherwise, we assume that the next byte contains the length of the remaining data
+        return cls.sub_function_code_length + 1 + data[cls.sub_function_code_length]
 
 
 class BaseSubFunctionPDU[RT](BaseSubFunctionClientPDU[RT], BasePDU[RT]):
-    """Extends the BaseServerPDU to include sub-function code.
-
-    Only the get_expected_response_data_length method is changed in this class.
-    """
+    """Extends BasePDU to include sub-function code."""
 
     sub_function_code: int
-
-    @classmethod
-    def get_expected_response_data_length(cls, data: bytes) -> int | None:
-        """Get the expected number of bytes for the data part of the response PDU.
-
-        This method should be implemented by subclasses to return the expected
-        length of the response based on the specific PDU type.
-
-        Returns:
-            Expected length of the response PDU in bytes
-
-        """
-        # Always assume that the first byte of the data-part of the frame contains the sub-function code
-        if data[0] != cls.sub_function_code:
-            msg = f"Expected sub-function code {cls.sub_function_code}, got {data[0]}"
-            raise FunctionCodeError(msg, response_bytes=data)
-
-        # if a fixed length is defined for the response PDU, return it
-        if cls.rtu_response_data_length is not None:
-            return cls.rtu_response_data_length
-
-        # otherwise, we assume that the second byte of the data-part of the frame contains the total length of the PDU.
-        return (
-            1  # the first byte containing the sub-function code
-            + 1  # the second byte containing the total length of the PDU
-            + data[1]
-        )
 
     @classmethod
     def get_expected_request_data_length(cls, data: bytes) -> int:
@@ -197,19 +168,17 @@ class BaseSubFunctionPDU[RT](BaseSubFunctionClientPDU[RT], BasePDU[RT]):
             Expected length of the request PDU in bytes
 
         """
-        # Always assume that the first byte of the data-part of the frame contains the sub-function code
-        if data[0] != cls.sub_function_code:
-            msg = f"Expected sub-function code {cls.sub_function_code}, got {data[0]}"
+        if len(data) < cls.sub_function_code_length:
+            msg = "Request data too short to read sub-function code"
+            raise InvalidRequestError(msg, request_bytes=data)
+        received_sub_func = int.from_bytes(data[: cls.sub_function_code_length], "big")
+
+        if received_sub_func != cls.sub_function_code:
+            msg = f"Expected sub-function code {cls.sub_function_code}, got {received_sub_func}"
             raise InvalidRequestError(msg, request_bytes=data)
 
         # if a fixed length is defined for the request PDU, return it
         if cls.rtu_request_data_length is not None:
             return cls.rtu_request_data_length
 
-        # otherwise, we assume that the first byte of the PDU-part of the response denotes
-        # the total length of the PDU.
-        # If this is not the case (ex. for function code 0x18), the subclass should override this method.
-        return (
-            1  # the first byte containing the total length of the PDU
-            + data[0]
-        )
+        return 1 + data[0]

--- a/src/tmodbus/pdu/serial_line.py
+++ b/src/tmodbus/pdu/serial_line.py
@@ -2,11 +2,645 @@
 
 import struct
 from dataclasses import dataclass
+from enum import IntEnum
 from typing import Self
 
+from tmodbus.const import FunctionCode
 from tmodbus.exceptions import FunctionCodeError, InvalidRequestError, InvalidResponseError
 
-from .base import BasePDU
+from .base import BasePDU, BaseSubFunctionPDU
+
+
+class DiagnosticSubFunction(IntEnum):
+    """Sub-function codes for Diagnostics (Function Code 0x08)."""
+
+    RETURN_QUERY_DATA = 0x0000
+    RESTART_COMMUNICATIONS_OPTION = 0x0001
+    RETURN_DIAGNOSTIC_REGISTER = 0x0002
+    CHANGE_ASCII_INPUT_DELIMITER = 0x0003
+    FORCE_LISTEN_ONLY_MODE = 0x0004
+    CLEAR_COUNTERS_AND_DIAGNOSTIC_REGISTER = 0x000A
+    RETURN_BUS_MESSAGE_COUNT = 0x000B
+    RETURN_BUS_COMMUNICATION_ERROR_COUNT = 0x000C
+    RETURN_BUS_EXCEPTION_ERROR_COUNT = 0x000D
+    RETURN_SERVER_MESSAGE_COUNT = 0x000E
+    RETURN_SERVER_NO_RESPONSE_COUNT = 0x000F
+    RETURN_SERVER_NAK_COUNT = 0x0010
+    RETURN_SERVER_BUSY_COUNT = 0x0011
+    RETURN_BUS_CHARACTER_OVERRUN_COUNT = 0x0012
+    CLEAR_OVERRUN_COUNTER_AND_FLAG = 0x0014
+
+
+class BaseDiagnosticsSubFunctionPDU[RT](BaseSubFunctionPDU[RT]):
+    """Base class for diagnostic sub-function PDUs (Function Code 0x08)."""
+
+    function_code = FunctionCode.DIAGNOSTICS
+    sub_function_code_length = 2
+
+
+class DiagnosticsQueryDataPDU(BaseDiagnosticsSubFunctionPDU[bytes]):
+    """Diagnostics sub-function 0x0000: Return Query Data."""
+
+    sub_function_code = DiagnosticSubFunction.RETURN_QUERY_DATA
+
+    def __init__(self, data: bytes = b"\x00\x00") -> None:
+        """Initialize DiagnosticsQueryDataPDU.
+
+        Args:
+            data: Data bytes to loop back (must be an even number of bytes).
+
+        """
+        if len(data) % 2 != 0:
+            msg = "Diagnostics query data must be an even number of bytes"
+            raise ValueError(msg)
+        self.data = data
+
+    def encode_request(self) -> bytes:
+        """Encode request PDU."""
+        return struct.pack(">BH", self.function_code, self.sub_function_code) + self.data
+
+    @classmethod
+    def get_expected_response_data_length(cls, data: bytes) -> int | None:
+        """Get expected response data length."""
+        if len(data) >= 2:
+            return len(data)
+        return 4
+
+    @classmethod
+    def get_expected_request_data_length(cls, data: bytes) -> int:
+        """Get expected request data length."""
+        if len(data) >= 2:
+            return len(data)
+        return 4
+
+    @classmethod
+    def decode_request(cls, request: bytes) -> Self:
+        """Decode request PDU."""
+        if len(request) < 3:
+            msg = f"Request length {len(request)} is too short"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        fc, sub_func = struct.unpack_from(">BH", request, 0)
+        if fc != cls.function_code or sub_func != cls.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {cls.function_code:#04x}/{cls.sub_function_code:#06x}"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        data = request[3:]
+        if len(data) % 2 != 0:
+            msg = "Diagnostics query data must be an even number of bytes"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        return cls(data=data)
+
+    def encode_response(self, value: bytes) -> bytes:
+        """Encode response PDU."""
+        if len(value) % 2 != 0:
+            msg = "Diagnostics query data must be an even number of bytes"
+            raise ValueError(msg)
+        return struct.pack(">BH", self.function_code, self.sub_function_code) + value
+
+    def decode_response(self, response: bytes) -> bytes:
+        """Decode response PDU."""
+        if len(response) < 3:
+            msg = f"Response length {len(response)} is too short"
+            raise InvalidResponseError(msg, response_bytes=response)
+
+        fc, sub_func = struct.unpack_from(">BH", response, 0)
+        if fc != self.function_code or sub_func != self.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {self.function_code:#04x}/{self.sub_function_code:#06x}"
+            raise FunctionCodeError(msg, response_bytes=response)
+
+        data = response[3:]
+        if len(data) % 2 != 0:
+            msg = "Diagnostics query data must be an even number of bytes"
+            raise InvalidResponseError(msg, response_bytes=response)
+
+        return data
+
+
+class DiagnosticsRestartCommunicationsOptionPDU(BaseDiagnosticsSubFunctionPDU[bool]):
+    """Diagnostics sub-function 0x0001: Restart Communications Option."""
+
+    sub_function_code = DiagnosticSubFunction.RESTART_COMMUNICATIONS_OPTION
+    rtu_request_data_length = 4
+    rtu_response_data_length = 4
+
+    def __init__(self, clear_event_log: bool = False) -> None:  # noqa: FBT001, FBT002
+        """Initialize DiagnosticsRestartCommunicationsOptionPDU.
+
+        Args:
+            clear_event_log: Whether to clear the communications event log.
+
+        """
+        self.clear_event_log = clear_event_log
+
+    def encode_request(self) -> bytes:
+        """Encode request PDU."""
+        data_val = 0xFF00 if self.clear_event_log else 0x0000
+        return struct.pack(">BHH", self.function_code, self.sub_function_code, data_val)
+
+    @classmethod
+    def decode_request(cls, request: bytes) -> Self:
+        """Decode request PDU."""
+        if len(request) != 5:
+            msg = f"Request length {len(request)} does not match expected 5"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        fc, sub_func, data_val = struct.unpack(">BHH", request)
+        if fc != cls.function_code or sub_func != cls.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {cls.function_code:#04x}/{cls.sub_function_code:#06x}"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        if data_val not in (0x0000, 0xFF00):
+            msg = f"Invalid restart option data: {data_val:#06x}, expected 0x0000 or 0xFF00"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        return cls(clear_event_log=(data_val == 0xFF00))
+
+    def encode_response(self, value: bool) -> bytes:  # noqa: FBT001
+        """Encode response PDU."""
+        data_val = 0xFF00 if value else 0x0000
+        return struct.pack(">BHH", self.function_code, self.sub_function_code, data_val)
+
+    def decode_response(self, response: bytes) -> bool:
+        """Decode response PDU."""
+        if len(response) != 5:
+            msg = f"Response length {len(response)} does not match expected 5"
+            raise InvalidResponseError(msg, response_bytes=response)
+
+        fc, sub_func, data_val = struct.unpack(">BHH", response)
+        if fc != self.function_code or sub_func != self.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {self.function_code:#04x}/{self.sub_function_code:#06x}"
+            raise FunctionCodeError(msg, response_bytes=response)
+
+        if data_val not in (0x0000, 0xFF00):
+            msg = f"Invalid restart option response data: {data_val:#06x}"
+            raise InvalidResponseError(msg, response_bytes=response)
+
+        return bool(data_val == 0xFF00)
+
+
+class DiagnosticsDiagnosticRegisterPDU(BaseDiagnosticsSubFunctionPDU[int]):
+    """Diagnostics sub-function 0x0002: Return Diagnostic Register."""
+
+    sub_function_code = DiagnosticSubFunction.RETURN_DIAGNOSTIC_REGISTER
+    rtu_request_data_length = 4
+    rtu_response_data_length = 4
+
+    def __init__(self) -> None:
+        """Initialize DiagnosticsDiagnosticRegisterPDU."""
+
+    def encode_request(self) -> bytes:
+        """Encode request PDU."""
+        return struct.pack(">BHH", self.function_code, self.sub_function_code, 0x0000)
+
+    @classmethod
+    def decode_request(cls, request: bytes) -> Self:
+        """Decode request PDU."""
+        if len(request) != 5:
+            msg = f"Request length {len(request)} does not match expected 5"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        fc, sub_func, _data_val = struct.unpack(">BHH", request)
+        if fc != cls.function_code or sub_func != cls.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {cls.function_code:#04x}/{cls.sub_function_code:#06x}"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        return cls()
+
+    def encode_response(self, value: int) -> bytes:
+        """Encode response PDU."""
+        if not (0 <= value <= 0xFFFF):
+            msg = f"Diagnostic register value {value} out of range (0-65535)"
+            raise ValueError(msg)
+        return struct.pack(">BHH", self.function_code, self.sub_function_code, value)
+
+    def decode_response(self, response: bytes) -> int:
+        """Decode response PDU."""
+        if len(response) != 5:
+            msg = f"Response length {len(response)} does not match expected 5"
+            raise InvalidResponseError(msg, response_bytes=response)
+
+        fc, sub_func, reg_val = struct.unpack(">BHH", response)
+        if fc != self.function_code or sub_func != self.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {self.function_code:#04x}/{self.sub_function_code:#06x}"
+            raise FunctionCodeError(msg, response_bytes=response)
+
+        return int(reg_val)
+
+
+class DiagnosticsChangeAsciiInputDelimiterPDU(BaseDiagnosticsSubFunctionPDU[int]):
+    """Diagnostics sub-function 0x0003: Change ASCII Input Delimiter."""
+
+    sub_function_code = DiagnosticSubFunction.CHANGE_ASCII_INPUT_DELIMITER
+    rtu_request_data_length = 4
+    rtu_response_data_length = 4
+
+    def __init__(self, delimiter: int = 0x0A) -> None:
+        """Initialize DiagnosticsChangeAsciiInputDelimiterPDU.
+
+        Args:
+            delimiter: ASCII delimiter character code (0-255).
+
+        """
+        if not (0 <= delimiter <= 0xFF):
+            msg = f"Delimiter {delimiter} out of range (0-255)"
+            raise ValueError(msg)
+        self.delimiter = delimiter
+
+    def encode_request(self) -> bytes:
+        """Encode request PDU."""
+        return struct.pack(">BHBB", self.function_code, self.sub_function_code, self.delimiter, 0x00)
+
+    @classmethod
+    def decode_request(cls, request: bytes) -> Self:
+        """Decode request PDU."""
+        if len(request) != 5:
+            msg = f"Request length {len(request)} does not match expected 5"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        fc, sub_func, delim, _pad = struct.unpack(">BHBB", request)
+        if fc != cls.function_code or sub_func != cls.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {cls.function_code:#04x}/{cls.sub_function_code:#06x}"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        return cls(delimiter=delim)
+
+    def encode_response(self, value: int) -> bytes:
+        """Encode response PDU."""
+        if not (0 <= value <= 0xFF):
+            msg = f"Delimiter {value} out of range (0-255)"
+            raise ValueError(msg)
+        return struct.pack(">BHBB", self.function_code, self.sub_function_code, value, 0x00)
+
+    def decode_response(self, response: bytes) -> int:
+        """Decode response PDU."""
+        if len(response) != 5:
+            msg = f"Response length {len(response)} does not match expected 5"
+            raise InvalidResponseError(msg, response_bytes=response)
+
+        _fc, _sub_func, delim, _pad = struct.unpack(">BHBB", response)
+        if _fc != self.function_code or _sub_func != self.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {self.function_code:#04x}/{self.sub_function_code:#06x}"
+            raise FunctionCodeError(msg, response_bytes=response)
+
+        return int(delim)
+
+
+class DiagnosticsForceListenOnlyModePDU(BaseDiagnosticsSubFunctionPDU[None]):
+    """Diagnostics sub-function 0x0004: Force Listen Only Mode."""
+
+    sub_function_code = DiagnosticSubFunction.FORCE_LISTEN_ONLY_MODE
+    rtu_request_data_length = 4
+    rtu_response_data_length = 4
+    expects_response = False
+
+    def get_broadcast_response(self) -> None:
+        """Get response for Force Listen Only Mode (no response)."""
+        return
+
+    def __init__(self) -> None:
+        """Initialize DiagnosticsForceListenOnlyModePDU."""
+
+    def encode_request(self) -> bytes:
+        """Encode request PDU."""
+        return struct.pack(">BHH", self.function_code, self.sub_function_code, 0x0000)
+
+    @classmethod
+    def decode_request(cls, request: bytes) -> Self:
+        """Decode request PDU."""
+        if len(request) != 5:
+            msg = f"Request length {len(request)} does not match expected 5"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        fc, sub_func, _data_val = struct.unpack(">BHH", request)
+        if fc != cls.function_code or sub_func != cls.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {cls.function_code:#04x}/{cls.sub_function_code:#06x}"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        return cls()
+
+    def encode_response(self, _value: None = None) -> bytes:
+        """Encode response PDU."""
+        return b""
+
+    def decode_response(self, response: bytes) -> None:
+        """Decode response PDU."""
+        msg = "No response expected"
+        raise InvalidResponseError(msg, response_bytes=response)
+
+
+class DiagnosticsClearCountersAndRegisterPDU(BaseDiagnosticsSubFunctionPDU[None]):
+    """Diagnostics sub-function 0x000A: Clear Counters and Diagnostic Register."""
+
+    sub_function_code = DiagnosticSubFunction.CLEAR_COUNTERS_AND_DIAGNOSTIC_REGISTER
+    rtu_request_data_length = 4
+    rtu_response_data_length = 4
+
+    def __init__(self) -> None:
+        """Initialize DiagnosticsClearCountersAndRegisterPDU."""
+
+    def encode_request(self) -> bytes:
+        """Encode request PDU."""
+        return struct.pack(">BHH", self.function_code, self.sub_function_code, 0x0000)
+
+    @classmethod
+    def decode_request(cls, request: bytes) -> Self:
+        """Decode request PDU."""
+        if len(request) != 5:
+            msg = f"Request length {len(request)} does not match expected 5"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        fc, sub_func, _data_val = struct.unpack(">BHH", request)
+        if fc != cls.function_code or sub_func != cls.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {cls.function_code:#04x}/{cls.sub_function_code:#06x}"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        return cls()
+
+    def encode_response(self, _value: None = None) -> bytes:
+        """Encode response PDU."""
+        return struct.pack(">BHH", self.function_code, self.sub_function_code, 0x0000)
+
+    def decode_response(self, response: bytes) -> None:
+        """Decode response PDU."""
+        if len(response) != 5:
+            msg = f"Response length {len(response)} does not match expected 5"
+            raise InvalidResponseError(msg, response_bytes=response)
+
+        fc, sub_func, _data_val = struct.unpack(">BHH", response)
+        if fc != self.function_code or sub_func != self.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {self.function_code:#04x}/{self.sub_function_code:#06x}"
+            raise FunctionCodeError(msg, response_bytes=response)
+
+
+class BaseDiagnosticsCounterPDU(BaseDiagnosticsSubFunctionPDU[int]):
+    """Base class for Diagnostics counter sub-function PDUs."""
+
+    rtu_request_data_length = 4
+    rtu_response_data_length = 4
+
+    def __init__(self) -> None:
+        """Initialize counter PDU."""
+
+    def encode_request(self) -> bytes:
+        """Encode request PDU."""
+        return struct.pack(">BHH", self.function_code, self.sub_function_code, 0x0000)
+
+    @classmethod
+    def decode_request(cls, request: bytes) -> Self:
+        """Decode request PDU."""
+        if len(request) != 5:
+            msg = f"Request length {len(request)} does not match expected 5"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        fc, sub_func, _data_val = struct.unpack(">BHH", request)
+        if fc != cls.function_code or sub_func != cls.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {cls.function_code:#04x}/{cls.sub_function_code:#06x}"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        return cls()
+
+    def encode_response(self, value: int) -> bytes:
+        """Encode response PDU."""
+        if not (0 <= value <= 0xFFFF):
+            msg = f"Counter value {value} out of range (0-65535)"
+            raise ValueError(msg)
+        return struct.pack(">BHH", self.function_code, self.sub_function_code, value)
+
+    def decode_response(self, response: bytes) -> int:
+        """Decode response PDU."""
+        if len(response) != 5:
+            msg = f"Response length {len(response)} does not match expected 5"
+            raise InvalidResponseError(msg, response_bytes=response)
+
+        fc, sub_func, count = struct.unpack(">BHH", response)
+        if fc != self.function_code or sub_func != self.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {self.function_code:#04x}/{self.sub_function_code:#06x}"
+            raise FunctionCodeError(msg, response_bytes=response)
+
+        return int(count)
+
+
+class DiagnosticsBusMessageCountPDU(BaseDiagnosticsCounterPDU):
+    """Diagnostics sub-function 0x000B: Return Bus Message Count."""
+
+    sub_function_code = DiagnosticSubFunction.RETURN_BUS_MESSAGE_COUNT
+
+
+class DiagnosticsBusCommunicationErrorCountPDU(BaseDiagnosticsCounterPDU):
+    """Diagnostics sub-function 0x000C: Return Bus Communication Error Count."""
+
+    sub_function_code = DiagnosticSubFunction.RETURN_BUS_COMMUNICATION_ERROR_COUNT
+
+
+class DiagnosticsBusExceptionErrorCountPDU(BaseDiagnosticsCounterPDU):
+    """Diagnostics sub-function 0x000D: Return Bus Exception Error Count."""
+
+    sub_function_code = DiagnosticSubFunction.RETURN_BUS_EXCEPTION_ERROR_COUNT
+
+
+class DiagnosticsServerMessageCountPDU(BaseDiagnosticsCounterPDU):
+    """Diagnostics sub-function 0x000E: Return Server Message Count."""
+
+    sub_function_code = DiagnosticSubFunction.RETURN_SERVER_MESSAGE_COUNT
+
+
+class DiagnosticsServerNoResponseCountPDU(BaseDiagnosticsCounterPDU):
+    """Diagnostics sub-function 0x000F: Return Server No Response Count."""
+
+    sub_function_code = DiagnosticSubFunction.RETURN_SERVER_NO_RESPONSE_COUNT
+
+
+class DiagnosticsServerNakCountPDU(BaseDiagnosticsCounterPDU):
+    """Diagnostics sub-function 0x0010: Return Server NAK Count."""
+
+    sub_function_code = DiagnosticSubFunction.RETURN_SERVER_NAK_COUNT
+
+
+class DiagnosticsServerBusyCountPDU(BaseDiagnosticsCounterPDU):
+    """Diagnostics sub-function 0x0011: Return Server Busy Count."""
+
+    sub_function_code = DiagnosticSubFunction.RETURN_SERVER_BUSY_COUNT
+
+
+class DiagnosticsBusCharacterOverrunCountPDU(BaseDiagnosticsCounterPDU):
+    """Diagnostics sub-function 0x0012: Return Bus Character Overrun Count."""
+
+    sub_function_code = DiagnosticSubFunction.RETURN_BUS_CHARACTER_OVERRUN_COUNT
+
+
+class DiagnosticsClearOverrunCounterAndFlagPDU(BaseDiagnosticsSubFunctionPDU[None]):
+    """Diagnostics sub-function 0x0014: Clear Overrun Counter and Flag."""
+
+    sub_function_code = DiagnosticSubFunction.CLEAR_OVERRUN_COUNTER_AND_FLAG
+    rtu_request_data_length = 4
+    rtu_response_data_length = 4
+
+    def __init__(self) -> None:
+        """Initialize DiagnosticsClearOverrunCounterAndFlagPDU."""
+
+    def encode_request(self) -> bytes:
+        """Encode request PDU."""
+        return struct.pack(">BHH", self.function_code, self.sub_function_code, 0x0000)
+
+    @classmethod
+    def decode_request(cls, request: bytes) -> Self:
+        """Decode request PDU."""
+        if len(request) != 5:
+            msg = f"Request length {len(request)} does not match expected 5"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        fc, sub_func, _data_val = struct.unpack(">BHH", request)
+        if fc != cls.function_code or sub_func != cls.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {cls.function_code:#04x}/{cls.sub_function_code:#06x}"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        return cls()
+
+    def encode_response(self, _value: None = None) -> bytes:
+        """Encode response PDU."""
+        return struct.pack(">BHH", self.function_code, self.sub_function_code, 0x0000)
+
+    def decode_response(self, response: bytes) -> None:
+        """Decode response PDU."""
+        if len(response) != 5:
+            msg = f"Response length {len(response)} does not match expected 5"
+            raise InvalidResponseError(msg, response_bytes=response)
+
+        fc, sub_func, _data_val = struct.unpack(">BHH", response)
+        if fc != self.function_code or sub_func != self.sub_function_code:
+            msg = f"Invalid function/sub-function: expected {self.function_code:#04x}/{self.sub_function_code:#06x}"
+            raise FunctionCodeError(msg, response_bytes=response)
+
+
+@dataclass(frozen=True)
+class CommEventCounterResponse:
+    """Response data structure for Get Comm Event Counter (FC0B)."""
+
+    status: int
+    event_count: int
+
+
+class GetCommEventCounterPDU(BasePDU[CommEventCounterResponse]):
+    """PDU for Get Comm Event Counter (function code 0x0B)."""
+
+    function_code = FunctionCode.GET_COM_EVENT_COUNTER
+    rtu_request_data_length = 0
+    rtu_response_data_length = 4
+
+    def __init__(self) -> None:
+        """Initialize GetCommEventCounterPDU."""
+
+    def encode_request(self) -> bytes:
+        """Encode the PDU into bytes."""
+        return bytes([self.function_code])
+
+    @classmethod
+    def decode_request(cls, request: bytes) -> Self:
+        """Decode bytes into a GetCommEventCounterPDU instance."""
+        if len(request) != 1:
+            msg = f"Expected request with only function code, got {len(request)} bytes"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        if request[0] != cls.function_code:
+            msg = f"Invalid function code: expected {cls.function_code:#04x}, received {request[0]:#04x}"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        return cls()
+
+    def encode_response(self, value: CommEventCounterResponse) -> bytes:
+        """Encode the response PDU."""
+        return struct.pack(">BHH", self.function_code, value.status, value.event_count)
+
+    def decode_response(self, response: bytes) -> CommEventCounterResponse:
+        """Decode the response PDU."""
+        if len(response) != 5:
+            msg = f"Response length {len(response)} does not match expected 5"
+            raise InvalidResponseError(msg, response_bytes=response)
+
+        function_code, status, event_count = struct.unpack(">BHH", response)
+        if function_code != self.function_code:
+            msg = f"Invalid function code: expected {self.function_code:#04x}, received {function_code:#04x}"
+            raise FunctionCodeError(msg, response_bytes=response)
+
+        return CommEventCounterResponse(status=status, event_count=event_count)
+
+
+# Alias matching const FunctionCode naming convention
+GetComEventCounterPDU = GetCommEventCounterPDU
+
+
+@dataclass(frozen=True)
+class CommEventLogResponse:
+    """Response data structure for Get Comm Event Log (FC0C)."""
+
+    status: int
+    event_count: int
+    message_count: int
+    events: bytes
+
+
+class GetCommEventLogPDU(BasePDU[CommEventLogResponse]):
+    """PDU for Get Comm Event Log (function code 0x0C)."""
+
+    function_code = FunctionCode.GET_COM_EVENT_LOG
+    rtu_request_data_length = 0
+
+    def __init__(self) -> None:
+        """Initialize GetCommEventLogPDU."""
+
+    def encode_request(self) -> bytes:
+        """Encode the PDU into bytes."""
+        return bytes([self.function_code])
+
+    @classmethod
+    def decode_request(cls, request: bytes) -> Self:
+        """Decode bytes into a GetCommEventLogPDU instance."""
+        if len(request) != 1:
+            msg = f"Expected request with only function code, got {len(request)} bytes"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        if request[0] != cls.function_code:
+            msg = f"Invalid function code: expected {cls.function_code:#04x}, received {request[0]:#04x}"
+            raise InvalidRequestError(msg, request_bytes=request)
+
+        return cls()
+
+    def encode_response(self, value: CommEventLogResponse) -> bytes:
+        """Encode the response PDU."""
+        byte_count = 6 + len(value.events)
+        return (
+            struct.pack(">BBHHH", self.function_code, byte_count, value.status, value.event_count, value.message_count)
+            + value.events
+        )
+
+    def decode_response(self, response: bytes) -> CommEventLogResponse:
+        """Decode the response PDU."""
+        if len(response) < 8:
+            msg = f"Response length {len(response)} is too short, expected at least 8 bytes"
+            raise InvalidResponseError(msg, response_bytes=response)
+
+        function_code, byte_count, status, event_count, message_count = struct.unpack_from(">BBHHH", response, 0)
+        if function_code != self.function_code:
+            msg = f"Invalid function code: expected {self.function_code:#04x}, received {function_code:#04x}"
+            raise FunctionCodeError(msg, response_bytes=response)
+
+        if len(response) != 2 + byte_count:
+            msg = f"Response length {len(response)} does not match expected {2 + byte_count}"
+            raise InvalidResponseError(msg, response_bytes=response)
+
+        events = response[8:]
+        return CommEventLogResponse(
+            status=status,
+            event_count=event_count,
+            message_count=message_count,
+            events=events,
+        )
+
+
+# Alias matching const FunctionCode naming convention
+GetComEventLogPDU = GetCommEventLogPDU
 
 
 @dataclass(frozen=True)

--- a/src/tmodbus/server/async_ascii.py
+++ b/src/tmodbus/server/async_ascii.py
@@ -213,7 +213,7 @@ class AsyncAsciiServer(AsyncBaseServer):
         else:
             response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)
 
-        if is_error or (unit_id != BROADCAST_UNIT_ID and request_pdu.expects_response):
+        if response_pdu_bytes and (is_error or (unit_id != BROADCAST_UNIT_ID and request_pdu.expects_response)):
             out_bin = bytearray([unit_id]) + response_pdu_bytes
             lrc = calculate_lrc(bytes(out_bin))
             out_bin.append(lrc)

--- a/src/tmodbus/server/async_ascii.py
+++ b/src/tmodbus/server/async_ascii.py
@@ -213,7 +213,7 @@ class AsyncAsciiServer(AsyncBaseServer):
         else:
             response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)
 
-        if unit_id != BROADCAST_UNIT_ID:
+        if is_error or (unit_id != BROADCAST_UNIT_ID and request_pdu.expects_response):
             out_bin = bytearray([unit_id]) + response_pdu_bytes
             lrc = calculate_lrc(bytes(out_bin))
             out_bin.append(lrc)
@@ -229,7 +229,7 @@ class AsyncAsciiServer(AsyncBaseServer):
                 log_raw_traffic("sent", out_frame, is_error=True)
         else:
             logger.debug(
-                "Response ignored for broadcast request. Not sending response bytes: %s",
+                "Response ignored for broadcast or no-response request. Not sending response bytes: %s",
                 format_bytes(response_pdu_bytes),
             )
         return "error" if is_error else "success"

--- a/src/tmodbus/server/async_rtu.py
+++ b/src/tmodbus/server/async_rtu.py
@@ -183,7 +183,7 @@ class AsyncRtuServer(AsyncBaseServer):
         else:
             response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)
 
-        if is_error or (unit_id != BROADCAST_UNIT_ID and request_pdu.expects_response):
+        if response_pdu_bytes and (is_error or (unit_id != BROADCAST_UNIT_ID and request_pdu.expects_response)):
             out_frame = bytearray([unit_id]) + response_pdu_bytes
             crc = calculate_crc16(bytes(out_frame))
             out_frame.extend(crc)

--- a/src/tmodbus/server/async_rtu.py
+++ b/src/tmodbus/server/async_rtu.py
@@ -183,7 +183,7 @@ class AsyncRtuServer(AsyncBaseServer):
         else:
             response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)
 
-        if unit_id != BROADCAST_UNIT_ID:
+        if is_error or (unit_id != BROADCAST_UNIT_ID and request_pdu.expects_response):
             out_frame = bytearray([unit_id]) + response_pdu_bytes
             crc = calculate_crc16(bytes(out_frame))
             out_frame.extend(crc)
@@ -200,7 +200,7 @@ class AsyncRtuServer(AsyncBaseServer):
                 log_raw_traffic("sent", bytes(out_frame), is_error=True)
         else:
             logger.debug(
-                "Response ignored for broadcast request. Not sending response bytes: %s",
+                "Response ignored for broadcast or no-response request. Not sending response bytes: %s",
                 format_bytes(response_pdu_bytes),
             )
 

--- a/src/tmodbus/server/async_rtu_over_tcp.py
+++ b/src/tmodbus/server/async_rtu_over_tcp.py
@@ -166,7 +166,7 @@ class AsyncRtuOverTcpServer(AsyncBaseServer):
             else:
                 response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)
 
-        if unit_id != BROADCAST_UNIT_ID:
+        if is_error or (unit_id != BROADCAST_UNIT_ID and request_pdu.expects_response):
             out_frame = bytearray([unit_id]) + response_pdu_bytes
             crc = calculate_crc16(bytes(out_frame))
             out_frame.extend(crc)
@@ -176,7 +176,7 @@ class AsyncRtuOverTcpServer(AsyncBaseServer):
             await writer.drain()
         else:
             logger.debug(
-                "Response ignored for broadcast request. Not sending response bytes: %s",
+                "Response ignored for broadcast or no-response request. Not sending response bytes: %s",
                 format_bytes(response_pdu_bytes),
             )
         return not is_error

--- a/src/tmodbus/server/async_rtu_over_tcp.py
+++ b/src/tmodbus/server/async_rtu_over_tcp.py
@@ -166,7 +166,7 @@ class AsyncRtuOverTcpServer(AsyncBaseServer):
             else:
                 response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)
 
-        if is_error or (unit_id != BROADCAST_UNIT_ID and request_pdu.expects_response):
+        if response_pdu_bytes and (is_error or (unit_id != BROADCAST_UNIT_ID and request_pdu.expects_response)):
             out_frame = bytearray([unit_id]) + response_pdu_bytes
             crc = calculate_crc16(bytes(out_frame))
             out_frame.extend(crc)

--- a/src/tmodbus/server/base.py
+++ b/src/tmodbus/server/base.py
@@ -9,6 +9,7 @@ from tmodbus.pdu import (
     BaseClientPDU,
     BasePDU,
     get_pdu_class,
+    get_subfunction_code_length,
     get_subfunction_pdu_class,
     is_function_code_for_subfunction_pdu,
 )
@@ -17,21 +18,22 @@ from .handler import is_server_pdu_class
 
 
 def get_server_pdu_class(pdu_bytes: bytes) -> type[BasePDU[Any]]:
-    """Return the server-capable PDU class for a request.
+    """Return the server-capable PDU class for *pdu_bytes*."""
+    return get_server_pdu_class_from_request_bytes(pdu_bytes)
 
-    Used by transports that receive a complete PDU byte string (TCP, ASCII).
-    The first byte of *pdu_bytes* is the function code; for sub-function PDUs
-    the second byte is the sub-function code.
+
+def get_server_pdu_class_from_request_bytes(pdu_bytes: bytes) -> type[BasePDU[Any]]:
+    """Return the server-capable PDU class for *pdu_bytes*.
 
     Args:
         pdu_bytes: Raw PDU bytes starting with the function code.
 
     Raises:
-        InvalidRequestError: If the PDU byte string is empty, or if a
-            sub-function PDU is detected but the byte string is too short to
-            contain the sub-function code.
-        ValueError: If the resolved PDU class does not implement server-side
-            methods (i.e. is a client-only PDU).
+        InvalidRequestError: If *pdu_bytes* is empty or too short for sub-function.
+        ValueError: If the resolved PDU class is client-only.
+
+    Returns:
+        The resolved ``BasePDU`` subclass.
 
     """
     if not pdu_bytes:
@@ -41,10 +43,12 @@ def get_server_pdu_class(pdu_bytes: bytes) -> type[BasePDU[Any]]:
     function_code = pdu_bytes[0]
     raw_pdu_class: type[BaseClientPDU[Any]]
     if is_function_code_for_subfunction_pdu(function_code):
-        if len(pdu_bytes) < 2:
+        # We assume all subfunction PDU's will report the same number of bytes for the subfunction code.
+        subfunction_code_length = get_subfunction_code_length(function_code)
+        if len(pdu_bytes) < 1 + subfunction_code_length:
             msg = "Missing sub-function code"
             raise InvalidRequestError(msg, request_bytes=pdu_bytes)
-        sub_function_code = pdu_bytes[1]
+        sub_function_code = int.from_bytes(pdu_bytes[1 : 1 + subfunction_code_length], "big")
         raw_pdu_class = get_subfunction_pdu_class(function_code, sub_function_code)
     else:
         raw_pdu_class = get_pdu_class(function_code)
@@ -81,9 +85,10 @@ def get_server_pdu_class_from_buffer(buffer: bytearray) -> type[BasePDU[Any]] | 
     function_code = buffer[1]
     pdu_class: type[BaseClientPDU[Any]]
     if is_function_code_for_subfunction_pdu(function_code):
-        if len(buffer) < 3:
+        subfunction_code_length = get_subfunction_code_length(function_code)
+        if len(buffer) < 2 + subfunction_code_length:
             return None
-        sub_function_code = buffer[2]
+        sub_function_code = int.from_bytes(buffer[2 : 2 + subfunction_code_length], "big")
         pdu_class = get_subfunction_pdu_class(function_code, sub_function_code)
     else:
         pdu_class = get_pdu_class(function_code)

--- a/src/tmodbus/server/handler.py
+++ b/src/tmodbus/server/handler.py
@@ -10,7 +10,7 @@ from collections.abc import Awaitable, Callable, Iterable
 from typing import TYPE_CHECKING, Any, Protocol, TypeGuard, cast
 
 from tmodbus.const import EXCEPTION_RESPONSE_BIT, ExceptionCode
-from tmodbus.exceptions import IllegalFunctionError, ModbusResponseError
+from tmodbus.exceptions import IllegalFunctionError, ModbusResponseError, SuppressResponseError
 from tmodbus.pdu import BaseClientPDU, BasePDU
 
 if TYPE_CHECKING:
@@ -306,6 +306,13 @@ async def handle_modbus_request[T](
         else:
             response_data = await handler(unit_id, request)
         return request.encode_response(response_data)
+    except SuppressResponseError:
+        logger.debug(
+            "Response explicitly suppressed by handler for unit_id %d, function %s",
+            unit_id,
+            request.function_code,
+        )
+        return b""
     except ModbusResponseError as e:
         logger.warning(
             "Modbus Exception %s (%s) for unit_id %d, function %s",

--- a/src/tmodbus/transport/async_ascii.py
+++ b/src/tmodbus/transport/async_ascii.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, TypeVar, Unpack
+from typing import Any, TypeVar, Unpack, cast
 
 from tmodbus.const import BROADCAST_UNIT_ID, EXCEPTION_RESPONSE_BIT, FUNCTION_CODE_MASK
 from tmodbus.exceptions import (
@@ -187,13 +187,14 @@ class ModbusAsciiProtocol(asyncio.Protocol):
                 await asyncio.sleep(to_wait)
 
             # Async send request
-            if broadcast_response is not None:
-                # We're broadcasting, so we don't need to wait for a response
-                # Just send it and return immediately
+            if not pdu.expects_response or broadcast_response is not None:
+                # We don't expect a response (broadcast or no-response PDU), so send and return immediately
                 self.transport.write(request_adu)
                 log_raw_traffic("sent", request_adu)
                 self._last_frame_ended_at = time.monotonic()
-                return broadcast_response
+                if broadcast_response is not None:
+                    return broadcast_response
+                return cast("RT", None)
 
             read_future: asyncio.Future[_ModbusAsciiMessage] = asyncio.get_running_loop().create_future()
             self._pending_request = _PendingRequest(unit_id=unit_id, future=read_future, pdu=pdu)
@@ -219,23 +220,27 @@ class ModbusAsciiProtocol(asyncio.Protocol):
             finally:
                 self._pending_request = None
 
-            # Check if it's an exception response
-            if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & EXCEPTION_RESPONSE_BIT:  # Exception response
-                function_code = response.pdu_bytes[0] & FUNCTION_CODE_MASK  # Remove exception flag bit
-                exception_code = response.pdu_bytes[1] if len(response.pdu_bytes) > 1 else 0
+            return self._decode_response_pdu(response, pdu)
 
-                if exception_code in error_code_to_exception_map:
-                    raise error_code_to_exception_map[exception_code](function_code)
-                raise UnknownModbusResponseError(exception_code, function_code)
+    def _decode_response_pdu(self, response: _ModbusAsciiMessage, pdu: BaseClientPDU[RT]) -> RT:
+        """Validate and decode the received PDU response."""
+        # Check if it's an exception response
+        if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & EXCEPTION_RESPONSE_BIT:
+            function_code = response.pdu_bytes[0] & FUNCTION_CODE_MASK
+            exception_code = response.pdu_bytes[1] if len(response.pdu_bytes) > 1 else 0
 
-            # Validate function code
-            response_function_code = response.pdu_bytes[0]
-            if response_function_code != pdu.function_code:
-                msg = f"Function code mismatch: expected {pdu.function_code}, received {response_function_code}"
-                raise FunctionCodeError(msg, response_bytes=response.bytes)
+            if exception_code in error_code_to_exception_map:
+                raise error_code_to_exception_map[exception_code](function_code)
+            raise UnknownModbusResponseError(exception_code, function_code)
 
-            # Return decoded response
-            return pdu.decode_response(response.pdu_bytes)
+        # Validate function code
+        response_function_code = response.pdu_bytes[0]
+        if response_function_code != pdu.function_code:
+            msg = f"Function code mismatch: expected {pdu.function_code}, received {response_function_code}"
+            raise FunctionCodeError(msg, response_bytes=response.bytes)
+
+        # Return decoded response
+        return pdu.decode_response(response.pdu_bytes)
 
     def _discard_garbage_data(self) -> None:
         """Discard garbage data from the buffer until we find a frame start."""

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -48,7 +48,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any, NotRequired, TypedDict, TypeVar, Unpack
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict, TypeVar, Unpack, cast
 
 if TYPE_CHECKING:
     from serialx import Parity, StopBits
@@ -62,7 +62,13 @@ from tmodbus.exceptions import (
     UnknownModbusResponseError,
     error_code_to_exception_map,
 )
-from tmodbus.pdu import BaseClientPDU, get_pdu_class, get_subfunction_pdu_class, is_function_code_for_subfunction_pdu
+from tmodbus.pdu import (
+    BaseClientPDU,
+    get_pdu_class,
+    get_subfunction_code_length,
+    get_subfunction_pdu_class,
+    is_function_code_for_subfunction_pdu,
+)
 from tmodbus.utils.crc import calculate_crc16, validate_crc16
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
 
@@ -378,12 +384,14 @@ class ModbusRtuProtocol(asyncio.Protocol):
                 await asyncio.sleep(to_wait)
 
             # Async send request
-            if broadcast_response is not None:
-                # We're broadcasting an action, so just send it and return immediately
+            if not pdu.expects_response or broadcast_response is not None:
+                # No response expected from server, so send and return immediately
                 self.transport.write(request_adu)
                 log_raw_traffic("sent", request_adu)
                 self._last_frame_ended_at = time.monotonic()
-                return broadcast_response
+                if broadcast_response is not None:
+                    return broadcast_response
+                return cast("RT", None)
 
             read_future: asyncio.Future[_ModbusRtuMessage] = asyncio.get_running_loop().create_future()
             self._pending_request = _PendingRequest(unit_id=unit_id, future=read_future, pdu=pdu)
@@ -408,23 +416,27 @@ class ModbusRtuProtocol(asyncio.Protocol):
             finally:
                 self._pending_request = None
 
-            # Check if it's an exception response
-            if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & EXCEPTION_RESPONSE_BIT:  # Exception response
-                function_code = response.pdu_bytes[0] & FUNCTION_CODE_MASK  # Remove exception flag bit
-                exception_code = response.pdu_bytes[1] if len(response.pdu_bytes) > 1 else 0
+            return self._decode_response_pdu(response, pdu)
 
-                if exception_code in error_code_to_exception_map:
-                    raise error_code_to_exception_map[exception_code](function_code)
-                raise UnknownModbusResponseError(exception_code, function_code)
+    def _decode_response_pdu(self, response: _ModbusRtuMessage, pdu: BaseClientPDU[RT]) -> RT:
+        """Validate and decode the received PDU response."""
+        # Check if it's an exception response
+        if len(response.pdu_bytes) > 0 and response.pdu_bytes[0] & EXCEPTION_RESPONSE_BIT:
+            function_code = response.pdu_bytes[0] & FUNCTION_CODE_MASK
+            exception_code = response.pdu_bytes[1] if len(response.pdu_bytes) > 1 else 0
 
-            # Validate function code
-            response_function_code = response.pdu_bytes[0]
-            if response_function_code != pdu.function_code:
-                msg = f"Function code mismatch: expected {pdu.function_code}, received {response_function_code}"
-                raise FunctionCodeError(msg, response_bytes=response.bytes)
+            if exception_code in error_code_to_exception_map:
+                raise error_code_to_exception_map[exception_code](function_code)
+            raise UnknownModbusResponseError(exception_code, function_code)
 
-            # Return decoded response
-            return pdu.decode_response(response.pdu_bytes)
+        # Validate function code
+        response_function_code = response.pdu_bytes[0]
+        if response_function_code != pdu.function_code:
+            msg = f"Function code mismatch: expected {pdu.function_code}, received {response_function_code}"
+            raise FunctionCodeError(msg, response_bytes=response.bytes)
+
+        # Return decoded response
+        return pdu.decode_response(response.pdu_bytes)
 
     def _get_expected_headers(self) -> set[bytes]:
         """Get set of expected 2-byte headers (unit_id + function_code).
@@ -541,11 +553,13 @@ class ModbusRtuProtocol(asyncio.Protocol):
                 if not is_function_code_for_subfunction_pdu(function_code):
                     pdu_class = get_pdu_class(function_code)
                 else:
-                    # It's a sub-function PDU, we need at least 6 bytes to determine the length
-                    # 6 = address + function code + sub-function code + at least 1 byte of data + CRC
-                    if len(self._buffer) < 6:
-                        return None  # Wait for more data
-                    sub_function_code = self._buffer[2]
+                    subfunction_code_length = get_subfunction_code_length(function_code)
+
+                    # It's a sub-function PDU, we need at least 5 + subfunction_code_length bytes to determine
+                    # the length: address + function code + sub-function code + at least 1 byte of data + CRC
+                    if len(self._buffer) < (5 + subfunction_code_length):
+                        return None
+                    sub_function_code = int.from_bytes(self._buffer[2 : 2 + subfunction_code_length], "big")
                     pdu_class = get_subfunction_pdu_class(function_code, sub_function_code)
             except ValueError as e:
                 if pending_pdu is not None:

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -457,15 +457,51 @@ async def test_mask_write_register(dummy_client: AsyncModbusClient) -> None:
 
 
 async def test_mask_request_server_id(dummy_client: AsyncModbusClient) -> None:
-    """Test mask_write_register method."""
+    """Test read_server_id method."""
     assert isinstance(dummy_client.transport, DummyAsyncTransport)
 
-    # Test successful mask write
+    # Test successful read server id
     result = await dummy_client.read_server_id()
     assert result == DUMMY_RESPONSE
 
     # Verify that send_and_receive was called with the correct PDU type
     assert ["send_and_receive", 1, "ReportServerIdPDU"] in dummy_client.transport.performed_actions
+
+
+async def test_diag_read_query_data(dummy_client: AsyncModbusClient) -> None:
+    """Test diag_read_query_data method."""
+    assert isinstance(dummy_client.transport, DummyAsyncTransport)
+
+    result = await dummy_client.diag_read_query_data(b"\xa5\x37")
+    assert result == DUMMY_RESPONSE
+    assert ["send_and_receive", 1, "DiagnosticsQueryDataPDU"] in dummy_client.transport.performed_actions
+
+
+async def test_diag_read_bus_message_count(dummy_client: AsyncModbusClient) -> None:
+    """Test diag_read_bus_message_count method."""
+    assert isinstance(dummy_client.transport, DummyAsyncTransport)
+
+    result = await dummy_client.diag_read_bus_message_count()
+    assert result == DUMMY_RESPONSE
+    assert ["send_and_receive", 1, "DiagnosticsBusMessageCountPDU"] in dummy_client.transport.performed_actions
+
+
+async def test_get_comm_event_counter(dummy_client: AsyncModbusClient) -> None:
+    """Test get_comm_event_counter method."""
+    assert isinstance(dummy_client.transport, DummyAsyncTransport)
+
+    result = await dummy_client.get_comm_event_counter()
+    assert result == DUMMY_RESPONSE
+    assert ["send_and_receive", 1, "GetCommEventCounterPDU"] in dummy_client.transport.performed_actions
+
+
+async def test_get_comm_event_log(dummy_client: AsyncModbusClient) -> None:
+    """Test get_comm_event_log method."""
+    assert isinstance(dummy_client.transport, DummyAsyncTransport)
+
+    result = await dummy_client.get_comm_event_log()
+    assert result == DUMMY_RESPONSE
+    assert ["send_and_receive", 1, "GetCommEventLogPDU"] in dummy_client.transport.performed_actions
 
 
 async def test_read_write_multiple_registers(dummy_client: AsyncModbusClient) -> None:
@@ -582,3 +618,26 @@ async def test_write_file_record(
     assert file_records[0].file_number == 1
     assert file_records[0].record_number == 0
     assert file_records[0].data == b"\x12\x34"
+
+
+async def test_diag_methods(dummy_client: AsyncModbusClient) -> None:
+    """Test all diagnostic helper methods on AsyncModbusClient."""
+    assert isinstance(dummy_client.transport, DummyAsyncTransport)
+
+    await dummy_client.diag_read_query_data(b"\x12\x34")
+    await dummy_client.diag_restart_communications_option(clear_event_log=True)
+    await dummy_client.diag_read_diagnostic_register()
+    await dummy_client.diag_change_ascii_input_delimiter(0x0A)
+    await dummy_client.diag_force_listen_only_mode()
+    await dummy_client.diag_clear_counters_and_register()
+    await dummy_client.diag_read_bus_message_count()
+    await dummy_client.diag_read_bus_communication_error_count()
+    await dummy_client.diag_read_bus_exception_error_count()
+    await dummy_client.diag_read_server_message_count()
+    await dummy_client.diag_read_server_no_response_count()
+    await dummy_client.diag_read_server_nak_count()
+    await dummy_client.diag_read_server_busy_count()
+    await dummy_client.diag_read_bus_character_overrun_count()
+    await dummy_client.diag_clear_overrun_counter_and_flag()
+
+    assert len(dummy_client.transport.performed_actions) == 15

--- a/tests/pdu/test_base.py
+++ b/tests/pdu/test_base.py
@@ -390,3 +390,36 @@ class TestBaseSubFunctionPDU:
         # First byte is different value
         with pytest.raises(InvalidRequestError):
             TestPDU.get_expected_request_data_length(b"\x0d")
+
+    def test_get_expected_request_data_length_custom_sub_function_length(self) -> None:
+        """Test sub_function_code_length larger than 2 bytes."""
+
+        class TestLargeSubFuncPDU(BaseSubFunctionPDU[int]):
+            function_code = 0x64
+            sub_function_code = 0x12345678
+            sub_function_code_length = 4
+            rtu_request_data_length = 8
+            rtu_response_data_length = 8
+
+            def encode_request(self) -> bytes:
+                return b""
+
+            def decode_response(self, _response: bytes) -> int:
+                return 0
+
+            @classmethod
+            def decode_request(cls, _request: bytes) -> "TestLargeSubFuncPDU":
+                return cls()
+
+            def encode_response(self, _value: int) -> bytes:
+                return b""
+
+        # 4-byte sub-function match (0x12345678)
+        data = b"\x12\x34\x56\x78\x00\x00\x00\x00"
+        assert TestLargeSubFuncPDU.get_expected_request_data_length(data) == 8
+        assert TestLargeSubFuncPDU.get_expected_response_data_length(data) == 8
+
+        # Short data
+        assert TestLargeSubFuncPDU.get_expected_response_data_length(b"\x12\x34") is None
+        with pytest.raises(InvalidRequestError):
+            TestLargeSubFuncPDU.get_expected_request_data_length(b"\x12\x34")

--- a/tests/pdu/test_pdu.py
+++ b/tests/pdu/test_pdu.py
@@ -6,8 +6,10 @@ from tmodbus.pdu import (
     BaseClientPDU,
     BaseSubFunctionClientPDU,
     get_pdu_class,
+    get_subfunction_code_length,
     get_subfunction_pdu_class,
     register_pdu_class,
+    sub_function_code_to_pdu_map,
 )
 
 
@@ -155,6 +157,40 @@ class TestRegisterPDUClass:
         ):
             register_pdu_class(CustomSubFunctionPDU2)
 
+    def test_register_different_length_sub_function_pdu_class(self) -> None:
+        """Test registering a different length sub-function code raises ValueError."""
+
+        class CustomSubFunctionPDU1(BaseSubFunctionClientPDU[int]):
+            function_code = 0xE3
+            sub_function_code = 0x01
+
+            def encode_request(self) -> bytes:
+                return b""
+
+            def decode_response(self, _response: bytes) -> int:
+                return 0
+
+        class CustomSubFunctionPDU2(BaseSubFunctionClientPDU[int]):
+            function_code = 0xE3
+            sub_function_code = 0x02
+            sub_function_code_length = 2
+
+            def encode_request(self) -> bytes:
+                return b""
+
+            def decode_response(self, _response: bytes) -> int:
+                return 0
+
+        # Register first sub-function PDU
+        register_pdu_class(CustomSubFunctionPDU1)
+
+        # Try to register duplicate
+        with pytest.raises(
+            ValueError,
+            match=r"Subfunction code length for function code 0xe3 must be 1, but got 2",
+        ):
+            register_pdu_class(CustomSubFunctionPDU2)
+
     def test_register_sub_function_pdu_when_normal_exists(self) -> None:
         """Test registering a sub-function PDU when a normal PDU already exists."""
 
@@ -268,3 +304,19 @@ class TestRegisterPDUClass:
         pdu_class_b = get_subfunction_pdu_class(0xF6, 0x02)
         assert pdu_class_a == SubFunctionPDUA
         assert pdu_class_b == SubFunctionPDUB
+
+    def test_get_subfunction_code_length_for_undefined_function_code(self) -> None:
+        """Test get_subfunction_code_length for undefined function code raises ValueError."""
+        with pytest.raises(
+            ValueError,
+            match=r"Unsupported function code 0xf7",
+        ):
+            get_subfunction_code_length(0xF7)
+
+        sub_function_code_to_pdu_map[0xF7] = {}
+
+        with pytest.raises(
+            ValueError,
+            match=r"No sub-function PDU classes registered for function code 0xf7",
+        ):
+            get_subfunction_code_length(0xF7)

--- a/tests/pdu/test_serial_line.py
+++ b/tests/pdu/test_serial_line.py
@@ -1,10 +1,34 @@
-"""Tests for tmodbus/pdu/serial_line.py ."""
+"""Tests for serial line PDUs."""
 
 import struct
 
 import pytest
-from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
-from tmodbus.pdu.serial_line import ID_OFF, ID_ON, ReportServerIdPDU, ServerIdResponse
+from tmodbus.exceptions import FunctionCodeError, InvalidRequestError, InvalidResponseError
+from tmodbus.pdu.serial_line import (
+    ID_OFF,
+    ID_ON,
+    CommEventCounterResponse,
+    CommEventLogResponse,
+    DiagnosticsBusCharacterOverrunCountPDU,
+    DiagnosticsBusCommunicationErrorCountPDU,
+    DiagnosticsBusExceptionErrorCountPDU,
+    DiagnosticsBusMessageCountPDU,
+    DiagnosticsChangeAsciiInputDelimiterPDU,
+    DiagnosticsClearCountersAndRegisterPDU,
+    DiagnosticsClearOverrunCounterAndFlagPDU,
+    DiagnosticsDiagnosticRegisterPDU,
+    DiagnosticsForceListenOnlyModePDU,
+    DiagnosticsQueryDataPDU,
+    DiagnosticsRestartCommunicationsOptionPDU,
+    DiagnosticsServerBusyCountPDU,
+    DiagnosticsServerMessageCountPDU,
+    DiagnosticsServerNakCountPDU,
+    DiagnosticsServerNoResponseCountPDU,
+    GetCommEventCounterPDU,
+    GetCommEventLogPDU,
+    ReportServerIdPDU,
+    ServerIdResponse,
+)
 
 
 def make_response(
@@ -132,3 +156,302 @@ def test_encode_response() -> None:
     encoded = pdu.encode_response(value)
     expected = make_response(pdu.function_code, b"", ID_OFF, b"")
     assert encoded == expected
+
+
+# --- Diagnostics Sub-Function PDU Tests ---
+
+
+def test_diagnostics_query_data_encode_decode() -> None:
+    """Test DiagnosticsQueryDataPDU encoding and decoding."""
+    pdu = DiagnosticsQueryDataPDU(b"\xa5\x37")
+    encoded = pdu.encode_request()
+    assert encoded == b"\x08\x00\x00\xa5\x37"
+
+    decoded_req = DiagnosticsQueryDataPDU.decode_request(encoded)
+    assert decoded_req.data == b"\xa5\x37"
+
+    resp_encoded = pdu.encode_response(b"\xa5\x37")
+    assert resp_encoded == b"\x08\x00\x00\xa5\x37"
+
+    resp_decoded = pdu.decode_response(resp_encoded)
+    assert resp_decoded == b"\xa5\x37"
+
+    # Odd length validation
+    with pytest.raises(ValueError, match="even number of bytes"):
+        DiagnosticsQueryDataPDU(b"\xa5")
+
+
+def test_diagnostics_restart_communications_option() -> None:
+    """Test DiagnosticsRestartCommunicationsOptionPDU encoding and decoding."""
+    pdu = DiagnosticsRestartCommunicationsOptionPDU(clear_event_log=True)
+    assert pdu.encode_request() == b"\x08\x00\x01\xff\x00"
+
+    decoded_req = DiagnosticsRestartCommunicationsOptionPDU.decode_request(b"\x08\x00\x01\xff\x00")
+    assert decoded_req.clear_event_log is True
+
+    assert pdu.encode_response(True) == b"\x08\x00\x01\xff\x00"  # noqa: FBT003
+    assert pdu.decode_response(b"\x08\x00\x01\xff\x00") is True
+
+
+def test_diagnostics_diagnostic_register() -> None:
+    """Test DiagnosticsDiagnosticRegisterPDU encoding and decoding."""
+    pdu = DiagnosticsDiagnosticRegisterPDU()
+    assert pdu.encode_request() == b"\x08\x00\x02\x00\x00"
+
+    decoded_req = DiagnosticsDiagnosticRegisterPDU.decode_request(b"\x08\x00\x02\x00\x00")
+    assert isinstance(decoded_req, DiagnosticsDiagnosticRegisterPDU)
+
+    assert pdu.encode_response(0x1234) == b"\x08\x00\x02\x12\x34"
+    assert pdu.decode_response(b"\x08\x00\x02\x12\x34") == 0x1234
+
+
+def test_diagnostics_change_ascii_input_delimiter() -> None:
+    """Test DiagnosticsChangeAsciiInputDelimiterPDU encoding and decoding."""
+    pdu = DiagnosticsChangeAsciiInputDelimiterPDU(delimiter=0x0A)
+    assert pdu.encode_request() == b"\x08\x00\x03\x0a\x00"
+
+    decoded_req = DiagnosticsChangeAsciiInputDelimiterPDU.decode_request(b"\x08\x00\x03\x0a\x00")
+    assert decoded_req.delimiter == 0x0A
+
+    assert pdu.encode_response(0x0A) == b"\x08\x00\x03\x0a\x00"
+    assert pdu.decode_response(b"\x08\x00\x03\x0a\x00") == 0x0A
+
+
+def test_diagnostics_force_listen_only_mode() -> None:
+    """Test DiagnosticsForceListenOnlyModePDU behavior (no response expected)."""
+    pdu = DiagnosticsForceListenOnlyModePDU()
+    assert pdu.expects_response is False
+    assert pdu.encode_request() == b"\x08\x00\x04\x00\x00"
+    pdu.get_broadcast_response()
+
+    decoded_req = DiagnosticsForceListenOnlyModePDU.decode_request(b"\x08\x00\x04\x00\x00")
+    assert isinstance(decoded_req, DiagnosticsForceListenOnlyModePDU)
+
+
+def test_all_diagnostic_classes_full_coverage() -> None:
+    """Test encode_request, decode_request, encode_response, decode_response for all diagnostic classes."""
+    # Query data short length tests
+    assert DiagnosticsQueryDataPDU.get_expected_response_data_length(b"\x00") == 4
+    assert DiagnosticsQueryDataPDU.get_expected_request_data_length(b"\x00") == 4
+    assert DiagnosticsQueryDataPDU.get_expected_response_data_length(b"\x00\x00\x12\x34") == 4
+    assert DiagnosticsQueryDataPDU.get_expected_request_data_length(b"\x00\x00\x12\x34") == 4
+
+    # Listen only mode response
+    p_listen = DiagnosticsForceListenOnlyModePDU()
+    assert p_listen.encode_request() == b"\x08\x00\x04\x00\x00"
+    assert p_listen.encode_response() == b""
+
+    with pytest.raises(InvalidResponseError):
+        p_listen.decode_response(b"\x08\x00\x04\x00\x00")
+
+    # Clear counters and register
+    p_clear = DiagnosticsClearCountersAndRegisterPDU()
+    assert p_clear.encode_request() == b"\x08\x00\x0a\x00\x00"
+    assert p_clear.encode_response() == b"\x08\x00\x0a\x00\x00"
+    p_clear.decode_response(b"\x08\x00\x0a\x00\x00")
+    assert isinstance(
+        DiagnosticsClearCountersAndRegisterPDU.decode_request(b"\x08\x00\x0a\x00\x00"),
+        DiagnosticsClearCountersAndRegisterPDU,
+    )
+
+    # Clear overrun counter and flag
+    p_overrun = DiagnosticsClearOverrunCounterAndFlagPDU()
+    assert p_overrun.encode_request() == b"\x08\x00\x14\x00\x00"
+    assert p_overrun.encode_response() == b"\x08\x00\x14\x00\x00"
+    p_overrun.decode_response(b"\x08\x00\x14\x00\x00")
+    assert isinstance(
+        DiagnosticsClearOverrunCounterAndFlagPDU.decode_request(b"\x08\x00\x14\x00\x00"),
+        DiagnosticsClearOverrunCounterAndFlagPDU,
+    )
+
+    # All counter classes
+    counter_classes = [
+        DiagnosticsBusMessageCountPDU,
+        DiagnosticsBusCommunicationErrorCountPDU,
+        DiagnosticsBusExceptionErrorCountPDU,
+        DiagnosticsServerMessageCountPDU,
+        DiagnosticsServerNoResponseCountPDU,
+        DiagnosticsServerNakCountPDU,
+        DiagnosticsServerBusyCountPDU,
+        DiagnosticsBusCharacterOverrunCountPDU,
+    ]
+    for cls in counter_classes:
+        inst = cls()
+        req_bytes = inst.encode_request()
+        dec_req = cls.decode_request(req_bytes)
+        assert isinstance(dec_req, cls)
+        resp_bytes = inst.encode_response(100)
+        dec_resp = inst.decode_response(resp_bytes)
+        assert dec_resp == 100
+
+
+def test_diagnostics_listen_only_error_paths() -> None:
+    """Test error validation paths for query data and restart options."""
+    with pytest.raises(InvalidRequestError, match="Request length"):
+        DiagnosticsForceListenOnlyModePDU.decode_request(b"\x08\x00")
+    with pytest.raises(InvalidRequestError, match="Invalid function/sub-function"):
+        DiagnosticsForceListenOnlyModePDU.decode_request(b"\x08\x00\x01\x00\x00")
+
+
+def test_diagnostics_query_and_restart_error_paths() -> None:
+    """Test error validation paths for query data and restart options."""
+    # DiagnosticsQueryDataPDU error paths
+    with pytest.raises(ValueError, match="even number of bytes"):
+        DiagnosticsQueryDataPDU(b"\x01")
+    q_pdu = DiagnosticsQueryDataPDU()
+    with pytest.raises(ValueError, match="even number of bytes"):
+        q_pdu.encode_response(b"\x01")
+    with pytest.raises(InvalidRequestError, match="too short"):
+        DiagnosticsQueryDataPDU.decode_request(b"\x08\x00")
+    with pytest.raises(InvalidRequestError, match="Invalid function/sub-function"):
+        DiagnosticsQueryDataPDU.decode_request(b"\x08\x00\x01\x00\x00")
+    with pytest.raises(InvalidRequestError, match="even number of bytes"):
+        DiagnosticsQueryDataPDU.decode_request(b"\x08\x00\x00\x01")
+    with pytest.raises(InvalidResponseError, match="too short"):
+        q_pdu.decode_response(b"\x08\x00")
+    with pytest.raises(FunctionCodeError, match="Invalid function/sub-function"):
+        q_pdu.decode_response(b"\x08\x00\x01\x00\x00")
+    with pytest.raises(InvalidResponseError, match="even number of bytes"):
+        q_pdu.decode_response(b"\x08\x00\x00\x01")
+
+    # DiagnosticsRestartCommunicationsOptionPDU error paths
+    r_pdu = DiagnosticsRestartCommunicationsOptionPDU()
+    with pytest.raises(InvalidRequestError, match="Request length"):
+        DiagnosticsRestartCommunicationsOptionPDU.decode_request(b"\x08\x00\x01")
+    with pytest.raises(InvalidRequestError, match="Invalid function/sub-function"):
+        DiagnosticsRestartCommunicationsOptionPDU.decode_request(b"\x08\x00\x02\x00\x00")
+    with pytest.raises(InvalidRequestError, match="Invalid restart option data"):
+        DiagnosticsRestartCommunicationsOptionPDU.decode_request(b"\x08\x00\x01\x12\x34")
+    with pytest.raises(InvalidResponseError, match="Response length"):
+        r_pdu.decode_response(b"\x08\x00\x01")
+    with pytest.raises(FunctionCodeError, match="Invalid function/sub-function"):
+        r_pdu.decode_response(b"\x08\x00\x02\x00\x00")
+    with pytest.raises(InvalidResponseError, match="Invalid restart option response data"):
+        r_pdu.decode_response(b"\x08\x00\x01\x12\x34")
+
+
+def test_diagnostics_register_counter_error_paths() -> None:
+    """Test error validation paths for diagnostic register, delimiter, and counters."""
+    # DiagnosticsDiagnosticRegisterPDU error paths
+    d_pdu = DiagnosticsDiagnosticRegisterPDU()
+    with pytest.raises(InvalidRequestError, match="Request length"):
+        DiagnosticsDiagnosticRegisterPDU.decode_request(b"\x08\x00\x02")
+    with pytest.raises(InvalidRequestError, match="Invalid function/sub-function"):
+        DiagnosticsDiagnosticRegisterPDU.decode_request(b"\x08\x00\x01\x00\x00")
+    with pytest.raises(ValueError, match="out of range"):
+        d_pdu.encode_response(0x10000)
+    with pytest.raises(InvalidResponseError, match="Response length"):
+        d_pdu.decode_response(b"\x08\x00\x02")
+    with pytest.raises(FunctionCodeError, match="Invalid function/sub-function"):
+        d_pdu.decode_response(b"\x08\x00\x01\x00\x00")
+
+    # DiagnosticsChangeAsciiInputDelimiterPDU error paths
+    with pytest.raises(ValueError, match="out of range"):
+        DiagnosticsChangeAsciiInputDelimiterPDU(256)
+    c_pdu = DiagnosticsChangeAsciiInputDelimiterPDU()
+    with pytest.raises(ValueError, match="out of range"):
+        c_pdu.encode_response(256)
+    with pytest.raises(InvalidRequestError, match="Request length"):
+        DiagnosticsChangeAsciiInputDelimiterPDU.decode_request(b"\x08\x00\x03")
+    with pytest.raises(InvalidRequestError, match="Invalid function/sub-function"):
+        DiagnosticsChangeAsciiInputDelimiterPDU.decode_request(b"\x08\x00\x01\x00\x00")
+    with pytest.raises(InvalidResponseError, match="Response length"):
+        c_pdu.decode_response(b"\x08\x00\x03")
+    with pytest.raises(FunctionCodeError, match="Invalid function/sub-function"):
+        c_pdu.decode_response(b"\x08\x00\x01\x00\x00")
+
+    # DiagnosticsForceListenOnlyModePDU & DiagnosticsClearCountersAndRegisterPDU & ClearOverrun error paths
+    for pdu_cls in (
+        DiagnosticsClearCountersAndRegisterPDU,
+        DiagnosticsClearOverrunCounterAndFlagPDU,
+    ):
+        inst = pdu_cls()
+        with pytest.raises(InvalidRequestError, match="Request length"):
+            pdu_cls.decode_request(b"\x08\x00")
+        with pytest.raises(InvalidRequestError, match="Invalid function/sub-function"):
+            pdu_cls.decode_request(b"\x08\xff\xff\x00\x00")
+        with pytest.raises(InvalidResponseError, match="Response length"):
+            inst.decode_response(b"\x08\x00")
+        with pytest.raises(FunctionCodeError, match="Invalid function/sub-function"):
+            inst.decode_response(b"\x08\xff\xff\x00\x00")
+
+    # BaseDiagnosticsCounterPDU error paths
+    cnt_pdu = DiagnosticsBusMessageCountPDU()
+    with pytest.raises(InvalidRequestError, match="Request length"):
+        DiagnosticsBusMessageCountPDU.decode_request(b"\x08\x00\x0b")
+    with pytest.raises(InvalidRequestError, match="Invalid function/sub-function"):
+        DiagnosticsBusMessageCountPDU.decode_request(b"\x08\x00\x01\x00\x00")
+    with pytest.raises(ValueError, match=r"Counter value .* out of range"):
+        cnt_pdu.encode_response(0x10000)
+    with pytest.raises(InvalidResponseError, match="Response length"):
+        cnt_pdu.decode_response(b"\x08\x00\x0b")
+    with pytest.raises(FunctionCodeError, match="Invalid function/sub-function"):
+        cnt_pdu.decode_response(b"\x08\x00\x01\x00\x00")
+
+
+# --- GetCommEventCounterPDU (FC0B) Tests ---
+
+
+def test_get_comm_event_counter_encode_decode() -> None:
+    """Test GetCommEventCounterPDU encoding and decoding."""
+    pdu = GetCommEventCounterPDU()
+    assert pdu.encode_request() == b"\x0b"
+
+    decoded_req = GetCommEventCounterPDU.decode_request(b"\x0b")
+    assert isinstance(decoded_req, GetCommEventCounterPDU)
+
+    with pytest.raises(InvalidRequestError, match="Expected request with only function code"):
+        GetCommEventCounterPDU.decode_request(b"\x0b\x00")
+
+    with pytest.raises(InvalidRequestError, match="Invalid function code"):
+        GetCommEventCounterPDU.decode_request(b"\x0c")
+
+    resp_val = CommEventCounterResponse(status=0xFFFF, event_count=264)
+    encoded_resp = pdu.encode_response(resp_val)
+    assert encoded_resp == b"\x0b\xff\xff\x01\x08"
+
+    decoded_resp = pdu.decode_response(encoded_resp)
+    assert decoded_resp == resp_val
+
+    with pytest.raises(InvalidResponseError, match="does not match expected 5"):
+        pdu.decode_response(b"\x0b\xff\xff\x01")
+
+    with pytest.raises(FunctionCodeError, match="Invalid function code"):
+        pdu.decode_response(b"\x8b\xff\xff\x01\x08")
+
+
+# --- GetCommEventLogPDU (FC0C) Tests ---
+
+
+def test_get_comm_event_log_encode_decode() -> None:
+    """Test GetCommEventLogPDU encoding and decoding."""
+    pdu = GetCommEventLogPDU()
+    assert pdu.encode_request() == b"\x0c"
+
+    decoded_req = GetCommEventLogPDU.decode_request(b"\x0c")
+    assert isinstance(decoded_req, GetCommEventLogPDU)
+
+    with pytest.raises(InvalidRequestError, match="Expected request with only function code"):
+        GetCommEventLogPDU.decode_request(b"\x0c\x00")
+
+    with pytest.raises(InvalidRequestError, match="Invalid function code"):
+        GetCommEventLogPDU.decode_request(b"\x0d")
+
+    resp_val = CommEventLogResponse(status=0x0000, event_count=264, message_count=289, events=b"\x20\x00")
+    encoded_resp = pdu.encode_response(resp_val)
+    assert encoded_resp == b"\x0c\x08\x00\x00\x01\x08\x01\x21\x20\x00"
+
+    decoded_resp = pdu.decode_response(encoded_resp)
+    assert decoded_resp == resp_val
+
+    # Response too short
+    with pytest.raises(InvalidResponseError, match="too short"):
+        pdu.decode_response(b"\x0c\x08\x00\x00\x01")
+
+    # Mismatched length
+    with pytest.raises(InvalidResponseError, match="does not match expected"):
+        pdu.decode_response(b"\x0c\x08\x00\x00\x01\x08\x01\x21\x20")
+
+    # Invalid function code
+    with pytest.raises(FunctionCodeError, match="Invalid function code"):
+        pdu.decode_response(b"\x8c\x08\x00\x00\x01\x08\x01\x21\x20\x00")

--- a/tests/server/test_async_rtu.py
+++ b/tests/server/test_async_rtu.py
@@ -7,6 +7,7 @@ from typing import cast
 from unittest.mock import patch
 
 import pytest
+from tmodbus.exceptions import SuppressResponseError
 from tmodbus.pdu import ReadHoldingRegistersPDU, WriteMultipleCoilsPDU, WriteMultipleRegistersPDU
 from tmodbus.server import AsyncRtuServer, ModbusRequestRouter
 from tmodbus.utils.crc import calculate_crc16
@@ -445,3 +446,27 @@ def test_rtu_server_parse_frame_length_expected_data_len_none(
     )
     buffer = bytearray(b"\x01\x03\x00")
     assert server._parse_frame_length(buffer) is None
+
+
+async def test_rtu_server_suppress_response_error() -> None:
+    """Test that RTU server omits sending a response when SuppressResponseError is raised by handler."""
+    router = ModbusRequestRouter()
+
+    @router.register(ReadHoldingRegistersPDU)
+    async def handle_read(_unit_id: int, _request: ReadHoldingRegistersPDU) -> list[int]:
+        raise SuppressResponseError
+
+    server = AsyncRtuServer(port="/dev/ttyUSB0", handler=router)
+    await server.start()
+
+    mock_serial_inst = cast("MockSerial", server._reader)
+    assert mock_serial_inst is not None
+
+    pdu = b"\x01\x03\x00\x00\x00\x01"
+    crc = calculate_crc16(pdu)
+    await mock_serial_inst.read_queue.put(pdu + crc)
+    await asyncio.sleep(0.05)
+
+    assert len(mock_serial_inst.write_calls) == 0
+
+    await server.stop()

--- a/tests/server/test_base.py
+++ b/tests/server/test_base.py
@@ -6,6 +6,7 @@ import pytest
 from tmodbus.exceptions import InvalidRequestError
 from tmodbus.pdu import (
     BaseClientPDU,
+    DiagnosticsQueryDataPDU,
     ReadHoldingRegistersPDU,
 )
 from tmodbus.pdu.base import BaseSubFunctionPDU
@@ -35,6 +36,10 @@ def test_get_server_pdu_class_success() -> None:
     cls = get_server_pdu_class(b"\x03\x00\x00\x00\x02")
     assert cls is ReadHoldingRegistersPDU
 
+    # FC08 Diagnostics sub-function code
+    cls_diag = get_server_pdu_class(b"\x08\x00\x00\x00\x00")
+    assert cls_diag is DiagnosticsQueryDataPDU
+
     # Sub-function code
     with patch("tmodbus.server.base.get_subfunction_pdu_class", return_value=DummySubFunctionServerPDU):
         cls = get_server_pdu_class(b"\x2b\x0e\x01\x00")
@@ -52,6 +57,9 @@ def test_get_server_pdu_class_missing_subfunction() -> None:
     with pytest.raises(InvalidRequestError, match="Missing sub-function code"):
         get_server_pdu_class(b"\x2b")
 
+    with pytest.raises(InvalidRequestError, match="Missing sub-function code"):
+        get_server_pdu_class(b"\x08\x00")
+
 
 def test_get_server_pdu_class_non_server() -> None:
     """Test get_server_pdu_class raises ValueError for client-only PDUs."""
@@ -68,6 +76,10 @@ def test_get_server_pdu_class_from_buffer_success() -> None:
     cls = get_server_pdu_class_from_buffer(bytearray(b"\x01\x03\x00\x00\x00\x02"))
     assert cls is ReadHoldingRegistersPDU
 
+    # FC08 Diagnostics
+    cls_diag = get_server_pdu_class_from_buffer(bytearray(b"\x01\x08\x00\x00\x00\x00"))
+    assert cls_diag is DiagnosticsQueryDataPDU
+
     # Sub-function code
     with patch("tmodbus.server.base.get_subfunction_pdu_class", return_value=DummySubFunctionServerPDU):
         cls = get_server_pdu_class_from_buffer(bytearray(b"\x01\x2b\x0e\x01\x00"))
@@ -79,6 +91,10 @@ def test_get_server_pdu_class_from_buffer_missing_subfunction() -> None:
     # Buffer has unit_id, fc, but is missing the sub-function byte at index 2
     cls = get_server_pdu_class_from_buffer(bytearray(b"\x01\x2b"))
     assert cls is None
+
+    # For FC08 Diagnostics (2-byte sub-function), buffer has unit_id, fc, 1 sub-function byte, missing 2nd byte
+    cls_diag = get_server_pdu_class_from_buffer(bytearray(b"\x01\x08\x00"))
+    assert cls_diag is None
 
 
 def test_get_server_pdu_class_from_buffer_too_short() -> None:

--- a/tests/server/test_handler.py
+++ b/tests/server/test_handler.py
@@ -4,7 +4,7 @@ from collections.abc import Awaitable
 from typing import Any, cast
 
 import pytest
-from tmodbus.exceptions import IllegalDataAddressError, IllegalFunctionError
+from tmodbus.exceptions import IllegalDataAddressError, IllegalFunctionError, SuppressResponseError
 from tmodbus.pdu import BasePDU, ReadHoldingRegistersPDU, WriteSingleRegisterPDU
 from tmodbus.server import (
     AnyModbusHandler,
@@ -98,13 +98,26 @@ async def test_handle_modbus_request_unexpected_error() -> None:
 
     @router.register(ReadHoldingRegistersPDU)
     async def handle_read(_unit_id: int, _request: ReadHoldingRegistersPDU) -> list[int]:
-        msg = "Something went wrong"
+        msg = "Database offline"
         raise RuntimeError(msg)
 
     req = ReadHoldingRegistersPDU(start_address=0, quantity=2)
     response_bytes = await handle_modbus_request(1, req, router)
-    # Expected SERVER_DEVICE_FAILURE exception code (0x04)
+    # Expected exception response: (function_code | 0x80) (1 byte) + ServerDeviceFailure (0x04)
     assert response_bytes == b"\x83\x04"
+
+
+async def test_handle_modbus_request_suppress_response_error() -> None:
+    """Test handle_modbus_request returns empty bytes when SuppressResponseError is raised."""
+    router = ModbusRequestRouter()
+
+    @router.register(ReadHoldingRegistersPDU)
+    async def handle_read(_unit_id: int, _request: ReadHoldingRegistersPDU) -> list[int]:
+        raise SuppressResponseError
+
+    req = ReadHoldingRegistersPDU(start_address=0, quantity=2)
+    response_bytes = await handle_modbus_request(1, req, router)
+    assert response_bytes == b""
 
 
 async def test_router_unit_id_routing() -> None:

--- a/tests/test_spec_conformance.py
+++ b/tests/test_spec_conformance.py
@@ -42,8 +42,13 @@ from tmodbus.exceptions import (
     UnknownModbusResponseError,
 )
 from tmodbus.pdu import (
+    CommEventCounterResponse,
+    CommEventLogResponse,
+    DiagnosticsQueryDataPDU,
     FileRecord,
     FileRecordRequest,
+    GetCommEventCounterPDU,
+    GetCommEventLogPDU,
     MaskWriteRegisterPDU,
     ReadCoilsPDU,
     ReadDeviceIdentificationPDU,
@@ -54,6 +59,8 @@ from tmodbus.pdu import (
     ReadHoldingRegistersPDU,
     ReadInputRegistersPDU,
     ReadWriteMultipleRegistersPDU,
+    ReportServerIdPDU,
+    ServerIdResponse,
     WriteFileRecordPDU,
     WriteMultipleCoilsPDU,
     WriteMultipleRegistersPDU,
@@ -170,6 +177,26 @@ def test_read_device_identification_request() -> None:
     assert ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00).encode_request() == _hex("2B 0E 01 00")
 
 
+def test_fc08_request() -> None:
+    """0x08 Diagnostics, Return Query Data sub-function with 0xA537 data."""
+    assert DiagnosticsQueryDataPDU(_hex("A5 37")).encode_request() == _hex("08 0000 A537")
+
+
+def test_get_comm_event_counter_request() -> None:
+    """0x0B Get Comm Event Counter has no payload."""
+    assert GetCommEventCounterPDU().encode_request() == _hex("0B")
+
+
+def test_get_comm_event_log_request() -> None:
+    """0x0C Get Comm Event Log has no payload."""
+    assert GetCommEventLogPDU().encode_request() == _hex("0C")
+
+
+def test_report_server_id_request() -> None:
+    """0x11 Report Server ID has no payload."""
+    assert ReportServerIdPDU().encode_request() == _hex("11")
+
+
 # --- Response decoding (client side) ----------------------------------------
 
 
@@ -271,6 +298,34 @@ def test_read_device_identification_response() -> None:
     assert decoded.objects == {0x00: b"ABC", 0x01: b"XY", 0x02: b"1.0"}
 
 
+def test_fc08_response() -> None:
+    """0x08 Diagnostics, Return Query Data sub-function response."""
+    decoded = DiagnosticsQueryDataPDU(_hex("A5 37")).decode_response(_hex("08 0000 A537"))
+    assert decoded == _hex("A5 37")
+
+
+def test_get_comm_event_counter_response() -> None:
+    """0x0B response in the format of specification section 6.9."""
+    decoded = GetCommEventCounterPDU().decode_response(_hex("0B FF FF 01 08"))
+    assert decoded == CommEventCounterResponse(status=0xFFFF, event_count=264)
+
+
+def test_get_comm_event_log_response() -> None:
+    """0x0C response in the format of specification section 6.10."""
+    decoded = GetCommEventLogPDU().decode_response(_hex("0C 08 00 00 01 08 01 21 20 00"))
+    assert decoded == CommEventLogResponse(status=0x0000, event_count=264, message_count=289, events=_hex("20 00"))
+
+
+def test_report_server_id_response() -> None:
+    """0x11 response in the format of specification section 6.13.
+
+    The server ID and additional data are device specific, so a representative
+    response is used.
+    """
+    decoded = ReportServerIdPDU().decode_response(_hex("11 02 A5 FF"))
+    assert decoded == ServerIdResponse(server_id=b"\xa5", run_indicator_status=True, additional_data=b"")
+
+
 # --- RTU response framing length --------------------------------------------
 #
 # The transport calls get_expected_response_data_length with everything after
@@ -286,8 +341,12 @@ _FRAMING_VECTORS: list[tuple[str, type[BaseClientPDU[Any]], bytes]] = [
     ("0x04 Read Input Registers", ReadInputRegistersPDU, _hex("04 02 000A")),
     ("0x05 Write Single Coil", WriteSingleCoilPDU, _hex("05 00AC FF00")),
     ("0x06 Write Single Register", WriteSingleRegisterPDU, _hex("06 0001 0003")),
+    ("0x08 Diagnostics", DiagnosticsQueryDataPDU, _hex("08 0000 A537")),
+    ("0x0B Get Comm Event Counter", GetCommEventCounterPDU, _hex("0B FF FF 01 08")),
+    ("0x0C Get Comm Event Log", GetCommEventLogPDU, _hex("0C 08 00 00 01 08 01 21 20 00")),
     ("0x0F Write Multiple Coils", WriteMultipleCoilsPDU, _hex("0F 0013 000A")),
     ("0x10 Write Multiple Registers", WriteMultipleRegistersPDU, _hex("10 0001 0002")),
+    ("0x11 Report Server ID", ReportServerIdPDU, _hex("11 02 A5 FF")),
     ("0x16 Mask Write Register", MaskWriteRegisterPDU, _hex("16 0004 00F2 0025")),
     ("0x17 Read/Write Multiple Registers", ReadWriteMultipleRegistersPDU, _hex("17 0C 00FE 0ACD 0001 0003 000D 00FF")),
     ("0x14 Read File Record", ReadFileRecordPDU, _hex("14 0C 05 06 0DFE 0020 05 06 33CD 0040")),
@@ -320,8 +379,12 @@ _REQUEST_ROUND_TRIPS: list[tuple[str, BasePDU[Any]]] = [
     ("0x04 Read Input Registers", ReadInputRegistersPDU(0x0008, 0x0001)),
     ("0x05 Write Single Coil", WriteSingleCoilPDU(0x00AC, value=True)),
     ("0x06 Write Single Register", WriteSingleRegisterPDU(0x0001, 0x0003)),
+    ("0x08 Diagnostics", DiagnosticsQueryDataPDU(_hex("A5 37"))),
+    ("0x0B Get Comm Event Counter", GetCommEventCounterPDU()),
+    ("0x0C Get Comm Event Log", GetCommEventLogPDU()),
     ("0x0F Write Multiple Coils", WriteMultipleCoilsPDU(0x0013, _bits(_hex("CD 01"), 10))),
     ("0x10 Write Multiple Registers", WriteMultipleRegistersPDU(0x0001, [0x000A, 0x0102])),
+    ("0x11 Report Server ID", ReportServerIdPDU()),
     ("0x16 Mask Write Register", MaskWriteRegisterPDU(0x0004, 0x00F2, 0x0025)),
     ("0x18 Read FIFO Queue", ReadFifoQueuePDU(0x04DE)),
     (
@@ -350,8 +413,16 @@ _RESPONSE_ROUND_TRIPS: list[tuple[str, BasePDU[Any], Any]] = [
     ("0x04 Read Input Registers", ReadInputRegistersPDU(0x0008, 0x0001), [0x000A]),
     ("0x05 Write Single Coil", WriteSingleCoilPDU(0x00AC, value=True), True),
     ("0x06 Write Single Register", WriteSingleRegisterPDU(0x0001, 0x0003), 0x0003),
+    ("0x08 Diagnostics", DiagnosticsQueryDataPDU(_hex("A5 37")), _hex("A5 37")),
+    ("0x0B Get Comm Event Counter", GetCommEventCounterPDU(), CommEventCounterResponse(0xFFFF, 264)),
+    ("0x0C Get Comm Event Log", GetCommEventLogPDU(), CommEventLogResponse(0x0000, 264, 289, _hex("20 00"))),
     ("0x0F Write Multiple Coils", WriteMultipleCoilsPDU(0x0013, _bits(_hex("CD 01"), 10)), 10),
     ("0x10 Write Multiple Registers", WriteMultipleRegistersPDU(0x0001, [0x000A, 0x0102]), 2),
+    (
+        "0x11 Report Server ID",
+        ReportServerIdPDU(),
+        ServerIdResponse(server_id=b"\xa5", run_indicator_status=True, additional_data=b""),
+    ),
     ("0x16 Mask Write Register", MaskWriteRegisterPDU(0x0004, 0x00F2, 0x0025), (0x00F2, 0x0025)),
     (
         "0x17 Read/Write Multiple Registers",

--- a/tests/transport/test_async_ascii.py
+++ b/tests/transport/test_async_ascii.py
@@ -1600,3 +1600,24 @@ async def test_timeout_does_not_log_error(
         await protocol.send_and_receive(1, _DummyPDU())
 
     assert not caplog.records
+
+
+async def test_send_and_receive_no_response_pdu(
+    mock_transport: MagicMock,
+) -> None:
+    """Test send_and_receive when PDU expects_response is False."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    class NoResponsePDU(BaseClientPDU[None]):
+        function_code = 0x08
+        expects_response = False
+
+        def encode_request(self) -> bytes:
+            return b"\x00\x04\x00\x00"
+
+        def decode_response(self, _response: bytes) -> None:
+            return None
+
+    await protocol.send_and_receive(1, NoResponsePDU())

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -1464,12 +1464,12 @@ async def test_determine_expected_frame_length_subfunction_pdu(
     monkeypatch.setattr("tmodbus.transport.async_rtu.get_subfunction_pdu_class", lambda _fc, _sfc: DummySubPDU)
 
     pdu = DummySubPDU()
-    protocol._buffer = bytearray(b"\x01\x08\x00\x00")
-    # Less than 6 bytes for subfunction PDU returns None
+    protocol._buffer = bytearray(b"\x01\x08\x00\x00\x00\x00")
+    # Less than 7 bytes for FC 0x08 subfunction PDU (2-byte subfunction code) returns None
     assert protocol._determine_expected_frame_length(pdu) is None
 
-    # With >= 6 bytes returns length (1 + 1 + 2 + 2 = 6)
-    protocol._buffer = bytearray(b"\x01\x08\x00\x00\x00\x00")
+    # With >= 7 bytes returns length (1 + 1 + 2 + 2 = 6)
+    protocol._buffer = bytearray(b"\x01\x08\x00\x00\x00\x00\x00")
     assert protocol._determine_expected_frame_length(pdu) == 6
 
 
@@ -2208,3 +2208,40 @@ async def test_discard_garbage_data_when_buffer_starts_with_valid_header(
     protocol._discard_garbage_data()
 
     assert protocol._buffer == bytearray(b"\x01\x03\x05\xaa\xbb")
+
+
+async def test_send_and_receive_no_response_pdu(
+    mock_transport: MagicMock,
+) -> None:
+    """Test send_and_receive when PDU expects_response is False."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    class NoResponsePDU(BaseClientPDU[None]):
+        function_code = 0x08
+        expects_response = False
+
+        def encode_request(self) -> bytes:
+            return b"\x00\x04\x00\x00"
+
+        def decode_response(self, _response: bytes) -> None:
+            return None
+
+    await protocol.send_and_receive(1, NoResponsePDU())
+
+
+def test_rtu_protocol_fc08_partial_buffer(mock_transport: MagicMock) -> None:
+    """Test data_received on ModbusRtuProtocol with partial FC08 Diagnostics frame."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    # 0x01 address, 0x08 FC, 0x00 sub-func byte 1 (missing 2nd sub-func byte, length < 7)
+    protocol.data_received(b"\x01\x08\x00")
+    assert protocol._pending_request is None
+
+    # Test buffer >= 7 bytes for FC08 Diagnostics frame parsing
+    protocol._buffer = bytearray(b"\x01\x08\x00\x00\x00")
+    assert protocol._determine_expected_frame_length() is None
+    protocol._buffer = bytearray(b"\x01\x08\x00\x00\x00\x00\x00")
+    assert protocol._determine_expected_frame_length() == 9


### PR DESCRIPTION
This PR implements all FC08 modbus messages. 

Noteworthy changes besides purely implementing the parsing of these messages:
- support for sub-function codes of more than 1 byte
- support in our server implementations to not respond to requests, which is needed to properly react to the force-listen / resume-communications messages in the FC08 message family.

By implementing these, we get 100% completeness of the Modbus spec 🎉