### PR TITLE
fix(pdu): frame Return Query Data by its fixed length, not the receive buffer

### DIFF
--- a/src/tmodbus/pdu/serial_line.py
+++ b/src/tmodbus/pdu/serial_line.py
@@ -42,12 +42,16 @@ class DiagnosticsQueryDataPDU(BaseDiagnosticsSubFunctionPDU[bytes]):
     """Diagnostics sub-function 0x0000: Return Query Data."""
 
     sub_function_code = DiagnosticSubFunction.RETURN_QUERY_DATA
+    # Length-based RTU framing only works for the spec-standard 2-byte data field.
+    rtu_request_data_length = 4
+    rtu_response_data_length = 4
 
     def __init__(self, data: bytes = b"\x00\x00") -> None:
         """Initialize DiagnosticsQueryDataPDU.
 
         Args:
             data: Data bytes to loop back (must be an even number of bytes).
+                Payloads longer than 2 bytes cannot be framed over RTU.
 
         """
         if len(data) % 2 != 0:
@@ -58,20 +62,6 @@ class DiagnosticsQueryDataPDU(BaseDiagnosticsSubFunctionPDU[bytes]):
     def encode_request(self) -> bytes:
         """Encode request PDU."""
         return struct.pack(">BH", self.function_code, self.sub_function_code) + self.data
-
-    @classmethod
-    def get_expected_response_data_length(cls, data: bytes) -> int | None:
-        """Get expected response data length."""
-        if len(data) >= 2:
-            return len(data)
-        return 4
-
-    @classmethod
-    def get_expected_request_data_length(cls, data: bytes) -> int:
-        """Get expected request data length."""
-        if len(data) >= 2:
-            return len(data)
-        return 4
 
     @classmethod
     def decode_request(cls, request: bytes) -> Self:

--- a/src/tmodbus/pdu/serial_line.py
+++ b/src/tmodbus/pdu/serial_line.py
@@ -42,8 +42,7 @@ class DiagnosticsQueryDataPDU(BaseDiagnosticsSubFunctionPDU[bytes]):
     """Diagnostics sub-function 0x0000: Return Query Data."""
 
     sub_function_code = DiagnosticSubFunction.RETURN_QUERY_DATA
-    # Length-based RTU framing only works for the spec-standard 2-byte data field.
-    rtu_request_data_length = 4
+    rtu_request_data_length = 4  # sub-function (2) + query data (2)
     rtu_response_data_length = 4
 
     def __init__(self, data: bytes = b"\x00\x00") -> None:

--- a/tests/pdu/test_serial_line.py
+++ b/tests/pdu/test_serial_line.py
@@ -230,11 +230,14 @@ def test_diagnostics_force_listen_only_mode() -> None:
 
 def test_all_diagnostic_classes_full_coverage() -> None:
     """Test encode_request, decode_request, encode_response, decode_response for all diagnostic classes."""
-    # Query data short length tests
-    assert DiagnosticsQueryDataPDU.get_expected_response_data_length(b"\x00") == 4
-    assert DiagnosticsQueryDataPDU.get_expected_request_data_length(b"\x00") == 4
+    # Fixed at sub-function (2) + query data (2), however much has been buffered.
+    assert DiagnosticsQueryDataPDU.get_expected_response_data_length(b"\x00") is None
+    assert DiagnosticsQueryDataPDU.get_expected_response_data_length(b"\x00\x00") == 4
+    assert DiagnosticsQueryDataPDU.get_expected_request_data_length(b"\x00\x00") == 4
     assert DiagnosticsQueryDataPDU.get_expected_response_data_length(b"\x00\x00\x12\x34") == 4
     assert DiagnosticsQueryDataPDU.get_expected_request_data_length(b"\x00\x00\x12\x34") == 4
+    assert DiagnosticsQueryDataPDU.get_expected_response_data_length(b"\x00\x00\xa5\x37\xda\x8d") == 4
+    assert DiagnosticsQueryDataPDU.get_expected_request_data_length(b"\x00\x00\xa5\x37\xda\x8d") == 4
 
     # Listen only mode response
     p_listen = DiagnosticsForceListenOnlyModePDU()

--- a/tests/server/test_async_rtu_over_tcp.py
+++ b/tests/server/test_async_rtu_over_tcp.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 from tmodbus.pdu import ReadHoldingRegistersPDU, WriteMultipleRegistersPDU
 from tmodbus.pdu.base import BaseClientPDU
+from tmodbus.pdu.serial_line import DiagnosticsQueryDataPDU
 from tmodbus.server import AsyncRtuOverTcpServer, ModbusRequestRouter
 from tmodbus.utils.crc import calculate_crc16, validate_crc16
 
@@ -37,6 +38,45 @@ def get_server_port(server: AsyncRtuOverTcpServer) -> int:
     addr = sockets[0].getsockname()
     assert isinstance(addr, tuple)
     return int(addr[1])
+
+
+async def test_rtu_over_tcp_server_diagnostics_query_data() -> None:
+    """Regression: a Return Query Data request must be framed, answered, and not wedge the link.
+
+    The expected length used to be derived from the receive buffer, which includes the
+    CRC, so the server waited for two bytes that never came and silently swallowed every
+    later request on the connection.
+    """
+    router = ModbusRequestRouter()
+
+    @router.register(DiagnosticsQueryDataPDU)
+    async def handle_query_data(_unit_id: int, request: DiagnosticsQueryDataPDU) -> bytes:
+        return request.data
+
+    server = AsyncRtuOverTcpServer(host="127.0.0.1", port=0, handler=router)
+    await server.start()
+    try:
+        port = get_server_port(server)
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            request = b"\x01\x08\x00\x00\xa5\x37"
+            writer.write(request + calculate_crc16(request))
+            await writer.drain()
+
+            resp = await asyncio.wait_for(reader.readexactly(8), timeout=5)
+            assert validate_crc16(resp)
+            assert resp == b"\x01\x08\x00\x00\xa5\x37" + calculate_crc16(b"\x01\x08\x00\x00\xa5\x37")
+
+            # The connection must still be usable afterwards.
+            writer.write(request + calculate_crc16(request))
+            await writer.drain()
+            assert await asyncio.wait_for(reader.readexactly(8), timeout=5) == resp
+        finally:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+    finally:
+        await server.stop()
 
 
 async def test_rtu_over_tcp_server_happy_path(rtu_over_tcp_server: AsyncRtuOverTcpServer) -> None:

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -19,6 +19,7 @@ from tmodbus.exceptions import (
     RTUFrameError,
 )
 from tmodbus.pdu.base import BaseClientPDU
+from tmodbus.pdu.serial_line import DiagnosticsQueryDataPDU
 from tmodbus.transport.async_rtu import (
     MAX_RTU_FRAME_SIZE,
     AsyncRtuTransport,
@@ -1116,6 +1117,20 @@ async def test_determine_expected_frame_length__subfunction_pdu(
 
     protocol._buffer.extend(bytes.fromhex("01 2B 0E 01 01 00 "))
     assert protocol._determine_expected_frame_length() is None
+
+
+async def test_determine_expected_frame_length__diagnostics_query_data(
+    mock_transport: MagicMock,
+) -> None:
+    """A complete Return Query Data response must frame at its real length, CRC included."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = DiagnosticsQueryDataPDU(b"\xa5\x37")
+
+    # A complete frame: unit and function code, then sub-function, query data and CRC.
+    protocol._buffer.extend(bytes.fromhex("01 08 00 00 A5 37 DA 8D"))
+    assert protocol._determine_expected_frame_length(pdu) == 8
 
 
 async def test_data_received_insufficient_data(
@@ -2243,5 +2258,6 @@ def test_rtu_protocol_fc08_partial_buffer(mock_transport: MagicMock) -> None:
     # Test buffer >= 7 bytes for FC08 Diagnostics frame parsing
     protocol._buffer = bytearray(b"\x01\x08\x00\x00\x00")
     assert protocol._determine_expected_frame_length() is None
+    # address(1) + fc(1) + sub-function(2) + query data(2) + crc(2)
     protocol._buffer = bytearray(b"\x01\x08\x00\x00\x00\x00\x00")
-    assert protocol._determine_expected_frame_length() == 9
+    assert protocol._determine_expected_frame_length() == 8


### PR DESCRIPTION
# Proposed Changes

FC08 sub-function 0x0000 (Return Query Data) cannot be framed over RTU, in either direction.

Both length hooks returned `len(data)`, but that argument is the remaining receive buffer including the CRC, not the PDU's data field. The caller adds address, function code and CRC back on top, so the target lands two bytes past the end of the frame and moves further out with every byte received:

```
full frame: 01 08 00 00 A5 37 DA 8D (8 bytes)
  buffer=8  data_arg=6  returns=6  ->  target=10   <-- complete frame, still waiting
```

The frame never closes. `get_expected_request_data_length` has the same body, so a server never dispatches the request either — and since the buffer is never consumed, one such request wedges the connection for good:

```
0x000B (before) -> 01 08 00 0B 04 D2 13 54
0x0000          -> NO RESPONSE
0x000B (after)  -> NO RESPONSE
```

TCP is unaffected (MBAP header). RTU-over-TCP shares `ModbusRtuProtocol`, so it is affected.

Return Query Data carries no length indicator, so it can only be framed at the spec-standard 2-byte data field — which `__init__` already defaults to, and which the tests already expected (`test_all_diagnostic_classes_full_coverage` asserted `== 4`; `len(data)` satisfied it only by coincidence). This drops both overrides for the fixed lengths the sibling diagnostics PDUs already declare:

```python
rtu_request_data_length = 4
rtu_response_data_length = 4
```

Deliberate limitation: payloads longer than 2 bytes still cannot be framed over RTU. They now fail CRC and resync rather than wedging, and still work over TCP. Framing them needs t3.5 silence-based receive framing, which the RTU server does not do — happy to look at that separately.

## Related Issues

None filed.
