### PR TITLE
fix(pdu): make frozen PDU dataclasses with sequence fields hashable

### DIFF
--- a/src/tmodbus/pdu/file.py
+++ b/src/tmodbus/pdu/file.py
@@ -1,6 +1,7 @@
 """PDU's for file record operations."""
 
 import struct
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Self
 
@@ -253,10 +254,13 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
 
     function_code = 0x15
 
-    file_records: list[FileRecord]
+    file_records: Sequence[FileRecord]
 
     def __post_init__(self) -> None:
         """Validate file records after initialization."""
+        # Store an immutable copy so the frozen dataclass stays hashable.
+        object.__setattr__(self, "file_records", tuple(self.file_records))
+
         for record in self.file_records:
             if not (0 <= record.file_number <= 0xFFFF):
                 msg = "File number must be between 0 and 65535."
@@ -285,7 +289,7 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
             raise ValueError(msg)
 
     @classmethod
-    def _encode(cls, file_records: list[FileRecord]) -> bytes:
+    def _encode(cls, file_records: Sequence[FileRecord]) -> bytes:
         """Encode the PDU into bytes.
 
         Returns:
@@ -399,7 +403,7 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
 
     def get_broadcast_response(self) -> list[FileRecord]:
         """Return dummy response for a broadcast request."""
-        return self.file_records
+        return list(self.file_records)
 
     def encode_response(self, value: list[FileRecord]) -> bytes:
         """Encode the response PDU.

--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -1,6 +1,7 @@
 """Holding/Input Registers PDU Module."""
 
 import struct
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Self
 
@@ -721,7 +722,7 @@ class ReadWriteMultipleRegistersPDU(BasePDU[list[int]]):
     read_start_address: int
     read_quantity: int
     write_start_address: int
-    write_values: list[int]
+    write_values: Sequence[int]
 
     REQUEST_HEADER_STRUCT = struct.Struct(">BHHHHB")
 
@@ -735,6 +736,9 @@ class ReadWriteMultipleRegistersPDU(BasePDU[list[int]]):
 
     def __post_init__(self) -> None:
         """Validate parameters after initialization."""
+        # Store an immutable copy so the frozen dataclass stays hashable.
+        object.__setattr__(self, "write_values", tuple(self.write_values))
+
         if not (0 <= self.read_start_address < 65536):
             msg = "Read starting address must be between 0 and 65535."
             raise ValueError(msg)

--- a/tests/pdu/test_file.py
+++ b/tests/pdu/test_file.py
@@ -391,6 +391,17 @@ class TestWriteFileRecordPDU:
         pdu = WriteFileRecordPDU(file_records=records)
         assert pdu.function_code == 0x15
 
+    def test_hashable(self) -> None:
+        """Test that file records are stored as a tuple, keeping the frozen PDU hashable."""
+        records = [FileRecord(file_number=4, record_number=7, data=b"\x06\xaf\x04\xbe")]
+        pdu = WriteFileRecordPDU(file_records=records)
+        equal_pdu = WriteFileRecordPDU(file_records=tuple(records))
+
+        assert pdu.file_records == tuple(records)
+        assert pdu == equal_pdu
+        assert len({pdu, equal_pdu}) == 1
+        assert {pdu: "value"}[equal_pdu] == "value"
+
     def test_get_expected_request_data_length(self) -> None:
         """Test get_expected_request_data_length."""
         assert WriteFileRecordPDU.get_expected_request_data_length(b"\x0b") == 12

--- a/tests/pdu/test_holding_registers.py
+++ b/tests/pdu/test_holding_registers.py
@@ -824,7 +824,25 @@ class TestReadWriteMultipleRegistersPDU:
         assert pdu.read_start_address == 100
         assert pdu.read_quantity == 10
         assert pdu.write_start_address == 200
-        assert pdu.write_values == [1, 2, 3, 4, 5]
+        assert pdu.write_values == (1, 2, 3, 4, 5)
+
+    def test_hashable(self) -> None:
+        """Test that write values are stored as a tuple, keeping the frozen PDU hashable."""
+        pdu = ReadWriteMultipleRegistersPDU(
+            read_start_address=100,
+            read_quantity=10,
+            write_start_address=200,
+            write_values=[1, 2, 3],
+        )
+        equal_pdu = ReadWriteMultipleRegistersPDU(
+            read_start_address=100,
+            read_quantity=10,
+            write_start_address=200,
+            write_values=(1, 2, 3),
+        )
+        assert pdu == equal_pdu
+        assert len({pdu, equal_pdu}) == 1
+        assert {pdu: "value"}[equal_pdu] == "value"
 
     @pytest.mark.parametrize(
         ("read_addr", "read_qty", "write_addr", "write_vals", "expected_error"),
@@ -1007,7 +1025,7 @@ class TestReadWriteMultipleRegistersPDU:
         assert pdu.read_start_address == 0x0003
         assert pdu.read_quantity == 6
         assert pdu.write_start_address == 0x000E
-        assert pdu.write_values == [0x00FF, 0x00FF, 0x00FF]
+        assert pdu.write_values == (0x00FF, 0x00FF, 0x00FF)
 
     def test_decode_request_single_write_value(self) -> None:
         """Test decoding request with single write value."""
@@ -1018,7 +1036,7 @@ class TestReadWriteMultipleRegistersPDU:
         assert pdu.read_start_address == 0
         assert pdu.read_quantity == 1
         assert pdu.write_start_address == 0
-        assert pdu.write_values == [0x1234]
+        assert pdu.write_values == (0x1234,)
 
     def test_decode_request_invalid_empty_write_values(self) -> None:
         """A server-side request with zero write registers raises InvalidRequestError."""
@@ -1180,7 +1198,7 @@ class TestReadWriteMultipleRegistersPDU:
         assert pdu.read_start_address == 0x0003
         assert pdu.read_quantity == 0x0006
         assert pdu.write_start_address == 0x000E
-        assert pdu.write_values == [0x00FF, 0x00FF, 0x00FF]
+        assert pdu.write_values == (0x00FF, 0x00FF, 0x00FF)
 
     def test_modbus_spec_example_decode_response(self) -> None:
         """Test decoding response using the exact example from Modbus specification.


### PR DESCRIPTION
# Proposed Changes

This addresses a low-severity consistency finding from a pre-1.0.0 review sweep. It is filed as its own small PR so it can be judged on its own merits — I completely understand if you prefer to close it.

`ReadWriteMultipleRegistersPDU` and `WriteFileRecordPDU` are `@dataclass(frozen=True)`, but their `list`-typed fields (`write_values`, `file_records`) break the contract that comes with that: `hash()` raises `TypeError` because the generated `__hash__` hashes the field values, and the mutable list also undermines the frozen semantics since the contents can still be changed after construction.

Both classes now annotate the field as `Sequence[...]` and normalize it to a tuple in `__post_init__` via `object.__setattr__` (the frozen-dataclass idiom), before the existing validation runs. Constructors still accept lists, validation behavior is unchanged, and the encoded bytes are identical. Instances are now hashable and usable as set members and dict keys.

Note: the stored attribute type changes from `list` to `tuple` — a minor breaking change for code that relies on the concrete type (e.g. `pdu.write_values == [1, 2, 3]` no longer holds). That seems acceptable pre-1.0.

The other frozen PDU dataclasses (`ReadFifoQueuePDU`, `ReadDeviceIdentificationPDU`, serial-line PDUs, `FileRecordRequest`, `FileRecord`) only hold hashable fields, so they are untouched. `ReadFileRecordPDU` stores a list too, but it is a plain class without generated `__eq__`/`__hash__`, so it does not have this problem and is left as is.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
