### PR TITLE
fix(pdu): make ReadFifoQueuePDU.function_code a class attribute

### DIFF
--- a/src/tmodbus/pdu/fifo.py
+++ b/src/tmodbus/pdu/fifo.py
@@ -13,10 +13,10 @@ from tmodbus.pdu.base import BasePDU
 class ReadFifoQueuePDU(BasePDU[list[int]]):
     """Read FIFO Queue PDU (Function Code 0x18)."""
 
-    address: int
-
-    function_code: int = FunctionCode.READ_FIFO_QUEUE
+    function_code = FunctionCode.READ_FIFO_QUEUE
     rtu_request_data_length = 2  # address (2)
+
+    address: int
 
     def __post_init__(self) -> None:
         """Initialize Read FIFO Queue PDU.

--- a/tests/pdu/test_fifo.py
+++ b/tests/pdu/test_fifo.py
@@ -16,6 +16,11 @@ class TestReadFifoQueuePDU:
         assert pdu.address == 0x04DE
         assert pdu.function_code == 0x18
 
+    def test_function_code_not_a_field(self) -> None:
+        """Test that function_code cannot be overridden per instance."""
+        with pytest.raises(TypeError):
+            ReadFifoQueuePDU(address=0x04DE, function_code=0x99)  # type: ignore[call-arg]
+
     @pytest.mark.parametrize(
         ("address", "expected_error"),
         [


### PR DESCRIPTION
# Proposed Changes

This addresses a low-severity finding from a pre-1.0.0 review sweep. It is filed as its own small PR so it can be judged on its own merits, and I completely understand if you prefer to close it.

`ReadFifoQueuePDU.function_code` was declared as a dataclass field with a default value. That made it part of the generated `__init__`, so a caller could pass `ReadFifoQueuePDU(address=0x04DE, function_code=0x99)` and silently produce a PDU that encodes the wrong function code. Every other PDU in the library declares `function_code` as a plain class attribute (see for example `ReadDeviceIdentificationPDU` in `pdu/device.py`, which is also a frozen dataclass).

This PR moves the declaration to a plain class attribute, matching the convention used everywhere else. Passing `function_code=...` to the constructor now raises `TypeError`, the class attribute still equals `FunctionCode.READ_FIFO_QUEUE` (0x18), and encode/decode behavior is unchanged. A test covering the rejected keyword argument is included.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
