### PR TITLE
fix(pdu): validate values consistently in encode_response

### DIFF
--- a/src/tmodbus/pdu/coils.py
+++ b/src/tmodbus/pdu/coils.py
@@ -126,7 +126,14 @@ class ReadCoilsPDU(BasePDU[list[bool]]):
         Returns:
             Bytes representation of the Read Coils Response PDU
 
+        Raises:
+            ValueError: If the number of values does not match the requested quantity
+
         """
+        if len(value) != self.quantity:
+            msg = f"Invalid number of coil values: expected {self.quantity}, got {len(value)}"
+            raise ValueError(msg)
+
         byte_count = (len(value) + 7) // 8
         data = bytearray(byte_count)
         for i, v in enumerate(value):
@@ -384,7 +391,14 @@ class WriteMultipleCoilsPDU(BasePDU[int]):
         Returns:
             Bytes representation of the Write Multiple Coils response PDU.
 
+        Raises:
+            ValueError: If the number of coils is out of range
+
         """
+        if not (1 <= value <= 0x07B0):
+            msg = "Number of coils must be between 1 and 1968."
+            raise ValueError(msg)
+
         return struct.pack(
             ">BHH",
             self.function_code,

--- a/src/tmodbus/pdu/device.py
+++ b/src/tmodbus/pdu/device.py
@@ -132,7 +132,30 @@ class ReadDeviceIdentificationPDU(BaseSubFunctionPDU[ReadDeviceIdentificationRes
         Returns:
             Bytes representation of the response PDU
 
+        Raises:
+            ValueError: If a field is out of range or the object count does not match
+
         """
+        if not (0x00 <= value.next_object_id <= 0xFF):
+            msg = "Next object ID must be between 0x00 and 0xFF."
+            raise ValueError(msg)
+
+        if value.number_of_objects != len(value.objects):
+            msg = f"Expected {value.number_of_objects} objects, got {len(value.objects)}"
+            raise ValueError(msg)
+
+        if not (0x00 <= value.number_of_objects <= 0xFF):
+            msg = "Number of objects must be between 0 and 255."
+            raise ValueError(msg)
+
+        for obj_id, obj_bytes in value.objects.items():
+            if not (0x00 <= obj_id <= 0xFF):
+                msg = "Object ID must be between 0x00 and 0xFF."
+                raise ValueError(msg)
+            if len(obj_bytes) > 0xFF:
+                msg = f"Object {obj_id:#04x} value length {len(obj_bytes)} exceeds the maximum of 255."
+                raise ValueError(msg)
+
         header = struct.pack(
             ">BBBBBBB",
             self.function_code,

--- a/src/tmodbus/pdu/file.py
+++ b/src/tmodbus/pdu/file.py
@@ -97,13 +97,30 @@ class ReadFileRecordPDU(BasePDU[list[bytes]]):
         Returns:
             Encoded bytes of the PDU.
 
+        Raises:
+            ValueError: If the number of records, a record length, or the byte count is invalid.
+
         """
+        if len(file_records) != len(self.requests):
+            msg = f"Invalid number of file records: expected {len(self.requests)}, got {len(file_records)}"
+            raise ValueError(msg)
+
         records_bytes = b""
         for record in file_records:
+            if len(record) % 2 != 0:
+                msg = "Record data length cannot be odd; each register is 2 bytes."
+                raise ValueError(msg)
             record_length = len(record) + 1
             records_bytes += struct.pack(">BB", record_length, FILE_RECORD_REFERENCE_TYPE) + record
 
         byte_count = len(records_bytes)
+        if byte_count > MAX_READ_FILE_RECORD_BYTE_COUNT:
+            msg = (
+                f"Read File Record response byte count {byte_count} exceeds the "
+                f"maximum of {MAX_READ_FILE_RECORD_BYTE_COUNT}."
+            )
+            raise ValueError(msg)
+
         return struct.pack(">BB", self.function_code, byte_count) + records_bytes
 
     def decode_response(self, response: bytes) -> list[bytes]:
@@ -295,6 +312,12 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
         records_bytes = b""
         for record in file_records:
             record_data = record.data
+            if not (0 <= record.file_number <= 0xFFFF):
+                msg = "File number must be between 0 and 65535."
+                raise ValueError(msg)
+            if not (0 <= record.record_number <= 9999):
+                msg = "Record number must be between 0 and 9999."
+                raise ValueError(msg)
             if len(record_data) % 2 != 0:
                 msg = "Record data length cannot be odd; each register is 2 bytes."
                 raise ValueError(msg)
@@ -308,6 +331,12 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
             records_bytes += record_data
 
         byte_count = len(records_bytes)
+        if byte_count > MAX_WRITE_FILE_RECORD_BYTE_COUNT:
+            msg = (
+                f"Write File Record byte count {byte_count} exceeds the maximum of {MAX_WRITE_FILE_RECORD_BYTE_COUNT}."
+            )
+            raise ValueError(msg)
+
         return struct.pack(">BB", cls.function_code, byte_count) + records_bytes
 
     @classmethod

--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -117,7 +117,14 @@ class RawReadHoldingRegistersPDU(BasePDU[bytes]):
         Returns:
             Bytes representation of the Read Holding Registers response PDU.
 
+        Raises:
+            ValueError: If the data length does not match the requested quantity
+
         """
+        if len(value) != self.quantity * 2:
+            msg = f"Invalid data length: expected {self.quantity * 2}, got {len(value)}"
+            raise ValueError(msg)
+
         return struct.pack(">BB", self.function_code, len(value)) + value
 
 
@@ -203,7 +210,19 @@ class ReadHoldingRegistersPDU(BasePDU[list[int]]):
         Returns:
             Bytes representation of the Read Holding Registers response PDU.
 
+        Raises:
+            ValueError: If the number of values does not match the requested quantity or a value is out of range
+
         """
+        if len(value) != self.quantity:
+            msg = f"Invalid number of read values: expected {self.quantity}, got {len(value)}"
+            raise ValueError(msg)
+
+        for idx, val in enumerate(value):
+            if not (0 <= val < 65536):
+                msg = f"Invalid read value {val} on index {idx}: must be between 0 and 65535"
+                raise ValueError(msg)
+
         data = struct.pack(f">{len(value)}H", *value)
         return struct.pack(">BB", self.function_code, len(data)) + data
 
@@ -335,7 +354,14 @@ class WriteSingleRegisterPDU(BasePDU[int]):
         Returns:
             Bytes representation of the Write Single Register response PDU (echo).
 
+        Raises:
+            ValueError: If value is out of range
+
         """
+        if not (0 <= value < 65536):
+            msg = "Value must be between 0 and 65535."
+            raise ValueError(msg)
+
         return struct.pack(">BHH", self.function_code, self.address, value)
 
 
@@ -473,7 +499,14 @@ class RawWriteMultipleRegistersPDU(BasePDU[int]):
         Returns:
             Bytes representation of the Write Multiple Registers response PDU.
 
+        Raises:
+            ValueError: If the number of registers is out of range
+
         """
+        if not (1 <= value <= 123):
+            msg = "Number of registers must be between 1 and 123."
+            raise ValueError(msg)
+
         return struct.pack(
             ">BHH",
             self.function_code,
@@ -704,7 +737,17 @@ class MaskWriteRegisterPDU(BasePDU[tuple[int, int]]):
         Returns:
             Bytes representation of the Mask Write Register response PDU.
 
+        Raises:
+            ValueError: If a mask is out of range
+
         """
+        if not (0 <= value[0] < 65536):
+            msg = "AND mask must be between 0 and 65535."
+            raise ValueError(msg)
+        if not (0 <= value[1] < 65536):
+            msg = "OR mask must be between 0 and 65535."
+            raise ValueError(msg)
+
         return struct.pack(">BHHH", self.function_code, self.address, value[0], value[1])
 
 

--- a/src/tmodbus/pdu/serial_line.py
+++ b/src/tmodbus/pdu/serial_line.py
@@ -124,7 +124,13 @@ class ReportServerIdPDU(BasePDU[ServerIdResponse]):
         Returns:
             Encoded bytes of the response PDU.
 
+        Raises:
+            ValueError: If the byte count is out of range.
+
         """
         byte_count = len(value.server_id) + 1 + len(value.additional_data)  # +1 for run indicator status
+        if byte_count > 0xFF:
+            msg = f"Server ID response byte count {byte_count} exceeds the maximum of 255."
+            raise ValueError(msg)
         run_indicator_status = ID_ON if value.run_indicator_status else ID_OFF
         return bytes([self.function_code, byte_count, *value.server_id, run_indicator_status, *value.additional_data])

--- a/tests/pdu/test_coils.py
+++ b/tests/pdu/test_coils.py
@@ -137,6 +137,18 @@ class TestReadCoilsPDU:
         # Expected: function code + byte count (2) + data (0xFF 0x03 = 0b11111111 0b00000011)
         assert response == b"\x01\x02\xff\x03"
 
+    def test_encode_response_boundary_quantity(self) -> None:
+        """Test encoding response with the maximum quantity of coils."""
+        pdu = ReadCoilsPDU(start_address=0, quantity=2000)
+        response = pdu.encode_response([True] * 2000)
+        assert response == b"\x01\xfa" + b"\xff" * 250
+
+    def test_encode_response_wrong_count(self) -> None:
+        """Test encode_response raises on wrong number of values."""
+        pdu = ReadCoilsPDU(start_address=0, quantity=5)
+        with pytest.raises(ValueError, match=r"Invalid number of coil values: expected 5, got 4"):
+            pdu.encode_response([True, False, True, False])
+
 
 class TestWriteSingleCoilPDU:
     """Test class for WriteSingleCoilPDU decode_request and encode_response methods."""
@@ -363,3 +375,15 @@ class TestWriteMultipleCoilsPDU:
         pdu = WriteMultipleCoilsPDU(start_address=100, values=[True] * 10)
         response = pdu.encode_response(10)
         assert response == struct.pack(">BHH", 0x0F, 100, 10)
+
+    def test_encode_response_boundary_quantity(self) -> None:
+        """Test encoding response with the maximum number of coils."""
+        pdu = WriteMultipleCoilsPDU(start_address=100, values=[True] * 1968)
+        response = pdu.encode_response(1968)
+        assert response == struct.pack(">BHH", 0x0F, 100, 1968)
+
+    def test_encode_response_invalid_quantity(self) -> None:
+        """Test encode_response raises on out-of-range number of coils."""
+        pdu = WriteMultipleCoilsPDU(start_address=100, values=[True] * 10)
+        with pytest.raises(ValueError, match=r"Number of coils must be between 1 and 1968\."):
+            pdu.encode_response(1969)

--- a/tests/pdu/test_device.py
+++ b/tests/pdu/test_device.py
@@ -552,6 +552,34 @@ class TestReadDeviceIdentificationPDUServer:
         with pytest.raises(ValueError, match="Next object ID must be between 0x00 and 0xFF"):
             pdu.encode_response(response)
 
+    def test_encode_response_too_many_objects(self) -> None:
+        """Test encode_response raises when the object count exceeds 255."""
+        pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)
+        response = ReadDeviceIdentificationResponse(
+            device_id_code=0x01,
+            conformity_level=ConformityLevel.BASIC,
+            more=False,
+            next_object_id=0x00,
+            number_of_objects=256,
+            objects=dict.fromkeys(range(256), b"x"),
+        )
+        with pytest.raises(ValueError, match="Number of objects must be between 0 and 255"):
+            pdu.encode_response(response)
+
+    def test_encode_response_invalid_object_id(self) -> None:
+        """Test encode_response raises on an out-of-range object ID."""
+        pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)
+        response = ReadDeviceIdentificationResponse(
+            device_id_code=0x01,
+            conformity_level=ConformityLevel.BASIC,
+            more=False,
+            next_object_id=0x00,
+            number_of_objects=1,
+            objects={0x100: b"Vendor"},
+        )
+        with pytest.raises(ValueError, match="Object ID must be between 0x00 and 0xFF"):
+            pdu.encode_response(response)
+
     def test_encode_response_object_value_too_long(self) -> None:
         """Test encode_response raises when an object value exceeds 255 bytes."""
         pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)

--- a/tests/pdu/test_device.py
+++ b/tests/pdu/test_device.py
@@ -509,3 +509,59 @@ class TestReadDeviceIdentificationPDUServer:
         expected += b"\x01\x07" + b"Product"
 
         assert encoded == expected
+
+    def test_encode_response_boundary_values(self) -> None:
+        """Test encoding a response with boundary field values."""
+        pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)
+        response = ReadDeviceIdentificationResponse(
+            device_id_code=0x01,
+            conformity_level=ConformityLevel.BASIC,
+            more=False,
+            next_object_id=0xFF,
+            number_of_objects=1,
+            objects={0xFF: b"\x00" * 255},
+        )
+        encoded = pdu.encode_response(response)
+        assert encoded == b"\x2b\x0e\x01\x01\x00\xff\x01" + b"\xff\xff" + b"\x00" * 255
+
+    def test_encode_response_object_count_mismatch(self) -> None:
+        """Test encode_response raises when number_of_objects does not match the objects."""
+        pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)
+        response = ReadDeviceIdentificationResponse(
+            device_id_code=0x01,
+            conformity_level=ConformityLevel.BASIC,
+            more=False,
+            next_object_id=0x00,
+            number_of_objects=3,
+            objects={0x00: b"Vendor", 0x01: b"Product"},
+        )
+        with pytest.raises(ValueError, match="Expected 3 objects, got 2"):
+            pdu.encode_response(response)
+
+    def test_encode_response_invalid_next_object_id(self) -> None:
+        """Test encode_response raises on out-of-range next object ID."""
+        pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)
+        response = ReadDeviceIdentificationResponse(
+            device_id_code=0x01,
+            conformity_level=ConformityLevel.BASIC,
+            more=False,
+            next_object_id=0x100,
+            number_of_objects=1,
+            objects={0x00: b"Vendor"},
+        )
+        with pytest.raises(ValueError, match="Next object ID must be between 0x00 and 0xFF"):
+            pdu.encode_response(response)
+
+    def test_encode_response_object_value_too_long(self) -> None:
+        """Test encode_response raises when an object value exceeds 255 bytes."""
+        pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)
+        response = ReadDeviceIdentificationResponse(
+            device_id_code=0x01,
+            conformity_level=ConformityLevel.BASIC,
+            more=False,
+            next_object_id=0x00,
+            number_of_objects=1,
+            objects={0x00: b"\x00" * 256},
+        )
+        with pytest.raises(ValueError, match="Object 0x00 value length 256 exceeds the maximum of 255"):
+            pdu.encode_response(response)

--- a/tests/pdu/test_file.py
+++ b/tests/pdu/test_file.py
@@ -268,6 +268,40 @@ class TestReadFileRecordPDU:
         # \x14 + \x06 + \x02 + \x06 + \x0d\xfe\x00\x20
         assert encoded == b"\x14\x06\x05\x06\x0d\xfe\x00\x20"
 
+    def test_encode_response_boundary_byte_count(self) -> None:
+        """Test encode_response accepts a record at the maximum byte count."""
+        requests = [FileRecordRequest(file_number=4, record_number=1, record_length=121)]
+        pdu = ReadFileRecordPDU(requests)
+
+        record = b"\x00" * 242  # byte count = 2 + 242 = 244, below the 245 maximum
+        encoded = pdu.encode_response([record])
+        assert encoded == b"\x14\xf4\xf3\x06" + record
+
+    def test_encode_response_wrong_count(self) -> None:
+        """Test encode_response raises on wrong number of records."""
+        requests = [FileRecordRequest(file_number=4, record_number=1, record_length=2)]
+        pdu = ReadFileRecordPDU(requests)
+
+        with pytest.raises(ValueError, match="Invalid number of file records: expected 1, got 2"):
+            pdu.encode_response([b"\x00\x01", b"\x02\x03"])
+
+    def test_encode_response_odd_length_record_rejected(self) -> None:
+        """Test encode_response raises on odd-length record data."""
+        requests = [FileRecordRequest(file_number=4, record_number=1, record_length=2)]
+        pdu = ReadFileRecordPDU(requests)
+
+        with pytest.raises(ValueError, match="Record data length cannot be odd"):
+            pdu.encode_response([b"\x00\x01\x02"])
+
+    def test_encode_response_byte_count_too_high(self) -> None:
+        """Test encode_response raises when the byte count exceeds the maximum."""
+        requests = [FileRecordRequest(file_number=4, record_number=1, record_length=122)]
+        pdu = ReadFileRecordPDU(requests)
+
+        record = b"\x00" * 244  # byte count = 2 + 244 = 246, above the 245 maximum
+        with pytest.raises(ValueError, match="Read File Record response byte count 246 exceeds the maximum of 245"):
+            pdu.encode_response([record])
+
     def test_decode_request_valid_single_request(self) -> None:
         """Test decode_request with a valid single request."""
         # Function code + byte count + reference type + file + record + length
@@ -619,6 +653,46 @@ class TestWriteFileRecordPDU:
         odd_records = [FileRecord(file_number=1, record_number=0, data=b"\x00\x01\x02")]
         with pytest.raises(ValueError, match="Record data length cannot be odd"):
             pdu.encode_response(odd_records)
+
+    def test_encode_response_boundary_numbers(self) -> None:
+        """Test encode_response accepts boundary file and record numbers."""
+        records = [FileRecord(file_number=4, record_number=7, data=b"\x06\xaf\x04\xbe")]
+        pdu = WriteFileRecordPDU(file_records=records)
+
+        boundary_records = [FileRecord(file_number=0xFFFF, record_number=9999, data=b"\x06\xaf")]
+        encoded = pdu.encode_response(boundary_records)
+        assert encoded == b"\x15\x09\x06\xff\xff\x27\x0f\x00\x01\x06\xaf"
+
+    def test_encode_response_invalid_file_number(self) -> None:
+        """Test encode_response raises on out-of-range file number."""
+        records = [FileRecord(file_number=4, record_number=7, data=b"\x06\xaf\x04\xbe")]
+        pdu = WriteFileRecordPDU(file_records=records)
+
+        bad_records = [FileRecord(file_number=0x10000, record_number=7, data=b"\x06\xaf")]
+        with pytest.raises(ValueError, match="File number must be between 0 and 65535"):
+            pdu.encode_response(bad_records)
+
+    def test_encode_response_invalid_record_number(self) -> None:
+        """Test encode_response raises on out-of-range record number."""
+        records = [FileRecord(file_number=4, record_number=7, data=b"\x06\xaf\x04\xbe")]
+        pdu = WriteFileRecordPDU(file_records=records)
+
+        bad_records = [FileRecord(file_number=4, record_number=10000, data=b"\x06\xaf")]
+        with pytest.raises(ValueError, match="Record number must be between 0 and 9999"):
+            pdu.encode_response(bad_records)
+
+    def test_encode_response_byte_count_too_high(self) -> None:
+        """Test encode_response raises when the byte count exceeds the maximum."""
+        records = [FileRecord(file_number=4, record_number=7, data=b"\x06\xaf\x04\xbe")]
+        pdu = WriteFileRecordPDU(file_records=records)
+
+        # Two records of 7-byte header + 120 bytes each: byte count = 254, above the 251 maximum
+        big_records = [
+            FileRecord(file_number=4, record_number=7, data=b"\x00" * 120),
+            FileRecord(file_number=4, record_number=8, data=b"\x00" * 120),
+        ]
+        with pytest.raises(ValueError, match="Write File Record byte count 254 exceeds the maximum of 251"):
+            pdu.encode_response(big_records)
 
     def test_decode_request_valid(self) -> None:
         """Test decode_request with valid request data."""

--- a/tests/pdu/test_holding_registers.py
+++ b/tests/pdu/test_holding_registers.py
@@ -211,6 +211,18 @@ class TestRawReadHoldingRegistersPDU:
         encoded = pdu.encode_response(value)
         assert encoded == b"\x03\x06\x12\x34\x56\x78\x9a\xbc"
 
+    def test_encode_response_boundary_quantity(self) -> None:
+        """Test encoding response with the maximum quantity of registers."""
+        pdu = RawReadHoldingRegistersPDU(start_address=100, quantity=125)
+        encoded = pdu.encode_response(b"\x00" * 250)
+        assert encoded == b"\x03\xfa" + b"\x00" * 250
+
+    def test_encode_response_wrong_length(self) -> None:
+        """Test encode_response raises on wrong data length."""
+        pdu = RawReadHoldingRegistersPDU(start_address=100, quantity=3)
+        with pytest.raises(ValueError, match=r"Invalid data length: expected 6, got 4"):
+            pdu.encode_response(b"\x12\x34\x56\x78")
+
 
 # ============================================================================
 # RawReadInputRegistersPDU Tests
@@ -291,6 +303,24 @@ class TestReadInputRegistersPDU:
         encoded = pdu.encode_response(values)
         assert encoded == b"\x04\x06\x12\x34\x56\x78\x9a\xbc"
 
+    def test_encode_response_boundary_values(self) -> None:
+        """Test encoding response with boundary register values."""
+        pdu = ReadInputRegistersPDU(start_address=100, quantity=2)
+        encoded = pdu.encode_response([0x0000, 0xFFFF])
+        assert encoded == b"\x04\x04\x00\x00\xff\xff"
+
+    def test_encode_response_wrong_count(self) -> None:
+        """Test encode_response raises on wrong number of values."""
+        pdu = ReadInputRegistersPDU(start_address=100, quantity=3)
+        with pytest.raises(ValueError, match=r"Invalid number of read values: expected 3, got 2"):
+            pdu.encode_response([0x1234, 0x5678])
+
+    def test_encode_response_invalid_value_too_high(self) -> None:
+        """Test encode_response raises on value too high."""
+        pdu = ReadInputRegistersPDU(start_address=100, quantity=2)
+        with pytest.raises(ValueError, match=r"Invalid read value 65536 on index 1: must be between 0 and 65535"):
+            pdu.encode_response([100, 65536])
+
 
 # ============================================================================
 # WriteSingleRegisterPDU Additional Tests
@@ -346,6 +376,18 @@ class TestWriteSingleRegisterPDU:
             InvalidRequestError, match="Expected request to start with function code, address, and value"
         ):
             WriteSingleRegisterPDU.decode_request(request)
+
+    def test_encode_response_boundary_value(self) -> None:
+        """Test encoding response with the maximum register value."""
+        pdu = WriteSingleRegisterPDU(address=0x1234, value=0x5678)
+        encoded = pdu.encode_response(0xFFFF)
+        assert encoded == b"\x06\x12\x34\xff\xff"
+
+    def test_encode_response_invalid_value(self) -> None:
+        """Test encode_response raises on out-of-range value."""
+        pdu = WriteSingleRegisterPDU(address=0x1234, value=0x5678)
+        with pytest.raises(ValueError, match=r"Value must be between 0 and 65535\."):
+            pdu.encode_response(65536)
 
     def test_encode_response(self) -> None:
         """Test encoding response."""
@@ -499,6 +541,18 @@ class TestRawWriteMultipleRegistersPDU:
         pdu = RawWriteMultipleRegistersPDU(start_address=0x1000, content=content)
         encoded = pdu.encode_response(2)
         assert encoded == b"\x10\x10\x00\x00\x02"
+
+    def test_encode_response_boundary_quantity(self) -> None:
+        """Test encoding response with the maximum number of registers."""
+        pdu = RawWriteMultipleRegistersPDU(start_address=0x1000, content=b"\x00" * 246)
+        encoded = pdu.encode_response(123)
+        assert encoded == b"\x10\x10\x00\x00\x7b"
+
+    def test_encode_response_invalid_quantity(self) -> None:
+        """Test encode_response raises on out-of-range number of registers."""
+        pdu = RawWriteMultipleRegistersPDU(start_address=0x1000, content=b"\x12\x34\x56\x78")
+        with pytest.raises(ValueError, match=r"Number of registers must be between 1 and 123\."):
+            pdu.encode_response(124)
 
     def test_rtu_response_data_length(self) -> None:
         """Test RTU response data length constant."""
@@ -795,6 +849,24 @@ class TestMaskWriteRegisterPDU:
         response = pdu.encode_response((0xF2F2, 0x2525))
         expected = b"\x16\x00\x04\xf2\xf2\x25\x25"
         assert response == expected
+
+    def test_encode_response_boundary_masks(self) -> None:
+        """Test encoding response with boundary mask values."""
+        pdu = MaskWriteRegisterPDU(address=0x0004, and_mask=0xF2F2, or_mask=0x2525)
+        response = pdu.encode_response((0xFFFF, 0x0000))
+        assert response == b"\x16\x00\x04\xff\xff\x00\x00"
+
+    def test_encode_response_invalid_and_mask(self) -> None:
+        """Test encode_response raises on out-of-range AND mask."""
+        pdu = MaskWriteRegisterPDU(address=0x0004, and_mask=0xF2F2, or_mask=0x2525)
+        with pytest.raises(ValueError, match=r"AND mask must be between 0 and 65535\."):
+            pdu.encode_response((0x10000, 0x2525))
+
+    def test_encode_response_invalid_or_mask(self) -> None:
+        """Test encode_response raises on out-of-range OR mask."""
+        pdu = MaskWriteRegisterPDU(address=0x0004, and_mask=0xF2F2, or_mask=0x2525)
+        with pytest.raises(ValueError, match=r"OR mask must be between 0 and 65535\."):
+            pdu.encode_response((0xF2F2, -1))
 
 
 class TestReadWriteMultipleRegistersPDU:

--- a/tests/pdu/test_serial_line.py
+++ b/tests/pdu/test_serial_line.py
@@ -132,3 +132,20 @@ def test_encode_response() -> None:
     encoded = pdu.encode_response(value)
     expected = make_response(pdu.function_code, b"", ID_OFF, b"")
     assert encoded == expected
+
+
+def test_encode_response_boundary_byte_count() -> None:
+    """Test encode_response accepts the maximum byte count of 255."""
+    pdu = ReportServerIdPDU()
+    value = ServerIdResponse(server_id=b"\x01" * 254, run_indicator_status=True, additional_data=b"")
+    encoded = pdu.encode_response(value)
+    assert encoded[1] == 255
+    assert len(encoded) == 257
+
+
+def test_encode_response_byte_count_too_high() -> None:
+    """Test encode_response raises when the byte count exceeds 255."""
+    pdu = ReportServerIdPDU()
+    value = ServerIdResponse(server_id=b"\x01" * 255, run_indicator_status=True, additional_data=b"")
+    with pytest.raises(ValueError, match="Server ID response byte count 256 exceeds the maximum of 255"):
+        pdu.encode_response(value)

--- a/tests/pdu/test_serial_line.py
+++ b/tests/pdu/test_serial_line.py
@@ -173,8 +173,8 @@ def test_encode_response_byte_count_too_high() -> None:
     value = ServerIdResponse(server_id=b"\x01" * 255, run_indicator_status=True, additional_data=b"")
     with pytest.raises(ValueError, match="Server ID response byte count 256 exceeds the maximum of 255"):
         pdu.encode_response(value)
-        
-        
+
+
 # --- Diagnostics Sub-Function PDU Tests ---
 def test_diagnostics_query_data_encode_decode() -> None:
     """Test DiagnosticsQueryDataPDU encoding and decoding."""


### PR DESCRIPTION
# Proposed Changes

This addresses a low-severity consistency finding from a pre-1.0.0 review sweep. It is filed as its own small PR so it can be judged on its own merits, and I completely understand if you prefer to close it.

The server-side `encode_response` implementations validated their input inconsistently. Some already raised `ValueError` for bad values (`ReadWriteMultipleRegistersPDU`, `ReadFifoQueuePDU`, `ReadExceptionStatusPDU`), while others passed unvalidated values straight to `struct.pack`. There, an out-of-range value surfaced as a raw `struct.error` (for example `WriteSingleRegisterPDU.encode_response(65536)`), and a mismatched length was silently encoded into a frame the client side would reject (for example `ReadCoilsPDU.encode_response` with a list shorter than the requested quantity).

This PR aligns all `encode_response` implementations to the validating style. Out-of-range register values, masks, quantities, and byte counts now raise `ValueError`, and read responses check that the number of values matches the requested quantity. The messages reuse the wording of the existing validating code paths. Covered PDUs: `ReadCoilsPDU` (and `ReadDiscreteInputsPDU`), `WriteMultipleCoilsPDU`, `RawReadHoldingRegistersPDU`, `ReadHoldingRegistersPDU` (and `ReadInputRegistersPDU`), `WriteSingleRegisterPDU`, `RawWriteMultipleRegistersPDU` (and `WriteMultipleRegistersPDU`), `MaskWriteRegisterPDU`, `ReadFileRecordPDU`, `WriteFileRecordPDU`, `ReportServerIdPDU`, and `ReadDeviceIdentificationPDU`. `WriteSingleCoilPDU` needs no check because a `bool` cannot be out of range.

Wire output for valid inputs is unchanged; the full existing test suite passes without modification. Each newly validating method gets a boundary-accepted test and rejected-case tests that mirror the existing `ValueError` test patterns.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
