### PR TITLE
feat(server): expose the TLS client role on RequestContext

### DIFF
--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -239,6 +239,8 @@ The `RequestContext` object has the following fields:
   54321)``) if available.
 - ``client_cert``: A :class:`cryptography.x509.Certificate` containing the parsed client
   x.509 certificate when connected over TLS.
+- ``client_role``: The Modbus role string extracted from the client certificate, or
+  ``None`` for plain TCP connections or certificates without a role extension.
 
 *************************************************
  Modbus/TCP Security (mbaps) & Mutual TLS (mTLS)

--- a/src/tmodbus/server/async_tcp.py
+++ b/src/tmodbus/server/async_tcp.py
@@ -252,20 +252,21 @@ class AsyncTcpServer(AsyncBaseServer):
             # Extract TLS client certificate once per connection (R-30).
             # Returns None for plain TCP connections or if the client sent no cert.
             # Kept inside the try so a parse failure cannot leak the socket.
+            client_role = None
             try:
                 client_cert = extract_client_cert(writer)
                 if client_cert is not None:
-                    role = extract_modbus_role(client_cert)
+                    client_role = extract_modbus_role(client_cert)
                     logger.debug(
                         "TLS client cert: subject=%s role=%s",
                         client_cert.subject.rfc4514_string(),
-                        role,
+                        client_role,
                     )
             except Exception as e:  # noqa: BLE001
                 logger.warning("Could not process TLS client certificate from %s, closing connection: %s", addr, e)
                 return
 
-            context = RequestContext(peer_addr=addr, client_cert=client_cert)
+            context = RequestContext(peer_addr=addr, client_cert=client_cert, client_role=client_role)
 
             while await self._handle_single_request(reader, writer, addr, context):
                 pass

--- a/src/tmodbus/server/handler.py
+++ b/src/tmodbus/server/handler.py
@@ -46,6 +46,14 @@ class RequestContext:
     with client certificate validation enabled.
     """
 
+    client_role: str | None = None
+    """The Modbus role extracted from the client TLS certificate (if available).
+
+    Only populated when ``client_cert`` is present and carries the Modbus role
+    OID extension (``1.3.6.1.4.1.50316.802.1``). ``None`` for plain TCP
+    connections or certificates without a role.
+    """
+
 
 # A type alias for the type-erased underlying handler callable.
 type RouterHandler = Callable[[int, Any], Awaitable[Any]]

--- a/tests/server/test_async_tcp_security.py
+++ b/tests/server/test_async_tcp_security.py
@@ -446,6 +446,7 @@ async def test_tls_server_cert_info_injected(
     assert client_cert is not None
     assert "TestClient" in client_cert.subject.rfc4514_string()
     assert extract_modbus_role(client_cert) == "Operator"
+    assert context.client_role == "Operator"
     san_ext = client_cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
     san_ips = [str(name.value) for name in san_ext.value if isinstance(name, x509.IPAddress)]
     assert "127.0.0.1" in san_ips
@@ -469,6 +470,7 @@ async def test_tls_server_cert_no_role(
     client_cert = context.client_cert
     assert client_cert is not None
     assert extract_modbus_role(client_cert) is None
+    assert context.client_role is None
 
 
 async def test_tls_server_cert_duplicate_role_uses_first(
@@ -490,6 +492,7 @@ async def test_tls_server_cert_duplicate_role_uses_first(
     client_cert = context.client_cert
     assert client_cert is not None
     assert extract_modbus_role(client_cert) == "Operator"
+    assert context.client_role == "Operator"
 
 
 async def test_tls_server_cert_malformed_role_handled(
@@ -511,6 +514,7 @@ async def test_tls_server_cert_malformed_role_handled(
     client_cert = context.client_cert
     assert client_cert is not None
     assert extract_modbus_role(client_cert) is None
+    assert context.client_role is None
 
 
 async def test_tls_server_cert_processing_failure_closes_connection(
@@ -607,6 +611,7 @@ async def test_plain_tcp_context_is_populated() -> None:
         assert context is not None
         assert context.peer_addr is not None
         assert context.client_cert is None
+        assert context.client_role is None
     finally:
         await server.stop()
 


### PR DESCRIPTION
# Proposed Changes

`AsyncTcpServer.handle_client` already extracts the Modbus role from the TLS client certificate via `extract_modbus_role`, but the value only ended up in a debug log. Handlers that wanted to do role-based authorization had to call `extract_modbus_role(context.client_cert)` themselves on every request.

This PR adds a `client_role: str | None` field to `RequestContext` and wires the role extracted once per connection in `handle_client` into the per-request context. Plain TCP connections and certificates without the Modbus role OID extension leave it `None`, matching the existing `client_cert` semantics. The `RequestContext` field list in `docs/source/server.rst` documents the new attribute.

Tests extend `tests/server/test_async_tcp_security.py`: a context-aware handler observes `client_role == "Operator"` for a certificate carrying the role extension (including the duplicate-extension case), `None` for a certificate without one or with a malformed role value, and `None` on a plain TCP connection.

## Related Issues

Follow-up suggested in #102.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
