### PR TITLE
fix(pdu): correct expected request length for RawWriteMultipleRegistersPDU

### DIFF
--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -481,6 +481,14 @@ class RawWriteMultipleRegistersPDU(BasePDU[int]):
             value,
         )
 
+    @classmethod
+    def get_expected_request_data_length(cls, data: bytes) -> int:
+        """Get the expected number of bytes for the data part of the request PDU."""
+        if len(data) < 5:
+            return 5  # wait for byte count
+        byte_count = data[4]
+        return 5 + byte_count
+
 
 class WriteMultipleRegistersPDU(BasePDU[int]):
     """Write Multiple Registers PDU."""

--- a/tests/pdu/test_holding_registers.py
+++ b/tests/pdu/test_holding_registers.py
@@ -512,6 +512,11 @@ class TestRawWriteMultipleRegistersPDU:
         response = pdu.encode_response(2)
         assert pdu.get_expected_response_data_length(response[1:]) == len(response) - 1
 
+    def test_get_expected_request_data_length(self) -> None:
+        """Test get_expected_request_data_length."""
+        assert RawWriteMultipleRegistersPDU.get_expected_request_data_length(b"\x00\x00\x00\x00") == 5
+        assert RawWriteMultipleRegistersPDU.get_expected_request_data_length(b"\x00\x00\x00\x00\x02") == 7
+
 
 # ============================================================================
 # WriteMultipleRegistersPDU Additional Tests


### PR DESCRIPTION
# Proposed Changes

This addresses a low-severity finding from a pre-1.0.0 review sweep. It is filed as its own small PR so it can be judged on its own merits — I completely understand if you prefer to close it.

`RawWriteMultipleRegistersPDU` subclasses `BasePDU` directly, so it inherits the default `get_expected_request_data_length`, which reads the length prefix from `data[0]` and returns `1 + data[0]`. A Write Multiple Registers (0x10) request data part is laid out as address (2) + quantity (2) + byte count (1) + data (N), so the correct expected length is `5 + byte_count` with the byte count at `data[4]`. `WriteMultipleRegistersPDU` already overrides this correctly, and that is the class registered in the server PDU map, so nothing is broken today. The raw class is only a trap for anyone who registers it via `register_pdu_class` on a serial (RTU) server: the inherited default would misframe every request.

This PR mirrors the `get_expected_request_data_length` override from `WriteMultipleRegistersPDU` onto `RawWriteMultipleRegistersPDU`, and adds a PDU-level test covering a partial (4-byte) and a complete request data payload, matching the existing `WriteMultipleRegistersPDU` test.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
