### PR TITLE
build: ship docs/source in the sdist so the doc tests can run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 only-packages = true
 
 [tool.hatch.build.targets.sdist]
-only-include = ["examples", "src", "tests"]
+only-include = ["docs/source", "examples", "src", "tests"]
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
# Proposed Changes

This addresses a low-severity finding from a pre-1.0.0 review sweep. It is filed as its own small PR so it can be judged on its own merits — I completely understand if you prefer to close it.

`[tool.pytest.ini_options] testpaths` lists `["tests", "docs/source"]` (the docs are collected as Sybil doctests), but the sdist `only-include` shipped only `examples`, `src`, and `tests`. When you run `pytest` from an unpacked sdist, pytest silently skips the missing `docs/source` entry: collection succeeds with exit 0, but only 1347 tests are collected instead of 1356 — the 9 doc tests are dropped without any warning. So the failure mode is quieter than a hard error, which makes it easy to miss.

The fix adds `docs/source` to the sdist `only-include`. I deliberately did not add all of `docs`: `docs/specifications` holds about 1.8 MB of third-party Modbus specification PDFs with their own EULA, which should not be redistributed in the sdist. With only `docs/source` included, the sdist grows from 167,830 to 176,893 bytes (about 9 KB), and `pytest --collect-only` from an unpacked sdist now collects all 1356 tests. Verified empirically with `uv build --sdist` and a fresh unpack.

The alternative would be to drop `docs/source` from `testpaths` instead. I chose against that because the doc examples are real tests worth running by default, and shipping doc sources in an sdist is conventional anyway.

One related observation, not changed in this PR: the CI tests workflow runs `pytest --cov tmodbus tests`, so the doc tests that `testpaths` includes locally are not exercised in that CI job. Worth knowing when deciding how much weight to give this fix.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
