### PR TITLE
fix(transport): reject RTU requests that cannot be framed by their declared length

### DIFF
--- a/src/tmodbus/pdu/base.py
+++ b/src/tmodbus/pdu/base.py
@@ -12,6 +12,7 @@ class BaseClientPDU[RT](ABC):
     """Base class that defines the functions needed to handle Modbus PDUs on the client-side."""
 
     function_code: int
+    rtu_request_data_length: int | None = None
     rtu_response_data_length: int | None = None
     expects_response: bool = True
 
@@ -68,8 +69,6 @@ class BaseClientPDU[RT](ABC):
 
 class BasePDU[RT](BaseClientPDU[RT]):
     """Base class that defines the functions needed to handle Modbus PDUs on both the client-side and server-side."""
-
-    rtu_request_data_length: int | None = None
 
     ### Server methods ###
 

--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -57,6 +57,7 @@ from tmodbus.const import BROADCAST_UNIT_ID, EXCEPTION_RESPONSE_BIT, FUNCTION_CO
 from tmodbus.exceptions import (
     CRCError,
     FunctionCodeError,
+    InvalidRequestError,
     ModbusConnectionError,
     RTUFrameError,
     UnknownModbusResponseError,
@@ -113,6 +114,27 @@ def compute_interframe_delay(one_char_send_duration: float) -> float:
     interframe_delay = 3.5 * one_char_send_duration
 
     return max(interframe_delay, 0.00175)  # Ensure at least 1.75 ms for faster baud rates
+
+
+def _validate_rtu_request_length(pdu: BaseClientPDU[Any], request_pdu_bytes: bytes) -> None:
+    """Reject a request that the receiving server will not be able to frame.
+
+    RTU framing is length-based, so a server determines where the request ends from
+    the PDU's declared length. A request that does not encode to that length would be
+    cut short and fail its CRC check, which surfaces as a timeout rather than as the
+    encoding mistake it is.
+    """
+    expected = pdu.rtu_request_data_length
+    if expected is None:
+        return
+
+    actual = len(request_pdu_bytes) - 1  # excluding the function code
+    if actual != expected:
+        msg = (
+            f"{type(pdu).__name__} encodes {actual} data bytes but declares "
+            f"{expected} for RTU framing, so this request cannot be framed over RTU."
+        )
+        raise InvalidRequestError(msg, request_bytes=request_pdu_bytes)
 
 
 def compute_max_continuous_transmission_delay(one_char_send_duration: float) -> float:
@@ -373,6 +395,7 @@ class ModbusRtuProtocol(asyncio.Protocol):
 
             # Build request frame
             request_pdu_bytes = pdu.encode_request()
+            _validate_rtu_request_length(pdu, request_pdu_bytes)
             frame_prefix = bytes([unit_id]) + request_pdu_bytes
             crc = calculate_crc16(frame_prefix)
             request_adu = frame_prefix + crc

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -14,6 +14,7 @@ from tmodbus.exceptions import (
     CRCError,
     FunctionCodeError,
     IllegalFunctionError,
+    InvalidRequestError,
     InvalidResponseError,
     ModbusConnectionError,
     RTUFrameError,
@@ -26,6 +27,7 @@ from tmodbus.transport.async_rtu import (
     ModbusRtuProtocol,
     _ModbusRtuMessage,
     _PendingRequest,
+    _validate_rtu_request_length,
     compute_interframe_delay,
     compute_max_continuous_transmission_delay,
 )
@@ -2261,3 +2263,51 @@ def test_rtu_protocol_fc08_partial_buffer(mock_transport: MagicMock) -> None:
     # address(1) + fc(1) + sub-function(2) + query data(2) + crc(2)
     protocol._buffer = bytearray(b"\x01\x08\x00\x00\x00\x00\x00")
     assert protocol._determine_expected_frame_length() == 8
+
+
+class _FixedLengthPDU(BaseClientPDU[bytes]):
+    """PDU declaring a fixed RTU request length, with a caller-controlled payload."""
+
+    function_code = 0x08
+    rtu_request_data_length = 4
+
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+
+    def encode_request(self) -> bytes:
+        return bytes([self.function_code]) + self.payload
+
+    def decode_response(self, response: bytes) -> bytes:
+        return response
+
+
+def test_validate_rtu_request_length__no_declared_length() -> None:
+    """A PDU without a fixed request length is left alone."""
+    pdu = _DummyPDU()
+    assert pdu.rtu_request_data_length is None
+    _validate_rtu_request_length(pdu, pdu.encode_request())
+
+
+def test_validate_rtu_request_length__matching() -> None:
+    """A request encoding to its declared length is accepted."""
+    pdu = _FixedLengthPDU(b"\x00\x00\xa5\x37")
+    _validate_rtu_request_length(pdu, pdu.encode_request())
+
+
+def test_validate_rtu_request_length__mismatch() -> None:
+    """A request that cannot be framed is rejected, naming both lengths."""
+    pdu = _FixedLengthPDU(b"\x00\x00\xa5\x37\x11\x22")
+    with pytest.raises(InvalidRequestError, match="encodes 6 data bytes but declares 4"):
+        _validate_rtu_request_length(pdu, pdu.encode_request())
+
+
+async def test_send_and_receive_rejects_unframable_request(mock_transport: MagicMock) -> None:
+    """An un-framable request is refused before anything reaches the wire."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+    mock_transport.write.reset_mock()
+
+    with pytest.raises(InvalidRequestError, match="cannot be framed over RTU"):
+        await protocol.send_and_receive(1, _FixedLengthPDU(b"\x00\x00\xa5\x37\x11\x22"))
+
+    mock_transport.write.assert_not_called()


### PR DESCRIPTION
# Proposed Changes

RTU framing is length-based: a server finds the end of a request from the PDU's declared `rtu_request_data_length`. If a PDU encodes to a different length, the server frames it short, the CRC check fails, and the client sees a response timeout — which points nowhere near the encoding mistake that caused it.

Nothing checked for that, even though the client knows both numbers before it writes a byte. This validates the encoded request against the declared length on the RTU send path and raises `InvalidRequestError` instead:

```
DiagnosticsQueryDataPDU encodes 6 data bytes but declares 4 for RTU framing,
so this request cannot be framed over RTU.
```

`rtu_request_data_length` moves from `BasePDU` up to `BaseClientPDU`. It describes the request frame the client puts on the wire, not a server-side behaviour, and the client transport needs to read it. Additive for client-only PDUs, which simply gain the `None` default.

Only the RTU path is affected — TCP frames from the MBAP header and ASCII is delimiter-framed, so neither can mis-frame this way. RTU-over-TCP shares `ModbusRtuProtocol` and is covered.

I checked every PDU that declares a fixed `rtu_request_data_length` (29 of them): all already encode to exactly that length, so nothing that works today starts raising.

The equivalent server-side check is not possible: a server only sees a frame that fails CRC and has no way to know a longer request was intended.

## Related Issues

Rebased onto main now that #125 has merged. It closes the sharp edge #125 documented rather than fixed — an over-long Return Query Data payload now fails immediately:

```
InvalidRequestError: DiagnosticsQueryDataPDU encodes 6 data bytes but declares 4
for RTU framing, so this request cannot be framed over RTU.
```

instead of mis-framing and surfacing as a response timeout.
