### PR TITLE
fix(transport): expire timed-out request tracking after 30 seconds

### DIFF
--- a/src/tmodbus/transport/async_ascii.py
+++ b/src/tmodbus/transport/async_ascii.py
@@ -25,7 +25,7 @@ from tmodbus.utils.lrc import calculate_lrc, validate_lrc
 from tmodbus.utils.raw_traffic_logger import log_raw_traffic as base_log_raw_traffic
 
 from .async_base import AsyncBaseTransport
-from .async_rtu import SerialXOptions
+from .async_rtu import TIMED_OUT_REQUEST_EXPIRY, SerialXOptions
 
 logger = logging.getLogger(__name__)
 log_raw_traffic = partial(base_log_raw_traffic, "ASCII")
@@ -122,7 +122,8 @@ class ModbusAsciiProtocol(asyncio.Protocol):
     _buffer: bytearray
     _last_frame_ended_at: float
     _pending_request: _PendingRequest | None
-    _timed_out_requests: dict[int, BaseClientPDU[Any]]
+    # unit_id -> (pdu, time.monotonic() when the request timed out)
+    _timed_out_requests: dict[int, tuple[BaseClientPDU[Any], float]]
 
     def __init__(
         self,
@@ -208,13 +209,13 @@ class ModbusAsciiProtocol(asyncio.Protocol):
                 response = await asyncio.wait_for(read_future, timeout=self.timeout)
             except TimeoutError as e:
                 # Save PDU for timed-out request so any delayed response can be discarded cleanly
-                self._timed_out_requests[unit_id] = pdu
+                self._timed_out_requests[unit_id] = (pdu, time.monotonic())
                 msg = f"Response timeout after {self.timeout} seconds"
                 raise TimeoutError(msg) from e
             except asyncio.CancelledError:
                 # Caller cancelled while the request was on the wire: track it like a
                 # timeout so a delayed response is not treated as garbage.
-                self._timed_out_requests[unit_id] = pdu
+                self._timed_out_requests[unit_id] = (pdu, time.monotonic())
                 raise
             finally:
                 self._pending_request = None
@@ -263,7 +264,8 @@ class ModbusAsciiProtocol(asyncio.Protocol):
 
     def _handle_inactive_unit_data(self, unit_id: int, base_function_code: int, raw: bytes) -> None:
         """Handle data for a unit ID with no active request."""
-        timed_out_pdu = self._timed_out_requests.get(unit_id)
+        timed_out_entry = self._timed_out_requests.get(unit_id)
+        timed_out_pdu = timed_out_entry[0] if timed_out_entry is not None else None
         if timed_out_pdu is None and self._pending_request is not None and self._pending_request.unit_id == unit_id:
             timed_out_pdu = self._pending_request.pdu
 
@@ -305,8 +307,8 @@ class ModbusAsciiProtocol(asyncio.Protocol):
         if base_function_code == (pending.pdu.function_code & FUNCTION_CODE_MASK):
             return False
 
-        timed_out_pdu = self._timed_out_requests.get(unit_id)
-        if timed_out_pdu is None or base_function_code != (timed_out_pdu.function_code & FUNCTION_CODE_MASK):
+        timed_out_entry = self._timed_out_requests.get(unit_id)
+        if timed_out_entry is None or base_function_code != (timed_out_entry[0].function_code & FUNCTION_CODE_MASK):
             return False
 
         # Only clear tracking when the LRC validates (mirrors RTU's CRC check):
@@ -328,10 +330,24 @@ class ModbusAsciiProtocol(asyncio.Protocol):
         self._timed_out_requests.pop(unit_id, None)
         return True
 
+    def _purge_expired_timed_out_requests(self) -> None:
+        """Drop timed-out requests whose delayed response never arrived within the expiry horizon."""
+        deadline = time.monotonic() - TIMED_OUT_REQUEST_EXPIRY
+        for unit_id, (_, timed_out_at) in list(self._timed_out_requests.items()):
+            if timed_out_at < deadline:
+                logger.warning(
+                    "Timed-out request for unit %d expired after %.0f seconds without a delayed response.",
+                    unit_id,
+                    TIMED_OUT_REQUEST_EXPIRY,
+                )
+                del self._timed_out_requests[unit_id]
+
     def data_received(self, data: bytes) -> None:
         """Handle data received event."""
         self._buffer.extend(data)
         log_raw_traffic("recv", data)
+
+        self._purge_expired_timed_out_requests()
 
         # Try to process complete frames
         while len(self._buffer) >= 1:

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -75,6 +75,11 @@ RT = TypeVar("RT")
 
 DEFAULT_TIMEOUT = 10.0  # Default timeout in seconds for async operations
 
+# How long (in seconds) a timed-out request is remembered so its delayed response can be
+# framed and discarded. After this, the device is considered truly dead and the entry is
+# purged so stale PDUs cannot influence framing of future data indefinitely.
+TIMED_OUT_REQUEST_EXPIRY = 30.0
+
 
 class SerialXOptions(TypedDict):
     """Options for the SerialX connection."""
@@ -310,7 +315,8 @@ class ModbusRtuProtocol(asyncio.Protocol):
     _buffer: bytearray
     _last_frame_ended_at: float
     _pending_request: _PendingRequest | None
-    _timed_out_requests: dict[int, BaseClientPDU[Any]]
+    # unit_id -> (pdu, time.monotonic() when the request timed out)
+    _timed_out_requests: dict[int, tuple[BaseClientPDU[Any], float]]
 
     def __init__(
         self,
@@ -397,13 +403,13 @@ class ModbusRtuProtocol(asyncio.Protocol):
                 response = await asyncio.wait_for(read_future, timeout=self.timeout)
             except TimeoutError as e:
                 # Save PDU for timed-out request so any delayed response can be framed and discarded cleanly
-                self._timed_out_requests[unit_id] = pdu
+                self._timed_out_requests[unit_id] = (pdu, time.monotonic())
                 msg = f"Response timeout after {self.timeout} seconds"
                 raise TimeoutError(msg) from e
             except asyncio.CancelledError:
                 # Caller cancelled while the request was on the wire: track it like a
                 # timeout so a delayed response is not treated as garbage.
-                self._timed_out_requests[unit_id] = pdu
+                self._timed_out_requests[unit_id] = (pdu, time.monotonic())
                 raise
             finally:
                 self._pending_request = None
@@ -434,7 +440,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
         - unit_id + exception response function code (base function code | EXCEPTION_RESPONSE_BIT)
         """
         headers: set[bytes] = set()
-        for uid, pdu in self._timed_out_requests.items():
+        for uid, (pdu, _) in self._timed_out_requests.items():
             base_fc = pdu.function_code & FUNCTION_CODE_MASK
             headers.add(bytes([uid, base_fc]))
             headers.add(bytes([uid, base_fc | EXCEPTION_RESPONSE_BIT]))
@@ -664,8 +670,9 @@ class ModbusRtuProtocol(asyncio.Protocol):
             True if waiting for more data, False if drained or skipped, or None if no match.
 
         """
-        timed_out_pdu = self._timed_out_requests.get(unit_id)
-        if timed_out_pdu is not None and len(self._buffer) >= 2:
+        timed_out_entry = self._timed_out_requests.get(unit_id)
+        if timed_out_entry is not None and len(self._buffer) >= 2:
+            timed_out_pdu = timed_out_entry[0]
             raw_function_code = self._buffer[1]
             base_function_code = raw_function_code & FUNCTION_CODE_MASK
             if (
@@ -683,7 +690,8 @@ class ModbusRtuProtocol(asyncio.Protocol):
             True if caller should return immediately (waiting for more data), False to continue.
 
         """
-        timed_out_pdu = self._timed_out_requests.get(unit_id)
+        timed_out_entry = self._timed_out_requests.get(unit_id)
+        timed_out_pdu = timed_out_entry[0] if timed_out_entry is not None else None
         if timed_out_pdu is None and self._pending_request is not None and self._pending_request.unit_id == unit_id:
             timed_out_pdu = self._pending_request.pdu
 
@@ -693,6 +701,18 @@ class ModbusRtuProtocol(asyncio.Protocol):
         # No pending or timed-out request for this unit_id - this is garbage data
         self._discard_garbage_data()
         return False
+
+    def _purge_expired_timed_out_requests(self) -> None:
+        """Drop timed-out requests whose delayed response never arrived within the expiry horizon."""
+        deadline = time.monotonic() - TIMED_OUT_REQUEST_EXPIRY
+        for unit_id, (_, timed_out_at) in list(self._timed_out_requests.items()):
+            if timed_out_at < deadline:
+                logger.warning(
+                    "Timed-out request for unit %d expired after %.0f seconds without a delayed response.",
+                    unit_id,
+                    TIMED_OUT_REQUEST_EXPIRY,
+                )
+                del self._timed_out_requests[unit_id]
 
     def data_received(self, data: bytes) -> None:
         """Handle data received event.
@@ -712,6 +732,8 @@ class ModbusRtuProtocol(asyncio.Protocol):
         # Received bytes are bus activity too: restart the 3.5-char silence clock so the
         # next request keeps the inter-frame delay from the end of a received frame.
         self._last_frame_ended_at = time.monotonic()
+
+        self._purge_expired_timed_out_requests()
 
         last_error: Exception | None = None
 

--- a/tests/transport/test_async_ascii.py
+++ b/tests/transport/test_async_ascii.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -21,6 +22,7 @@ from tmodbus.transport.async_ascii import (
     ASCII_FRAME_END,
     ASCII_FRAME_START,
     MAX_ASCII_FRAME_SIZE,
+    TIMED_OUT_REQUEST_EXPIRY,
     AsyncAsciiTransport,
     ModbusAsciiProtocol,
     _PendingRequest,
@@ -797,7 +799,7 @@ async def test_protocol_multiple_frames(mock_transport: MagicMock) -> None:
     with pytest.raises(TimeoutError):
         await protocol.send_and_receive(unit_id, pdu1)
 
-    assert protocol._timed_out_requests[unit_id] is pdu1
+    assert protocol._timed_out_requests[unit_id][0] is pdu1
 
     # Build delayed response for request 1 and valid response for request 2
     frame1 = build_ascii_frame(unit_id, b"\x03\x02\xaa\xbb")
@@ -1190,7 +1192,7 @@ async def test_send_and_receive_timeout_resets_pending_request(
         await protocol.send_and_receive(unit_id, pdu)
 
     assert protocol._pending_request is None
-    assert protocol._timed_out_requests[unit_id] is pdu
+    assert protocol._timed_out_requests[unit_id][0] is pdu
 
 
 async def test_send_and_receive_serialized_by_bus_lock(
@@ -1241,7 +1243,7 @@ async def test_delayed_response_after_timeout_is_cleanly_discarded(
     with pytest.raises(TimeoutError):
         await protocol.send_and_receive(unit_id, pdu)
 
-    assert protocol._timed_out_requests[unit_id] is pdu
+    assert protocol._timed_out_requests[unit_id][0] is pdu
 
     # Delayed response arrives
     delayed_frame = build_ascii_frame(unit_id, b"\x03\x02\x00\x55")
@@ -1271,7 +1273,7 @@ async def test_delayed_response_during_active_request_same_unit(
     with pytest.raises(TimeoutError):
         await protocol.send_and_receive(unit_id, pdu1)
 
-    assert protocol._timed_out_requests[unit_id] is pdu1
+    assert protocol._timed_out_requests[unit_id][0] is pdu1
 
     # Step 2: Request 2 (FC 0x06) is sent and active
     delayed_frame_1 = build_ascii_frame(unit_id, b"\x03\x02\xaa\xbb")
@@ -1320,7 +1322,7 @@ async def test_delayed_exception_response_during_active_request_same_unit(
     with pytest.raises(TimeoutError):
         await protocol.send_and_receive(unit_id, pdu1)
 
-    assert protocol._timed_out_requests[unit_id] is pdu1
+    assert protocol._timed_out_requests[unit_id][0] is pdu1
 
     # Step 2: Request 2 (FC 0x06) is sent and active
     # Late exception response for Request 1 (FC 0x83, exception code 0x02)
@@ -1366,7 +1368,7 @@ async def test_active_request_succeeds_and_clears_stale_timed_out_request(
     with pytest.raises(TimeoutError):
         await protocol.send_and_receive(unit_id, pdu1)
 
-    assert protocol._timed_out_requests[unit_id] is pdu1
+    assert protocol._timed_out_requests[unit_id][0] is pdu1
 
     # Request 2 is sent and succeeds
     response = build_ascii_frame(unit_id, b"\x03\x02\x00\x55")
@@ -1454,7 +1456,7 @@ async def test_cancelled_request_is_tracked_and_delayed_response_discarded(
         await task
 
     assert protocol._pending_request is None
-    assert protocol._timed_out_requests[unit_id] is pdu1
+    assert protocol._timed_out_requests[unit_id][0] is pdu1
 
     # Step 2: the delayed response is discarded and clears the tracking
     delayed_frame = build_ascii_frame(unit_id, b"\x03\x02\x00\x55")
@@ -1491,13 +1493,13 @@ async def test_corrupt_delayed_frame_keeps_timed_out_tracking(
 
     with pytest.raises(TimeoutError):
         await protocol.send_and_receive(unit_id, pdu)
-    assert protocol._timed_out_requests[unit_id] is pdu
+    assert protocol._timed_out_requests[unit_id][0] is pdu
 
     good_frame = build_ascii_frame(unit_id, b"\x03\x02\x00\x55")
     corrupt_frame = good_frame.replace(b"0055", b"0056")  # data changed, LRC now invalid
 
     protocol.data_received(corrupt_frame)
-    assert protocol._timed_out_requests[unit_id] is pdu  # tracking kept
+    assert protocol._timed_out_requests[unit_id][0] is pdu  # tracking kept
 
     protocol.data_received(good_frame)
     assert unit_id not in protocol._timed_out_requests
@@ -1522,7 +1524,7 @@ async def test_corrupt_delayed_frame_during_active_request_keeps_tracking(
     # Step 1: Request 1 (FC 0x03) times out
     with pytest.raises(TimeoutError):
         await protocol.send_and_receive(unit_id, pdu1)
-    assert protocol._timed_out_requests[unit_id] is pdu1
+    assert protocol._timed_out_requests[unit_id][0] is pdu1
 
     # Step 2: Request 2 (FC 0x06) is sent and active
     good_delayed_1 = build_ascii_frame(unit_id, b"\x03\x02\xaa\xbb")
@@ -1535,7 +1537,7 @@ async def test_corrupt_delayed_frame_during_active_request_keeps_tracking(
         protocol.data_received(corrupt_delayed_1)
         assert protocol._pending_request is not None
         assert not protocol._pending_request.future.done()
-        assert protocol._timed_out_requests[unit_id] is pdu1
+        assert protocol._timed_out_requests[unit_id][0] is pdu1
 
         # Real delayed frame clears the tracking
         protocol.data_received(good_delayed_1)
@@ -1566,7 +1568,7 @@ async def test_lrc_error_on_active_request_keeps_timed_out_tracking(
 
     stale_pdu = _DummyPDU()
     unit_id = 1
-    protocol._timed_out_requests[unit_id] = stale_pdu
+    protocol._timed_out_requests[unit_id] = (stale_pdu, time.monotonic())
 
     pdu = _DummyPDU()
     corrupt_frame = build_ascii_frame(unit_id, b"\x03\x02\x00\x55").replace(b"0055", b"0056")
@@ -1581,7 +1583,7 @@ async def test_lrc_error_on_active_request_keeps_timed_out_tracking(
         await task
     await deliv_task
 
-    assert protocol._timed_out_requests[unit_id] is stale_pdu
+    assert protocol._timed_out_requests[unit_id][0] is stale_pdu
 
 
 async def test_timeout_does_not_log_error(
@@ -1600,3 +1602,62 @@ async def test_timeout_does_not_log_error(
         await protocol.send_and_receive(1, _DummyPDU())
 
     assert not caplog.records
+
+
+async def test_timed_out_request_drained_within_expiry_horizon(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a delayed response arriving just before the expiry horizon is still drained cleanly."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("tmodbus.transport.async_ascii.time", SimpleNamespace(monotonic=lambda: clock["now"]))
+
+    pdu = _DummyPDU()
+    unit_id = 1
+
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu)
+
+    # Registration records the monotonic clock
+    assert protocol._timed_out_requests[unit_id] == (pdu, 1000.0)
+
+    # Just before the horizon, the delayed response is still recognized and discarded cleanly
+    clock["now"] += TIMED_OUT_REQUEST_EXPIRY - 1
+    protocol.data_received(build_ascii_frame(unit_id, b"\x03\x02\x00\x55"))
+
+    assert len(protocol._buffer) == 0
+    assert unit_id not in protocol._timed_out_requests
+
+
+async def test_timed_out_request_expires_after_horizon(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a stale timed-out entry is purged and a late frame is treated as garbage."""
+    protocol = ModbusAsciiProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("tmodbus.transport.async_ascii.time", SimpleNamespace(monotonic=lambda: clock["now"]))
+
+    pdu = _DummyPDU()
+    unit_id = 1
+
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu)
+
+    assert protocol._timed_out_requests[unit_id] == (pdu, 1000.0)
+
+    # After the horizon, the entry is purged before it is consulted:
+    # the late frame is discarded as an unexpected frame, as before tracking existed
+    clock["now"] += TIMED_OUT_REQUEST_EXPIRY + 1
+    with caplog.at_level(logging.WARNING):
+        protocol.data_received(build_ascii_frame(unit_id, b"\x03\x02\x00\x55"))
+
+    assert unit_id not in protocol._timed_out_requests
+    assert len(protocol._buffer) == 0
+    assert "expired" in caplog.text

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -5,6 +5,7 @@ import contextlib
 import logging
 import time
 from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -21,6 +22,7 @@ from tmodbus.exceptions import (
 from tmodbus.pdu.base import BaseClientPDU
 from tmodbus.transport.async_rtu import (
     MAX_RTU_FRAME_SIZE,
+    TIMED_OUT_REQUEST_EXPIRY,
     AsyncRtuTransport,
     ModbusRtuProtocol,
     _ModbusRtuMessage,
@@ -561,7 +563,7 @@ async def test_protocol_per_unit_request_tracking(
     with pytest.raises(TimeoutError):
         await protocol.send_and_receive(unit_id_1, pdu1)
 
-    assert protocol._timed_out_requests[unit_id_1] is pdu1
+    assert protocol._timed_out_requests[unit_id_1][0] is pdu1
 
     # Request 2 succeeds -> stored in _timed_out_requests[unit_id_2] (if timed out), but unit 1 is kept
     resp2_payload = bytes([unit_id_2, pdu2.function_code, 0x05])
@@ -577,7 +579,7 @@ async def test_protocol_per_unit_request_tracking(
 
     assert res2[0] == "decoded"
     # Unit 1 timed-out request is still tracked safely!
-    assert protocol._timed_out_requests[unit_id_1] is pdu1
+    assert protocol._timed_out_requests[unit_id_1][0] is pdu1
     assert unit_id_2 not in protocol._timed_out_requests
 
 
@@ -743,7 +745,7 @@ async def test_on_connection_lost_pending_futures(mock_serial_connection: tuple[
     send_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
     await asyncio.sleep(0.01)  # Ensure the send_and_receive has started
     assert protocol._pending_request is not None
-    protocol._timed_out_requests[3] = pdu
+    protocol._timed_out_requests[3] = (pdu, time.monotonic())
     # Now simulate connection lost
     protocol.connection_lost(None)
     assert len(protocol._timed_out_requests) == 0
@@ -1172,7 +1174,7 @@ async def test_send_and_receive_timeout_resets_pending_request(
         await protocol.send_and_receive(unit_id, pdu)
 
     assert protocol._pending_request is None
-    assert protocol._timed_out_requests[unit_id] is pdu
+    assert protocol._timed_out_requests[unit_id][0] is pdu
 
 
 async def test_sliding_window_recovers_when_noise_matches_unit_id(
@@ -1570,7 +1572,7 @@ async def test_delayed_response_after_timeout_is_cleanly_discarded_using_old_pdu
         await protocol.send_and_receive(unit_id, pdu1)
 
     # Verify that the timed out PDU is preserved
-    assert protocol._timed_out_requests[unit_id] is pdu1
+    assert protocol._timed_out_requests[unit_id][0] is pdu1
 
     # Step 2: Now the delayed response arrives. It should be framed and discarded cleanly.
     protocol.data_received(delayed_response)
@@ -1614,7 +1616,7 @@ async def test_try_drain_timed_out_response_branches(
 
     # 2. When _determine_expected_frame_length raises error -> pops and discards leading garbage slice
     protocol._buffer = bytearray(b"\x01\x65\x00\x00")
-    protocol._timed_out_requests[unit_id] = pdu
+    protocol._timed_out_requests[unit_id] = (pdu, time.monotonic())
     assert protocol._try_drain_timed_out_response(unit_id, pdu) is False
     assert unit_id not in protocol._timed_out_requests
     assert protocol._buffer == bytearray(b"")  # No plausible start ahead; entire slice discarded
@@ -1627,7 +1629,7 @@ async def test_try_drain_timed_out_response_branches(
 
     monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
     protocol._buffer = bytearray(b"\x01\x03\x05\xff\xff\x01\x03\x05\xaa\xbb")  # bad frame followed by next candidate
-    protocol._timed_out_requests[unit_id] = pdu
+    protocol._timed_out_requests[unit_id] = (pdu, time.monotonic())
     assert protocol._try_drain_timed_out_response(unit_id, pdu) is False
     assert protocol._buffer == bytearray(b"\x01\x03\x05\xaa\xbb")  # Resynchronized to next plausible frame start
 
@@ -1642,7 +1644,7 @@ async def test_delayed_response_drained_in_chunks(
 
     pdu = _DummyPDU()
     unit_id = 1
-    protocol._timed_out_requests[unit_id] = pdu
+    protocol._timed_out_requests[unit_id] = (pdu, time.monotonic())
 
     class DummyPduClass:
         @staticmethod
@@ -1706,7 +1708,7 @@ async def test_delayed_response_arriving_during_active_request_different_fc(
     with pytest.raises(TimeoutError):
         await protocol.send_and_receive(unit_id, pdu1)
 
-    assert protocol._timed_out_requests[unit_id] is pdu1
+    assert protocol._timed_out_requests[unit_id][0] is pdu1
 
     # Step 2: Request 2 is dispatched (FC 0x06) and is active
     delayed_payload_1 = bytes([unit_id, 0x03, 0xAA])
@@ -1762,7 +1764,7 @@ async def test_active_request_succeeds_and_clears_stale_timed_out_request(
     with pytest.raises(TimeoutError):
         await protocol.send_and_receive(unit_id, pdu1)
 
-    assert protocol._timed_out_requests[unit_id] is pdu1
+    assert protocol._timed_out_requests[unit_id][0] is pdu1
 
     # Request 2 is sent, and its response arrives directly
     resp_payload = bytes([unit_id, pdu2.function_code, 0x55])
@@ -1811,7 +1813,7 @@ async def test_delayed_exception_response_arriving_during_active_request(
     with pytest.raises(TimeoutError):
         await protocol.send_and_receive(unit_id, pdu1)
 
-    assert protocol._timed_out_requests[unit_id] is pdu1
+    assert protocol._timed_out_requests[unit_id][0] is pdu1
 
     # Step 2: Request 2 (FC 0x06) is sent and active
     # Late response for Request 1 is an Exception Response (FC 0x83, Exception Code 0x02)
@@ -1885,7 +1887,7 @@ async def test_delayed_response_in_chunks_during_active_request(
     with pytest.raises(TimeoutError):
         await protocol.send_and_receive(unit_id, pdu1)
 
-    assert protocol._timed_out_requests[unit_id] is pdu1
+    assert protocol._timed_out_requests[unit_id][0] is pdu1
 
     # Step 2: Request 2 (FC 0x06) is sent and active
     delayed_payload_1 = bytes([unit_id, 0x03, 0xAA, 0xBB])
@@ -2044,7 +2046,7 @@ async def test_cancelled_request_is_tracked_and_delayed_response_drained(
         await task
 
     assert protocol._pending_request is None
-    assert protocol._timed_out_requests[unit_id] is pdu1
+    assert protocol._timed_out_requests[unit_id][0] is pdu1
 
     # Step 2: the delayed response is framed and discarded cleanly
     protocol.data_received(delayed_response)
@@ -2208,3 +2210,71 @@ async def test_discard_garbage_data_when_buffer_starts_with_valid_header(
     protocol._discard_garbage_data()
 
     assert protocol._buffer == bytearray(b"\x01\x03\x05\xaa\xbb")
+
+
+async def test_timed_out_request_drained_within_expiry_horizon(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a delayed response arriving just before the expiry horizon is still drained cleanly."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("tmodbus.transport.async_rtu.time", SimpleNamespace(monotonic=lambda: clock["now"]))
+
+    pdu = _DummyPDU()
+    unit_id = 1
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu)
+
+    # Registration records the monotonic clock
+    assert protocol._timed_out_requests[unit_id] == (pdu, 1000.0)
+
+    # Just before the horizon, the delayed response is still framed and drained cleanly
+    clock["now"] += TIMED_OUT_REQUEST_EXPIRY - 1
+    delayed_payload = bytes([unit_id, pdu.function_code, 0x05])
+    protocol.data_received(delayed_payload + calculate_crc16(delayed_payload))
+
+    assert len(protocol._buffer) == 0
+    assert unit_id not in protocol._timed_out_requests
+
+
+async def test_timed_out_request_expires_after_horizon(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a stale timed-out entry is purged and a late frame is treated as garbage."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=0.05)
+    protocol.connection_made(mock_transport)
+
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("tmodbus.transport.async_rtu.time", SimpleNamespace(monotonic=lambda: clock["now"]))
+
+    pdu = _DummyPDU()
+    unit_id = 1
+
+    with pytest.raises(TimeoutError):
+        await protocol.send_and_receive(unit_id, pdu)
+
+    assert protocol._timed_out_requests[unit_id] == (pdu, 1000.0)
+
+    # After the horizon, the entry is purged before it is consulted:
+    # the late frame is discarded as garbage, as before tracking existed
+    clock["now"] += TIMED_OUT_REQUEST_EXPIRY + 1
+    delayed_payload = bytes([unit_id, pdu.function_code, 0x05])
+    with caplog.at_level(logging.WARNING):
+        protocol.data_received(delayed_payload + calculate_crc16(delayed_payload))
+
+    assert unit_id not in protocol._timed_out_requests
+    assert len(protocol._buffer) == 0
+    assert "expired" in caplog.text


### PR DESCRIPTION
# Proposed Changes

This addresses a low-severity finding from a pre-1.0.0 review sweep. It is filed as its own small PR so it can be judged on its own merits, and I completely understand if you prefer to close it.

The finding: entries in `_timed_out_requests` never expire. When a delayed response never arrives (the device is truly dead), the stale PDU lives until connection loss. Any future garbage byte matching that unit id is then framed against the stale PDU, so the stale framing behavior can persist for hours.

This PR records `time.monotonic()` when a timed-out request is registered and lazily purges entries older than 30 seconds (`TIMED_OUT_REQUEST_EXPIRY`) at the start of `data_received`, before the tracking is consulted. No background tasks. Within the horizon, a delayed response is still framed and drained cleanly exactly as before. After the horizon, the entry is gone and a late frame is treated as garbage, as before tracking existed. The same mechanism applies to both RTU and ASCII.

Tests use a patched monotonic clock to cover both sides of the horizon in both transports, and the existing `_timed_out_requests` tests are updated for the `(pdu, timestamp)` entries.

Note: this deliberately stays tiny because `fix/tighten-rtu-resync` is in flight and touches the RTU resync logic. Happy to rebase this onto that work if it lands first.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
