### PR TITLE
fix(server): make batch handler registration atomic

### DIFF
--- a/src/tmodbus/server/handler.py
+++ b/src/tmodbus/server/handler.py
@@ -212,23 +212,19 @@ class ModbusRequestRouter(ModbusHandler):
             # Ensure pdu_class has function_code (since it should be a BasePDU subclass)
             func_code = pdu_class.function_code
 
-            def add_handler(uid: int | None) -> None:
-                if uid not in self._handlers:
-                    self._handlers[uid] = {}
+            unit_ids: list[int | None] = [unit_id] if unit_id is None or isinstance(unit_id, int) else list(unit_id)
 
-                if func_code in self._handlers[uid]:
+            # Validate the whole batch before mutating, so a failing call
+            # leaves the router unchanged.
+            seen: set[int | None] = set()
+            for uid in unit_ids:
+                if uid in seen or func_code in self._handlers.get(uid, {}):
                     msg = f"Handler for function code {func_code} and unit ID {uid} already registered"
                     raise ValueError(msg)
+                seen.add(uid)
 
-                self._handlers[uid][func_code] = handler
-
-            if unit_id is None:
-                add_handler(None)
-            elif isinstance(unit_id, int):
-                add_handler(unit_id)
-            else:
-                for uid in unit_id:
-                    add_handler(uid)
+            for uid in unit_ids:
+                self._handlers.setdefault(uid, {})[func_code] = handler
             return handler
 
         return decorator

--- a/tests/server/test_handler.py
+++ b/tests/server/test_handler.py
@@ -64,6 +64,46 @@ async def test_router_registration_and_dispatch() -> None:
         await router(1, unregistered_req)
 
 
+async def test_router_registration_batch_is_atomic() -> None:
+    """Test that a failing register() call leaves the router unchanged."""
+    router = ModbusRequestRouter()
+    req = ReadHoldingRegistersPDU(start_address=10, quantity=1)
+
+    # Batch with an internal duplicate: nothing is registered
+    with pytest.raises(ValueError, match="already registered"):
+
+        @router.register(ReadHoldingRegistersPDU, unit_id=[1, 2, 1])
+        async def handle_dup(_unit_id: int, _request: ReadHoldingRegistersPDU) -> list[int]:
+            return [-1]
+
+    for unit in (1, 2):
+        with pytest.raises(IllegalFunctionError):
+            await router(unit, req)
+
+    # Batch conflicting with an existing registration: pre-existing state intact
+    @router.register(ReadHoldingRegistersPDU, unit_id=2)
+    async def handle_unit_2(_unit_id: int, _request: ReadHoldingRegistersPDU) -> list[int]:
+        return [2]
+
+    with pytest.raises(ValueError, match="already registered"):
+
+        @router.register(ReadHoldingRegistersPDU, unit_id=[1, 2])
+        async def handle_conflict(_unit_id: int, _request: ReadHoldingRegistersPDU) -> list[int]:
+            return [-1]
+
+    assert await router(2, req) == [2]
+    with pytest.raises(IllegalFunctionError):
+        await router(1, req)
+
+    # A valid batch still registers all unit IDs
+    @router.register(ReadHoldingRegistersPDU, unit_id=[3, 4])
+    async def handle_units_3_4(unit_id: int, _request: ReadHoldingRegistersPDU) -> list[int]:
+        return [unit_id]
+
+    assert await router(3, req) == [3]
+    assert await router(4, req) == [4]
+
+
 async def test_handle_modbus_request_success() -> None:
     """Test handle_modbus_request encodes successful responses."""
     router = ModbusRequestRouter()


### PR DESCRIPTION
# Proposed Changes

This addresses a low-severity finding from a pre-1.0.0 review sweep. It is filed as its own small PR so it can be judged on its own merits, and I completely understand if you prefer to close it.

`ModbusRequestRouter.register(...)` with an iterable of unit ids mutated the router while iterating. A call like `register(pdu_class, unit_id=[1, 2, 1])` raised on the duplicate only after units 1 and 2 were already registered, leaving the router in a half-registered state. The same applied when a later id in the batch conflicted with an existing registration.

The decorator now materializes the unit-id iterable, validates the whole batch up front (duplicates within the input and conflicts with already-registered entries), and only then mutates. A failing `register()` call leaves the router exactly as it was. The error message is unchanged.

Tests cover the three cases: a batch with an internal duplicate raises and registers nothing, a batch conflicting with an existing registration raises and keeps the pre-existing state intact, and a valid batch still registers all unit ids.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
