### PR TITLE
test(ascii): remove timing race in delayed-exception-response test

### DIFF
--- a/tests/transport/test_async_ascii.py
+++ b/tests/transport/test_async_ascii.py
@@ -1323,28 +1323,30 @@ async def test_delayed_exception_response_during_active_request_same_unit(
     assert protocol._timed_out_requests[unit_id] is pdu1
 
     # Step 2: Request 2 (FC 0x06) is sent and active
+    # The tight timeout was only needed to make request 1 time out; request 2
+    # must not race the wall clock, so give it a generous timeout.
+    protocol.timeout = 10.0
+
     # Late exception response for Request 1 (FC 0x83, exception code 0x02)
     delayed_exc_frame_1 = build_ascii_frame(unit_id, b"\x83\x02")
     real_frame_2 = build_ascii_frame(unit_id, b"\x06\x00\x01\x11\x22")
 
-    async def deliver_delayed_exc_then_real() -> None:
-        await asyncio.sleep(0.01)
-        # Deliver late exception response for request 1
-        protocol.data_received(delayed_exc_frame_1)
-        # Active request should still be pending and not failed
-        assert protocol._pending_request is not None
-        assert not protocol._pending_request.future.done()
-        assert unit_id not in protocol._timed_out_requests
-
-        # Deliver real response for request 2
-        await asyncio.sleep(0.01)
-        protocol.data_received(real_frame_2)
-
     req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
-    deliv_task = asyncio.create_task(deliver_delayed_exc_then_real())
+    while protocol._pending_request is None:
+        assert not req2_task.done()
+        await asyncio.sleep(0)
+
+    # Deliver late exception response for request 1
+    protocol.data_received(delayed_exc_frame_1)
+    # Active request should still be pending and not failed
+    assert protocol._pending_request is not None
+    assert not protocol._pending_request.future.done()
+    assert unit_id not in protocol._timed_out_requests
+
+    # Deliver real response for request 2
+    protocol.data_received(real_frame_2)
 
     result = await req2_task
-    await deliv_task
 
     assert result == ("decoded", b"\x06\x00\x01\x11\x22")
     assert len(protocol._buffer) == 0


### PR DESCRIPTION
# Proposed Changes

This addresses a low-severity finding from a pre-1.0.0 review sweep. It is filed as its own small PR so it can be judged on its own merits, and I completely understand if you prefer to close it.

`tests/transport/test_async_ascii.py::test_delayed_exception_response_during_active_request_same_unit` failed once during a full-suite run on a loaded machine, then passed standalone and in consecutive full runs. The test contained a wall-clock race: request 2 runs under the same tight `wait_for(timeout=0.05)` that step 1 uses to force request 1 to time out, while a separate deliver task races that deadline with two real `asyncio.sleep(0.01)` calls. If the event loop stalls for roughly 40 ms at the wrong moment, the timeout callback cancels request 2's future before the deliver task wakes up, and the test fails with `TimeoutError: Response timeout after 0.05 seconds` (plus an `AssertionError` from the deliver task, whose `future.done()` check then trips).

What I could and could not reproduce: 500 iterations of the test coroutine under 64 busy-loop CPU hogs never failed on my machine, so I could not trigger it with plain CPU load. Injecting a single synchronous 50 ms event-loop stall at the vulnerable moment (`loop.call_later(0.055, time.sleep, 0.05)`, which is exactly what a heavily loaded scheduler produces naturally) reproduced the reported failure in 2 of 3 runs, with the exact `TimeoutError` and `AssertionError` signature. So the mechanism is confirmed even though the natural trigger needs a harsher scheduler than I could simulate.

The fix removes the race rather than widening the window: the tight 0.05 s timeout is kept only for step 1, where it is the point of the test. Before request 2 is sent, `protocol.timeout` is raised to 10.0 (the generous value the robust tests in this file already use), so request 2 no longer races the wall clock. The deliver task and its sleeps are gone: the test now waits for `protocol._pending_request` to be set (yielding via `asyncio.sleep(0)`, guarded so an early task failure cannot hang the loop) and then delivers both frames synchronously via `data_received`. Since `data_received` is a plain synchronous callback, no timer can fire between delivery and the assertions, and the injected-stall reproduction passes at every offset I swept (0.045 through 0.070). The transport itself is not at fault, so it is unchanged.

Deliberately not done here: three sibling tests (`test_delayed_response_during_active_request_same_unit`, `test_active_request_succeeds_and_clears_stale_timed_out_request`, `test_corrupt_delayed_frame_during_active_request_keeps_tracking`) share the same tight-timeout-plus-sleeps construction and could get the same treatment, but only the flagged test has actually been seen to flake, so this PR stays limited to it.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
