### PR TITLE
fix(pdu): return None from sub-function expected-length hooks on short data

### DIFF
--- a/src/tmodbus/pdu/base.py
+++ b/src/tmodbus/pdu/base.py
@@ -149,6 +149,8 @@ class BaseSubFunctionClientPDU[RT](BaseClientPDU[RT]):
             return cls.rtu_response_data_length
 
         # otherwise, we assume that the next byte contains the length of the remaining data
+        if len(data) <= cls.sub_function_code_length:
+            return None  # length byte not received yet
         return cls.sub_function_code_length + 1 + data[cls.sub_function_code_length]
 
 
@@ -158,19 +160,18 @@ class BaseSubFunctionPDU[RT](BaseSubFunctionClientPDU[RT], BasePDU[RT]):
     sub_function_code: int
 
     @classmethod
-    def get_expected_request_data_length(cls, data: bytes) -> int:
+    def get_expected_request_data_length(cls, data: bytes) -> int | None:
         """Get the expected number of bytes for the data part of the request PDU.
 
         This method should be implemented by subclasses to return the expected
         length of the request based on the specific PDU type.
 
         Returns:
-            Expected length of the request PDU in bytes
+            Expected length of the request PDU in bytes, or None if it cannot be determined yet.
 
         """
         if len(data) < cls.sub_function_code_length:
-            msg = "Request data too short to read sub-function code"
-            raise InvalidRequestError(msg, request_bytes=data)
+            return None  # sub-function code not received yet
         received_sub_func = int.from_bytes(data[: cls.sub_function_code_length], "big")
 
         if received_sub_func != cls.sub_function_code:
@@ -181,4 +182,7 @@ class BaseSubFunctionPDU[RT](BaseSubFunctionClientPDU[RT], BasePDU[RT]):
         if cls.rtu_request_data_length is not None:
             return cls.rtu_request_data_length
 
-        return 1 + data[0]
+        # otherwise, we assume that the next byte contains the length of the remaining data
+        if len(data) <= cls.sub_function_code_length:
+            return None  # length byte not received yet
+        return cls.sub_function_code_length + 1 + data[cls.sub_function_code_length]

--- a/tests/pdu/test_base.py
+++ b/tests/pdu/test_base.py
@@ -364,8 +364,8 @@ class TestBaseSubFunctionPDU:
         # Should return the fixed length when sub-function code matches
         assert TestPDU.get_expected_request_data_length(b"\x0e\x00") == 15
 
-    def test_get_expected_request_data_length_from_first_byte(self) -> None:
-        """Test get_expected_request_data_length when length is in first byte."""
+    def test_get_expected_request_data_length_from_byte_count(self) -> None:
+        """Test the length is read from the byte count following the sub-function code."""
 
         class TestPDU(BaseSubFunctionPDU[int]):
             function_code = 0x2B
@@ -384,9 +384,12 @@ class TestBaseSubFunctionPDU:
             def encode_response(self, _value: int) -> bytes:
                 return b""
 
-        # First byte is sub-function code (0x0E = 14)
-        # Expected: 1 (length byte) + 14 = 15
-        assert TestPDU.get_expected_request_data_length(b"\x0e") == 15
+        # Only the sub-function code has arrived, so the byte count is still unknown.
+        assert TestPDU.get_expected_request_data_length(b"\x0e") is None
+        assert TestPDU.get_expected_response_data_length(b"\x0e") is None
+        # Sub-function code (1) + byte count (1) + 4 bytes of data
+        assert TestPDU.get_expected_request_data_length(b"\x0e\x04") == 6
+        assert TestPDU.get_expected_response_data_length(b"\x0e\x04") == 6
         # First byte is different value
         with pytest.raises(InvalidRequestError):
             TestPDU.get_expected_request_data_length(b"\x0d")
@@ -419,7 +422,6 @@ class TestBaseSubFunctionPDU:
         assert TestLargeSubFuncPDU.get_expected_request_data_length(data) == 8
         assert TestLargeSubFuncPDU.get_expected_response_data_length(data) == 8
 
-        # Short data
+        # Short data: neither side can determine a length yet
         assert TestLargeSubFuncPDU.get_expected_response_data_length(b"\x12\x34") is None
-        with pytest.raises(InvalidRequestError):
-            TestLargeSubFuncPDU.get_expected_request_data_length(b"\x12\x34")
+        assert TestLargeSubFuncPDU.get_expected_request_data_length(b"\x12\x34") is None


### PR DESCRIPTION
# Proposed Changes

#100 made the expected-length defaults return `None` when the length byte has not arrived yet, instead of indexing past the buffer. It fixed `BaseClientPDU` and `BasePDU` but not the two sub-function overrides, which have the same flaw one line deeper — they index at `sub_function_code_length` rather than `0`.

**Response side** raises `IndexError` once exactly the sub-function code is buffered:

```
1 byte(s) buffered -> None
2 byte(s) buffered -> IndexError: index out of range
3 byte(s) buffered -> 7
```

**Request side** raises `InvalidRequestError` before the sub-function code is even complete. Both are ordinary partial-buffer states while a frame is still arriving, so both now return `None` and let the framer wait for more data. That also makes the request side consistent with the response side, which already returned `None` there — an asymmetry the existing test had captured:

```python
# Short data
assert TestLargeSubFuncPDU.get_expected_response_data_length(b"\x12\x34") is None
with pytest.raises(InvalidRequestError):
    TestLargeSubFuncPDU.get_expected_request_data_length(b"\x12\x34")
```

`get_expected_request_data_length` returns `int | None` accordingly, matching what #100 did to `BasePDU`.

## A second bug in the same method

The request side read the byte count from `data[0]`, which is the *first byte of the sub-function code*, not the byte count that follows it. The response side reads it at `data[sub_function_code_length]`. For the same input the two disagreed:

```
request  side: 1
response side: 7
```

`1 + data[0]` treats a sub-function code byte as a length. Happy to split this into its own PR if you would rather keep the two apart.

## Reachability

Neither path is reachable through the shipped PDUs: every sub-function PDU declares a fixed `rtu_request_data_length` / `rtu_response_data_length` and returns before either branch, and the RTU framers only call these once enough bytes are buffered to resolve the PDU class. So this is a latent fix that matters for custom sub-function PDUs.

One existing test asserted the old request-side behaviour with a comment that shows the bug plainly — `# First byte is sub-function code (0x0E = 14)` / `# Expected: 1 (length byte) + 14 = 15`. It now checks that the length comes from the byte count, and is renamed to match.

## Related Issues

Completes #100.
