### PR TITLE
fix(pdu): reject address ranges that wrap past the 16-bit address space

### DIFF
--- a/src/tmodbus/pdu/coils.py
+++ b/src/tmodbus/pdu/coils.py
@@ -43,6 +43,10 @@ class ReadCoilsPDU(BasePDU[list[bool]]):
             raise ValueError(msg)
         self.quantity = quantity
 
+        if start_address + quantity > 65536:
+            msg = "Start address plus quantity must not exceed 65536."
+            raise ValueError(msg)
+
     def encode_request(self) -> bytes:
         """Convert PDU to bytes.
 
@@ -269,6 +273,10 @@ class WriteMultipleCoilsPDU(BasePDU[int]):
         self.start_address = start_address
         if not (1 <= len(values) <= 0x07B0):  # 1968 coils max
             msg = "Number of coils must be between 1 and 1968."
+            raise ValueError(msg)
+
+        if start_address + len(values) > 65536:
+            msg = "Start address plus number of coils must not exceed 65536."
             raise ValueError(msg)
 
         self.values = values

--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -38,6 +38,10 @@ class RawReadHoldingRegistersPDU(BasePDU[bytes]):
             raise ValueError(msg)
         self.quantity = quantity
 
+        if start_address + quantity > 65536:
+            msg = "Start address plus quantity must not exceed 65536."
+            raise ValueError(msg)
+
     def encode_request(self) -> bytes:
         """Convert PDU to bytes.
 
@@ -371,6 +375,10 @@ class RawWriteMultipleRegistersPDU(BasePDU[int]):
 
         if len(content) % 2 != 0:
             msg = "Content length cannot be odd; each register is 2 bytes."
+            raise ValueError(msg)
+
+        if start_address + len(content) // 2 > 65536:
+            msg = "Start address plus number of registers must not exceed 65536."
             raise ValueError(msg)
 
         self.content = content
@@ -743,12 +751,20 @@ class ReadWriteMultipleRegistersPDU(BasePDU[list[int]]):
             msg = "Read quantity must be between 1 and 125."
             raise ValueError(msg)
 
+        if self.read_start_address + self.read_quantity > 65536:
+            msg = "Read starting address plus read quantity must not exceed 65536."
+            raise ValueError(msg)
+
         if not (0 <= self.write_start_address < 65536):
             msg = "Write starting address must be between 0 and 65535."
             raise ValueError(msg)
 
         if not (1 <= len(self.write_values) <= 121):
             msg = "Number of registers to write must be between 1 and 121."
+            raise ValueError(msg)
+
+        if self.write_start_address + len(self.write_values) > 65536:
+            msg = "Write starting address plus number of registers to write must not exceed 65536."
             raise ValueError(msg)
 
         for idx, value in enumerate(self.write_values):

--- a/tests/pdu/test_coils.py
+++ b/tests/pdu/test_coils.py
@@ -50,6 +50,19 @@ class TestReadCoilsPDU:
         with pytest.raises(ValueError, match=r"Quantity must be between 1 and 2000."):
             ReadCoilsPDU(start_address=1, quantity=2001)
 
+    def test_read_coils_address_overflow_validation(self) -> None:
+        """The requested range must stay within the 16-bit address space."""
+        pdu = ReadCoilsPDU(start_address=65535, quantity=1)
+        assert pdu.start_address == 65535
+
+        pdu = ReadCoilsPDU(start_address=63536, quantity=2000)
+        assert pdu.quantity == 2000
+
+        with pytest.raises(ValueError, match=r"Start address plus quantity must not exceed 65536\."):
+            ReadCoilsPDU(start_address=63537, quantity=2000)
+        with pytest.raises(ValueError, match=r"Start address plus quantity must not exceed 65536\."):
+            ReadCoilsPDU(start_address=65535, quantity=2)
+
     def test_read_coils_encode_request(self) -> None:
         """Test encoding of Read Coils PDU."""
         pdu = ReadCoilsPDU(start_address=1, quantity=10)
@@ -111,6 +124,15 @@ class TestReadCoilsPDU:
         """A server-side request with an invalid quantity raises InvalidRequestError."""
         request = struct.pack(">BHH", 0x01, 100, 0)
         with pytest.raises(InvalidRequestError, match=r"Quantity must be between 1 and 2000\."):
+            ReadCoilsPDU.decode_request(request)
+
+    def test_decode_request_address_overflow(self) -> None:
+        """A server-side request past the end of the address space raises InvalidRequestError."""
+        pdu = ReadCoilsPDU.decode_request(struct.pack(">BHH", 0x01, 63536, 2000))
+        assert pdu.start_address == 63536
+
+        request = struct.pack(">BHH", 0x01, 63537, 2000)
+        with pytest.raises(InvalidRequestError, match=r"Start address plus quantity must not exceed 65536\."):
             ReadCoilsPDU.decode_request(request)
 
     def test_encode_response_single_byte(self) -> None:
@@ -250,6 +272,14 @@ class TestWriteMultipleCoilsPDU:
         with pytest.raises(ValueError, match=r"Number of coils must be between 1 and 1968\."):
             WriteMultipleCoilsPDU(start_address=1, values=[True] * 1969)
 
+    def test_write_multiple_coils_address_overflow_validation(self) -> None:
+        """The written range must stay within the 16-bit address space."""
+        pdu = WriteMultipleCoilsPDU(start_address=65535, values=[True])
+        assert pdu.start_address == 65535
+
+        with pytest.raises(ValueError, match=r"Start address plus number of coils must not exceed 65536\."):
+            WriteMultipleCoilsPDU(start_address=65535, values=[True, True])
+
     @pytest.mark.parametrize(
         ("start_address", "values", "expected_bytes"),
         [
@@ -343,6 +373,15 @@ class TestWriteMultipleCoilsPDU:
         """Test decode_request with invalid byte count."""
         request = struct.pack(">BHHB", 0x0F, 100, 5, 2) + b"\x15\x00"  # Wrong byte count
         with pytest.raises(InvalidRequestError, match=r"Invalid byte count: expected 1, got 2"):
+            WriteMultipleCoilsPDU.decode_request(request)
+
+    def test_decode_request_address_overflow(self) -> None:
+        """A server-side request past the end of the address space raises InvalidRequestError."""
+        pdu = WriteMultipleCoilsPDU.decode_request(struct.pack(">BHHB", 0x0F, 65528, 8, 1) + b"\xff")
+        assert pdu.start_address == 65528
+
+        request = struct.pack(">BHHB", 0x0F, 65529, 8, 1) + b"\xff"
+        with pytest.raises(InvalidRequestError, match=r"Start address plus number of coils must not exceed 65536\."):
             WriteMultipleCoilsPDU.decode_request(request)
 
     def test_decode_request_value_error_is_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/pdu/test_holding_registers.py
+++ b/tests/pdu/test_holding_registers.py
@@ -24,6 +24,23 @@ class TestReadHoldingRegistersPDU:
     with pytest.raises(ValueError, match=r"Quantity must be between 1 and 125."):
         ReadHoldingRegistersPDU(start_address=1, quantity=126)
 
+    def test_read_holding_registers_address_overflow_validation(self) -> None:
+        """The requested range must stay within the 16-bit address space."""
+        pdu = ReadHoldingRegistersPDU(start_address=65411, quantity=125)
+        assert pdu.quantity == 125
+
+        with pytest.raises(ValueError, match=r"Start address plus quantity must not exceed 65536\."):
+            ReadHoldingRegistersPDU(start_address=65412, quantity=125)
+
+    def test_decode_request_address_overflow(self) -> None:
+        """A server-side request past the end of the address space raises InvalidRequestError."""
+        pdu = ReadHoldingRegistersPDU.decode_request(b"\x03\xff\x83\x00\x7d")  # 65411 + 125 == 65536
+        assert pdu.start_address == 65411
+
+        request = b"\x03\xff\x84\x00\x7d"  # 65412 + 125 > 65536
+        with pytest.raises(InvalidRequestError, match=r"Start address plus quantity must not exceed 65536\."):
+            ReadHoldingRegistersPDU.decode_request(request)
+
     def test_read_holding_registers_encode_request(self) -> None:
         """Test encoding of Read Holding Registers PDU."""
         pdu = ReadHoldingRegistersPDU(start_address=1, quantity=10)
@@ -189,6 +206,23 @@ class TestRawReadHoldingRegistersPDU:
         """A server-side request with an invalid quantity raises InvalidRequestError."""
         request = b"\x03\x12\x34\x00\x00"
         with pytest.raises(InvalidRequestError, match="Quantity must be between 1 and 125"):
+            RawReadHoldingRegistersPDU.decode_request(request)
+
+    def test_address_overflow_validation(self) -> None:
+        """The requested range must stay within the 16-bit address space."""
+        pdu = RawReadHoldingRegistersPDU(start_address=65535, quantity=1)
+        assert pdu.start_address == 65535
+
+        with pytest.raises(ValueError, match=r"Start address plus quantity must not exceed 65536\."):
+            RawReadHoldingRegistersPDU(start_address=65535, quantity=2)
+
+    def test_decode_request_address_overflow(self) -> None:
+        """A server-side request past the end of the address space raises InvalidRequestError."""
+        pdu = RawReadHoldingRegistersPDU.decode_request(b"\x03\xff\xff\x00\x01")
+        assert pdu.start_address == 65535
+
+        request = b"\x03\xff\xff\x00\x02"
+        with pytest.raises(InvalidRequestError, match=r"Start address plus quantity must not exceed 65536\."):
             RawReadHoldingRegistersPDU.decode_request(request)
 
     def test_decode_request_value_error_is_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -480,6 +514,25 @@ class TestRawWriteMultipleRegistersPDU:
         with pytest.raises(InvalidRequestError, match="Invalid data length"):
             RawWriteMultipleRegistersPDU.decode_request(request)
 
+    def test_address_overflow_validation(self) -> None:
+        """The written range must stay within the 16-bit address space."""
+        pdu = RawWriteMultipleRegistersPDU(start_address=65535, content=b"\x12\x34")
+        assert pdu.start_address == 65535
+
+        with pytest.raises(ValueError, match=r"Start address plus number of registers must not exceed 65536\."):
+            RawWriteMultipleRegistersPDU(start_address=65535, content=b"\x12\x34\x56\x78")
+
+    def test_decode_request_address_overflow(self) -> None:
+        """A server-side request past the end of the address space raises InvalidRequestError."""
+        pdu = RawWriteMultipleRegistersPDU.decode_request(b"\x10\xff\xff\x00\x01\x02\x12\x34")
+        assert pdu.start_address == 65535
+
+        request = b"\x10\xff\xff\x00\x02\x04\x12\x34\x56\x78"
+        with pytest.raises(
+            InvalidRequestError, match=r"Start address plus number of registers must not exceed 65536\."
+        ):
+            RawWriteMultipleRegistersPDU.decode_request(request)
+
     def test_decode_request_value_error_is_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A constructor ValueError is converted to InvalidRequestError for server-side decoding."""
 
@@ -560,6 +613,25 @@ class TestWriteMultipleRegistersPDU:
 
         with pytest.raises(ValueError, match=r"Value must be between 0 and 65535: 70000"):
             WriteMultipleRegistersPDU(start_address=1, values=[70000])
+
+    def test_write_multiple_registers_address_overflow_validation(self) -> None:
+        """The written range must stay within the 16-bit address space."""
+        pdu = WriteMultipleRegistersPDU(start_address=65535, values=[123])
+        assert pdu.start_address == 65535
+
+        with pytest.raises(ValueError, match=r"Start address plus number of registers must not exceed 65536\."):
+            WriteMultipleRegistersPDU(start_address=65535, values=[123, 456])
+
+    def test_decode_request_address_overflow(self) -> None:
+        """A server-side request past the end of the address space raises InvalidRequestError."""
+        pdu = WriteMultipleRegistersPDU.decode_request(b"\x10\xff\xff\x00\x01\x02\x12\x34")
+        assert pdu.start_address == 65535
+
+        request = b"\x10\xff\xff\x00\x02\x04\x12\x34\x56\x78"
+        with pytest.raises(
+            InvalidRequestError, match=r"Start address plus number of registers must not exceed 65536\."
+        ):
+            WriteMultipleRegistersPDU.decode_request(request)
 
     def test_write_multiple_registers_encode_request(self) -> None:
         """Test encoding of Write Multiple Registers PDU."""
@@ -1024,6 +1096,53 @@ class TestReadWriteMultipleRegistersPDU:
         """A server-side request with zero write registers raises InvalidRequestError."""
         request = b"\x17\x00\x10\x00\x01\x00\x20\x00\x00\x00"
         with pytest.raises(InvalidRequestError, match="Number of registers to write must be between 1 and 121"):
+            ReadWriteMultipleRegistersPDU.decode_request(request)
+
+    def test_address_overflow_validation(self) -> None:
+        """Both the read and the write range must stay within the 16-bit address space."""
+        pdu = ReadWriteMultipleRegistersPDU(
+            read_start_address=65535,
+            read_quantity=1,
+            write_start_address=65535,
+            write_values=[1],
+        )
+        assert pdu.read_start_address == 65535
+
+        with pytest.raises(ValueError, match=r"Read starting address plus read quantity must not exceed 65536\."):
+            ReadWriteMultipleRegistersPDU(
+                read_start_address=65535,
+                read_quantity=2,
+                write_start_address=200,
+                write_values=[1],
+            )
+
+        with pytest.raises(
+            ValueError, match=r"Write starting address plus number of registers to write must not exceed 65536\."
+        ):
+            ReadWriteMultipleRegistersPDU(
+                read_start_address=100,
+                read_quantity=1,
+                write_start_address=65535,
+                write_values=[1, 2],
+            )
+
+    def test_decode_request_address_overflow(self) -> None:
+        """A server-side request past the end of the address space raises InvalidRequestError."""
+        pdu = ReadWriteMultipleRegistersPDU.decode_request(b"\x17\xff\xff\x00\x01\xff\xff\x00\x01\x02\x12\x34")
+        assert pdu.read_start_address == 65535
+        assert pdu.write_start_address == 65535
+
+        request = b"\x17\xff\xff\x00\x02\x00\x00\x00\x01\x02\x12\x34"
+        with pytest.raises(
+            InvalidRequestError, match=r"Read starting address plus read quantity must not exceed 65536\."
+        ):
+            ReadWriteMultipleRegistersPDU.decode_request(request)
+
+        request = b"\x17\x00\x00\x00\x01\xff\xff\x00\x02\x04\x12\x34\x56\x78"
+        with pytest.raises(
+            InvalidRequestError,
+            match=r"Write starting address plus number of registers to write must not exceed 65536\.",
+        ):
             ReadWriteMultipleRegistersPDU.decode_request(request)
 
     def test_decode_request_too_short(self) -> None:


### PR DESCRIPTION
# Proposed Changes

This addresses a low-severity finding from a pre-1.0.0 review sweep. It is filed as its own small PR so it can be judged on its own merits — I completely understand if you prefer to close it.

No PDU validated that `start_address + quantity` stays within the 16-bit address space. `ReadCoilsPDU(65535, 2000)` encoded a request that wraps past address 65535, and server-side `decode_request` accepted such requests as well. The Modbus spec expects them to be rejected.

This PR adds a `start_address + quantity <= 0x10000` check to every PDU with an address/quantity pair: `ReadCoilsPDU` (and `ReadDiscreteInputsPDU` via inheritance), `WriteMultipleCoilsPDU`, `RawReadHoldingRegistersPDU` (and the raw/typed holding and input register read PDUs built on it), `RawWriteMultipleRegistersPDU` (and `WriteMultipleRegistersPDU`), and both the read and the write range of `ReadWriteMultipleRegistersPDU`. Client-side constructors raise `ValueError`, matching the wording of the existing quantity validations. Server-side `decode_request` converts this to `InvalidRequestError` through the existing conversion path, so the transports answer with ILLEGAL DATA VALUE (0x03).

One note: the spec arguably calls for ILLEGAL DATA ADDRESS (0x02) for this case, but that would need new plumbing to carry an exception code from decode to the transports. I left that as your call and deferred it.

Tests cover the boundaries for each touched PDU: the maximum valid range (`start + quantity == 0x10000`) is accepted, one register/coil past it is rejected, on both the constructor and the `decode_request` side.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
