### PR TITLE
Expand integration tests

### DIFF
--- a/integration_tests/fieldtalk/test_diagslave.py
+++ b/integration_tests/fieldtalk/test_diagslave.py
@@ -121,6 +121,38 @@ async def run_client_assertions(client: AsyncModbusClient) -> None:
     res = await client.read_input_registers(20, 3)
     assert res == [100, 200, 300]
 
+    # 5. Diagnostics: Return Query Data (FC 0x08, sub 0x0000)
+    query_echo = await client.diag_read_query_data(b"\x12\x34")
+    assert query_echo == b"\x12\x34"
+
+    # 6. Read Device Identification (FC 0x2B/0x0E)
+    device_id = await client.read_device_identification(1, 0)
+    assert device_id[0] == b"proconX Pty Ltd"
+    assert device_id[1] == b"FT-MBSV"
+    assert device_id[2] == b"2.9.1.0"
+
+    # 8. Typed / Struct Register Read/Write Mixin Helpers
+    await client.write_int16(50, -1234)
+    assert await client.read_int16(50) == -1234
+
+    await client.write_uint16(51, 65000)
+    assert await client.read_uint16(51) == 65000
+
+    await client.write_int32(52, -12345678)
+    assert await client.read_int32(52) == -12345678
+
+    await client.write_uint32(54, 3000000000)
+    assert await client.read_uint32(54) == 3000000000
+
+    await client.write_float(56, 3.141592)
+    assert pytest.approx(await client.read_float(56), rel=1e-5) == 3.141592
+
+    await client.write_double(58, 2.718281828459045)
+    assert pytest.approx(await client.read_double(58), rel=1e-9) == 2.718281828459045
+
+    await client.write_string(62, "HelloModbus", number_of_registers=6)
+    assert (await client.read_string(62, number_of_registers=6)).rstrip("\x00") == "HelloModbus"
+
 
 @pytest.mark.usefixtures("log_traffic")
 async def test_diagslave_tcp() -> None:
@@ -131,6 +163,7 @@ async def test_diagslave_tcp() -> None:
         client = AsyncModbusClient(transport=transport, unit_id=1)
         await client.connect()
         await run_client_assertions(client)
+        assert await client.read_exception_status() == 0x55
         await client.disconnect()
 
 
@@ -143,6 +176,7 @@ async def test_diagslave_udp() -> None:
         client = AsyncModbusClient(transport=transport, unit_id=1)
         await client.connect()
         await run_client_assertions(client)
+        assert await client.read_exception_status() == 0x55
         await client.disconnect()
 
 
@@ -193,4 +227,5 @@ async def test_diagslave_ascii_serial() -> None:
             client = AsyncModbusClient(transport=transport, unit_id=1)
             await client.connect()
             await run_client_assertions(client)
+            assert await client.read_exception_status() == 0x55
             await client.disconnect()

--- a/integration_tests/helpers.py
+++ b/integration_tests/helpers.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import Generator
 from pathlib import Path
 
-from tmodbus.server import AsyncRtuOverTcpServer, AsyncTcpServer
+from tmodbus.server import AsyncRtuOverTcpServer, AsyncTcpServer, AsyncUdpServer
 
 
 @contextlib.contextmanager
@@ -49,8 +49,12 @@ def make_virtual_serial_ports(server_path: Path, client_path: Path) -> Generator
                 path.unlink()
 
 
-def get_server_port(server: AsyncTcpServer | AsyncRtuOverTcpServer) -> int:
-    """Get the dynamically allocated port from an active TCP server."""
+def get_server_port(server: AsyncTcpServer | AsyncRtuOverTcpServer | AsyncUdpServer) -> int:
+    """Get the dynamically allocated port from an active server."""
+    if isinstance(server, AsyncUdpServer):
+        assert server._transport is not None
+        sockname = server._transport.get_extra_info("sockname")
+        return int(sockname[1])
     assert server._server is not None
     sockets = server._server.sockets
     assert sockets is not None

--- a/integration_tests/integration_test_server.py
+++ b/integration_tests/integration_test_server.py
@@ -1,14 +1,42 @@
 """Shared server implementation and device simulation for integration tests."""
 
+from typing import Any
+
 from tmodbus.pdu import (
+    BaseDiagnosticsSubFunctionPDU,
+    CommEventCounterResponse,
+    CommEventLogResponse,
+    DiagnosticsBusCharacterOverrunCountPDU,
+    DiagnosticsBusCommunicationErrorCountPDU,
+    DiagnosticsBusExceptionErrorCountPDU,
+    DiagnosticsBusMessageCountPDU,
+    DiagnosticsChangeAsciiInputDelimiterPDU,
+    DiagnosticsClearCountersAndRegisterPDU,
+    DiagnosticsClearOverrunCounterAndFlagPDU,
+    DiagnosticsDiagnosticRegisterPDU,
+    DiagnosticsQueryDataPDU,
+    DiagnosticsRestartCommunicationsOptionPDU,
+    DiagnosticsServerBusyCountPDU,
+    DiagnosticsServerMessageCountPDU,
+    DiagnosticsServerNakCountPDU,
+    DiagnosticsServerNoResponseCountPDU,
+    FileRecord,
+    GetCommEventCounterPDU,
+    GetCommEventLogPDU,
     MaskWriteRegisterPDU,
     ReadCoilsPDU,
     ReadDeviceIdentificationPDU,
     ReadDeviceIdentificationResponse,
     ReadDiscreteInputsPDU,
+    ReadExceptionStatusPDU,
+    ReadFifoQueuePDU,
+    ReadFileRecordPDU,
     ReadHoldingRegistersPDU,
     ReadInputRegistersPDU,
     ReadWriteMultipleRegistersPDU,
+    ReportServerIdPDU,
+    ServerIdResponse,
+    WriteFileRecordPDU,
     WriteMultipleCoilsPDU,
     WriteMultipleRegistersPDU,
     WriteSingleCoilPDU,
@@ -44,8 +72,48 @@ class ModbusDevice:
         self.input_registers[0] = 1234
         self.input_registers[1] = 5678
 
+        # Exception Status (FC 0x07)
+        self.exception_status = 0x55
 
-def setup_router(device: ModbusDevice) -> ModbusRequestRouter:  # noqa: C901
+        # Comm Events (FC 0x0B, FC 0x0C)
+        self.comm_status = 0x0000
+        self.comm_event_count = 42
+        self.comm_message_count = 100
+        self.comm_events = b"\x01\x02\x03\x04"
+
+        # Server ID (FC 0x11)
+        self.server_id = b"TMB-DEV"
+        self.run_indicator_status = True
+        self.additional_data = b"V1.0"
+
+        # File Records (FC 0x14, FC 0x15)
+        # Map: file_number -> {record_number: bytes}
+        self.files: dict[int, dict[int, bytes]] = {
+            4: {
+                0: b"\x12\x34\x56\x78",
+                1: b"\xaa\xbb\xcc\xdd",
+            }
+        }
+
+        # FIFO Queue (FC 0x18)
+        self.fifo_queues: dict[int, list[int]] = {
+            0: [100, 200, 300, 400],
+        }
+
+        # Diagnostics (FC 0x08)
+        self.diagnostic_register = 0x1234
+        self.ascii_input_delimiter = 0x0A
+        self.bus_message_count = 10
+        self.bus_comm_error_count = 0
+        self.bus_exception_error_count = 0
+        self.server_message_count = 10
+        self.server_no_response_count = 0
+        self.server_nak_count = 0
+        self.server_busy_count = 0
+        self.bus_character_overrun_count = 0
+
+
+def setup_router(device: ModbusDevice) -> ModbusRequestRouter:  # noqa: C901, PLR0915
     """Register all PDU handlers on a ModbusRequestRouter.
 
     To verify integration compatibility, a client should perform the following:
@@ -74,6 +142,24 @@ def setup_router(device: ModbusDevice) -> ModbusRequestRouter:  # noqa: C901
     4. Input Registers (FC 0x04)
        - Read 2 input registers starting at address 0.
        - Assert that the returned array is [1234, 5678].
+
+    5. Exception Status (FC 0x07)
+       - Read exception status byte.
+
+    6. Comm Events (FC 0x0B, FC 0x0C)
+       - Read comm event counter and comm event log.
+
+    7. Server ID (FC 0x11)
+       - Report Server ID response.
+
+    8. File Records (FC 0x14, FC 0x15)
+       - Read and write file records.
+
+    9. FIFO Queue (FC 0x18)
+       - Read FIFO queue registers.
+
+    10. Diagnostics (FC 0x08)
+        - Diagnostics loopback query data and counters.
     """
     router = ModbusRequestRouter()
 
@@ -134,6 +220,104 @@ def setup_router(device: ModbusDevice) -> ModbusRequestRouter:  # noqa: C901
         # Then read
         read_start = request.read_start_address
         return device.holding_registers[read_start : read_start + request.read_quantity]
+
+    @router.register(ReadExceptionStatusPDU)
+    async def handle_read_exception_status(_unit_id: int, _request: ReadExceptionStatusPDU) -> int:
+        return device.exception_status
+
+    @router.register(GetCommEventCounterPDU)
+    async def handle_get_comm_event_counter(
+        _unit_id: int, _request: GetCommEventCounterPDU
+    ) -> CommEventCounterResponse:
+        return CommEventCounterResponse(status=device.comm_status, event_count=device.comm_event_count)
+
+    @router.register(GetCommEventLogPDU)
+    async def handle_get_comm_event_log(_unit_id: int, _request: GetCommEventLogPDU) -> CommEventLogResponse:
+        return CommEventLogResponse(
+            status=device.comm_status,
+            event_count=device.comm_event_count,
+            message_count=device.comm_message_count,
+            events=device.comm_events,
+        )
+
+    @router.register(ReportServerIdPDU)
+    async def handle_report_server_id(_unit_id: int, _request: ReportServerIdPDU) -> ServerIdResponse:
+        return ServerIdResponse(
+            server_id=device.server_id,
+            run_indicator_status=device.run_indicator_status,
+            additional_data=device.additional_data,
+        )
+
+    @router.register(ReadFileRecordPDU)
+    async def handle_read_file_record(_unit_id: int, request: ReadFileRecordPDU) -> list[bytes]:
+        results: list[bytes] = []
+        for req in request.requests:
+            file_data = device.files.get(req.file_number, {})
+            record_data = file_data.get(req.record_number, b"\x00" * (req.record_length * 2))
+            results.append(record_data[: req.record_length * 2])
+        return results
+
+    @router.register(WriteFileRecordPDU)
+    async def handle_write_file_record(_unit_id: int, request: WriteFileRecordPDU) -> list[FileRecord]:
+        echo_records: list[FileRecord] = []
+        for rec in request.file_records:
+            if rec.file_number not in device.files:
+                device.files[rec.file_number] = {}
+            device.files[rec.file_number][rec.record_number] = rec.data
+            echo_records.append(rec)
+        return echo_records
+
+    @router.register(ReadFifoQueuePDU)
+    async def handle_read_fifo_queue(_unit_id: int, request: ReadFifoQueuePDU) -> list[int]:
+        return device.fifo_queues.get(request.address, [])
+
+    @router.register(DiagnosticsQueryDataPDU)
+    async def handle_diagnostics(  # noqa: C901, PLR0911, PLR0912
+        _unit_id: int, request: BaseDiagnosticsSubFunctionPDU[Any]
+    ) -> Any:
+        if isinstance(request, DiagnosticsQueryDataPDU):
+            return request.data
+        if isinstance(request, DiagnosticsRestartCommunicationsOptionPDU):
+            if request.clear_event_log:
+                device.comm_events = b""
+                device.comm_event_count = 0
+            return request.clear_event_log
+        if isinstance(request, DiagnosticsDiagnosticRegisterPDU):
+            return device.diagnostic_register
+        if isinstance(request, DiagnosticsChangeAsciiInputDelimiterPDU):
+            device.ascii_input_delimiter = request.delimiter
+            return request.delimiter
+        if isinstance(request, DiagnosticsClearCountersAndRegisterPDU):
+            device.diagnostic_register = 0
+            device.bus_message_count = 0
+            device.bus_comm_error_count = 0
+            device.bus_exception_error_count = 0
+            device.server_message_count = 0
+            device.server_no_response_count = 0
+            device.server_nak_count = 0
+            device.server_busy_count = 0
+            device.bus_character_overrun_count = 0
+            return None
+        if isinstance(request, DiagnosticsBusMessageCountPDU):
+            return device.bus_message_count
+        if isinstance(request, DiagnosticsBusCommunicationErrorCountPDU):
+            return device.bus_comm_error_count
+        if isinstance(request, DiagnosticsBusExceptionErrorCountPDU):
+            return device.bus_exception_error_count
+        if isinstance(request, DiagnosticsServerMessageCountPDU):
+            return device.server_message_count
+        if isinstance(request, DiagnosticsServerNoResponseCountPDU):
+            return device.server_no_response_count
+        if isinstance(request, DiagnosticsServerNakCountPDU):
+            return device.server_nak_count
+        if isinstance(request, DiagnosticsServerBusyCountPDU):
+            return device.server_busy_count
+        if isinstance(request, DiagnosticsBusCharacterOverrunCountPDU):
+            return device.bus_character_overrun_count
+        if isinstance(request, DiagnosticsClearOverrunCounterAndFlagPDU):
+            device.bus_character_overrun_count = 0
+            return None
+        return None
 
     @router.register(ReadDeviceIdentificationPDU)
     async def handle_read_device_identification(

--- a/integration_tests/rmodbus/test_rmodbus_client.py
+++ b/integration_tests/rmodbus/test_rmodbus_client.py
@@ -84,6 +84,13 @@ async def test_client(transport: AsyncBaseTransport) -> None:
     await client.connect()
     # Perform read/write operations using the client
 
+    # Coils
+    await client.write_single_coil(0, value=True)
+    assert await client.read_coils(0, 1) == [True]
+    await client.write_multiple_coils(5, [True, False, True, True])
+
+    assert await client.read_coils(5, 4) == [True, False, True, True]
+
     # First write to some registers
     await client.write_multiple_registers(0, [10, 20, 30, 40])
 
@@ -99,6 +106,25 @@ async def test_client(transport: AsyncBaseTransport) -> None:
     # Read the input registers
     ir0_1 = await client.read_input_registers(0, 2)
     assert ir0_1 == [1234, 5678]
+
+    # Struct / Typed helpers
+    await client.write_int16(50, -1234)
+    assert await client.read_int16(50) == -1234
+
+    await client.write_uint16(51, 65000)
+    assert await client.read_uint16(51) == 65000
+
+    await client.write_int32(52, -12345678)
+    assert await client.read_int32(52) == -12345678
+
+    await client.write_uint32(54, 3000000000)
+    assert await client.read_uint32(54) == 3000000000
+
+    await client.write_float(56, 3.141592)
+    assert pytest.approx(await client.read_float(56), rel=1e-5) == 3.141592
+
+    await client.write_string(62, "HelloRModbus", number_of_registers=6)
+    assert (await client.read_string(62, number_of_registers=6)).rstrip("\x00") == "HelloRModbus"
 
     await client.disconnect()
 

--- a/integration_tests/simonvetter/test_simonvetter_client.py
+++ b/integration_tests/simonvetter/test_simonvetter_client.py
@@ -1,12 +1,14 @@
 """Integration tests for tmodbus against the simonvetter/modbus client and server."""
 
 import asyncio
+import sys
 from pathlib import Path
 
 import pytest
 from tmodbus.client import AsyncModbusClient
 from tmodbus.transport import AsyncTcpTransport
 
+sys.path.append(str(Path(__file__).parent.parent))
 from helpers import find_free_port
 
 server_bin_path = Path(__file__).parent / "server"
@@ -57,6 +59,28 @@ async def test_tcp_client() -> None:
         # 4. Input Registers
         res = await client.read_input_registers(0, 2)
         assert res == [1234, 5678]
+
+        # 5. Struct / Typed helpers
+        await client.write_int16(50, -1234)
+        assert await client.read_int16(50) == -1234
+
+        await client.write_uint16(51, 65000)
+        assert await client.read_uint16(51) == 65000
+
+        await client.write_int32(52, -12345678)
+        assert await client.read_int32(52) == -12345678
+
+        await client.write_uint32(54, 3000000000)
+        assert await client.read_uint32(54) == 3000000000
+
+        await client.write_float(56, 3.141592)
+        assert pytest.approx(await client.read_float(56), rel=1e-5) == 3.141592
+
+        await client.write_double(58, 2.718281828459045)
+        assert pytest.approx(await client.read_double(58), rel=1e-9) == 2.718281828459045
+
+        await client.write_string(62, "SimonVetter", number_of_registers=6)
+        assert (await client.read_string(62, number_of_registers=6)).rstrip("\x00") == "SimonVetter"
 
         await client.disconnect()
     finally:

--- a/integration_tests/test_tmodbus_end_to_end.py
+++ b/integration_tests/test_tmodbus_end_to_end.py
@@ -1,0 +1,470 @@
+"""End-to-end integration tests covering all PDUs, transports, and features in tmodbus."""
+
+from __future__ import annotations
+
+import datetime
+import ipaddress
+import ssl
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from tmodbus.client import AsyncModbusClient
+from tmodbus.pdu import FileRecord, FileRecordRequest
+from tmodbus.server import (
+    AsyncAsciiServer,
+    AsyncRtuOverTcpServer,
+    AsyncRtuServer,
+    AsyncTcpServer,
+    AsyncUdpServer,
+)
+from tmodbus.server.security import MODBUS_ROLE_OID
+from tmodbus.transport import (
+    AsyncAsciiTransport,
+    AsyncRtuOverTcpTransport,
+    AsyncRtuTransport,
+    AsyncSmartTransport,
+    AsyncTcpTransport,
+    AsyncUdpTransport,
+)
+
+from helpers import get_server_port, make_virtual_serial_ports
+from integration_test_server import ModbusDevice, setup_router
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture
+def virtual_serial_ports() -> Generator[tuple[Path, Path], None, None]:
+    """Create a pair of virtual serial ports for RTU/ASCII integration testing."""
+    server_socket_path = Path(__file__).parent / "e2e-server-socket"
+    client_socket_path = Path(__file__).parent / "e2e-client-socket"
+    with make_virtual_serial_ports(server_socket_path, client_socket_path) as ports:
+        yield ports
+
+
+async def run_full_pdu_test_suite(client: AsyncModbusClient) -> None:  # noqa: PLR0915
+    """Execute assertions for every PDU and feature supported by tmodbus."""
+    # 1. Coils (FC 0x01, FC 0x05, FC 0x0F)
+    await client.write_single_coil(0, value=True)
+    assert await client.read_coils(0, 1) == [True]
+    await client.write_single_coil(0, value=False)
+    assert await client.read_coils(0, 1) == [False]
+
+    await client.write_multiple_coils(5, [True, False, True, True, False])
+    assert await client.read_coils(5, 5) == [True, False, True, True, False]
+
+    # 2. Discrete Inputs (FC 0x02)
+    assert await client.read_discrete_inputs(0, 4) == [True, False, True, False]
+
+    # 3. Holding Registers (FC 0x03, FC 0x06, FC 0x10)
+    await client.write_single_register(10, 42)
+    assert await client.read_holding_registers(10, 1) == [42]
+
+    await client.write_multiple_registers(20, [100, 200, 300, 400])
+    assert await client.read_holding_registers(20, 4) == [100, 200, 300, 400]
+
+    # 4. Mask Write Register (FC 0x16)
+    await client.write_single_register(30, 0x1234)
+    and_mask, or_mask = await client.mask_write_register(30, and_mask=0x00FF, or_mask=0x5600)
+    assert (and_mask, or_mask) == (0x00FF, 0x5600)
+    assert await client.read_holding_registers(30, 1) == [0x5634]
+
+    # 5. Read/Write Multiple Registers (FC 0x17)
+    res = await client.read_write_multiple_registers(
+        read_start_address=40,
+        read_quantity=2,
+        write_start_address=40,
+        write_values=[888, 999],
+    )
+    assert res == [888, 999]
+    assert await client.read_holding_registers(40, 2) == [888, 999]
+
+    # 6. Input Registers (FC 0x04)
+    assert await client.read_input_registers(0, 2) == [1234, 5678]
+
+    # 7. Read Exception Status (FC 0x07)
+    assert await client.read_exception_status() == 0x55
+
+    # 8. Comm Events (FC 0x0B, FC 0x0C)
+    counter_resp = await client.get_comm_event_counter()
+    assert counter_resp.event_count == 42
+    assert counter_resp.status == 0x0000
+
+    log_resp = await client.get_comm_event_log()
+    assert log_resp.event_count == 42
+    assert log_resp.message_count == 100
+    assert log_resp.events == b"\x01\x02\x03\x04"
+
+    # 9. Server ID (FC 0x11)
+    srv_id = await client.read_server_id()
+    assert srv_id.server_id == b"TMB-DEV"
+    assert srv_id.run_indicator_status is True
+    assert srv_id.additional_data == b"V1.0"
+
+    # 10. File Records (FC 0x14, FC 0x15)
+    # Read file records
+    read_recs = await client.read_file_records(
+        [
+            FileRecordRequest(file_number=4, record_number=0, record_length=2),
+            FileRecordRequest(file_number=4, record_number=1, record_length=2),
+        ]
+    )
+    assert read_recs == [b"\x12\x34\x56\x78", b"\xaa\xbb\xcc\xdd"]
+
+    read_single = await client.read_file_record(file_number=4, record_number=0, record_length=2)
+    assert read_single == b"\x12\x34\x56\x78"
+
+    # Write file records
+    written = await client.write_file_records(
+        [
+            FileRecord(file_number=4, record_number=2, data=b"\x11\x22\x33\x44"),
+        ]
+    )
+    assert written == [FileRecord(file_number=4, record_number=2, data=b"\x11\x22\x33\x44")]
+    assert await client.read_file_record(file_number=4, record_number=2, record_length=2) == b"\x11\x22\x33\x44"
+
+    written_single = await client.write_file_record(file_number=4, record_number=3, data=b"\x55\x66\x77\x88")
+    assert written_single == FileRecord(file_number=4, record_number=3, data=b"\x55\x66\x77\x88")
+    assert await client.read_file_record(file_number=4, record_number=3, record_length=2) == b"\x55\x66\x77\x88"
+
+    # 11. Read FIFO Queue (FC 0x18)
+    fifo = await client.read_fifo_queue(0)
+    assert fifo == [100, 200, 300, 400]
+
+    # 12. Read Device Identification (FC 0x2B/0x0E)
+    dev_id = await client.read_device_identification(1, 0)
+    assert dev_id[0] == b"wlcrs"
+    assert dev_id[1] == b"TMB"
+    assert dev_id[2] == b"1.0"
+
+    # 13. Diagnostics Subfunctions (FC 0x08)
+    assert await client.diag_read_query_data(b"\xaa\x55") == b"\xaa\x55"
+    assert await client.diag_read_diagnostic_register() == 0x1234
+    assert await client.diag_read_bus_message_count() == 10
+    assert await client.diag_read_bus_communication_error_count() == 0
+    assert await client.diag_read_bus_exception_error_count() == 0
+    assert await client.diag_read_server_message_count() == 10
+    assert await client.diag_read_server_no_response_count() == 0
+    assert await client.diag_read_server_nak_count() == 0
+    assert await client.diag_read_server_busy_count() == 0
+    assert await client.diag_read_bus_character_overrun_count() == 0
+
+    assert await client.diag_restart_communications_option(clear_event_log=True) is True
+    assert (await client.get_comm_event_counter()).event_count == 0
+
+    assert await client.diag_change_ascii_input_delimiter(0x0D) == 0x0D
+
+    await client.diag_clear_counters_and_register()
+    assert await client.diag_read_diagnostic_register() == 0
+    assert await client.diag_read_bus_message_count() == 0
+
+    await client.diag_clear_overrun_counter_and_flag()
+    assert await client.diag_read_bus_character_overrun_count() == 0
+
+    # 14. Struct / Typed Register Helpers
+    await client.write_int16(50, -32000)
+    assert await client.read_int16(50) == -32000
+
+    await client.write_uint16(51, 65500)
+    assert await client.read_uint16(51) == 65500
+
+    await client.write_int32(52, -2000000000)
+    assert await client.read_int32(52) == -2000000000
+
+    await client.write_uint32(54, 4000000000)
+    assert await client.read_uint32(54) == 4000000000
+
+    await client.write_int64(56, -9000000000000000000)
+    assert await client.read_int64(56) == -9000000000000000000
+
+    await client.write_uint64(60, 18000000000000000000)
+    assert await client.read_uint64(60) == 18000000000000000000
+
+    await client.write_float(64, -123.456)
+    assert pytest.approx(await client.read_float(64), rel=1e-5) == -123.456
+
+    await client.write_double(66, 123456789.987654321)
+    assert pytest.approx(await client.read_double(66), rel=1e-9) == 123456789.987654321
+
+    await client.write_string(70, "TMODBUS-TEST", number_of_registers=6)
+    assert (await client.read_string(70, number_of_registers=6)).rstrip("\x00") == "TMODBUS-TEST"
+
+    # 15. Endianness Variants
+    client_be_le = AsyncModbusClient(
+        client.transport,
+        unit_id=client.unit_id,
+        word_order="big",
+        byte_order="little",
+    )
+    await client_be_le.write_uint32(80, 0x12345678)
+    assert await client_be_le.read_uint32(80) == 0x12345678
+    raw_regs = await client.read_holding_registers(80, 2)
+    assert raw_regs == [0x3412, 0x7856]
+
+    client_le_be = AsyncModbusClient(
+        client.transport,
+        unit_id=client.unit_id,
+        word_order="little",
+        byte_order="big",
+    )
+    await client_le_be.write_uint32(82, 0x12345678)
+    assert await client_le_be.read_uint32(82) == 0x12345678
+    raw_regs = await client.read_holding_registers(82, 2)
+    assert raw_regs == [0x5678, 0x1234]
+
+    client_le_le = AsyncModbusClient(
+        client.transport,
+        unit_id=client.unit_id,
+        word_order="little",
+        byte_order="little",
+    )
+    await client_le_le.write_uint32(84, 0x12345678)
+    assert await client_le_le.read_uint32(84) == 0x12345678
+    raw_regs = await client.read_holding_registers(84, 2)
+    assert raw_regs == [0x7856, 0x3412]
+
+    # 16. Unit ID switching via for_unit_id
+    client_u2 = client.for_unit_id(2)
+    assert client_u2.unit_id == 2
+    assert await client_u2.read_holding_registers(10, 1) == [42]
+
+
+@pytest.mark.asyncio
+async def test_tcp_server_and_client_e2e() -> None:
+    """Test AsyncTcpServer with AsyncTcpTransport."""
+    device = ModbusDevice()
+    router = setup_router(device)
+    server = AsyncTcpServer(host="127.0.0.1", port=0, handler=router)
+    await server.start()
+    port = get_server_port(server)
+
+    transport = AsyncTcpTransport("127.0.0.1", port)
+    client = AsyncModbusClient(transport=transport, unit_id=1)
+
+    async with client:
+        await run_full_pdu_test_suite(client)
+
+    await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_udp_server_and_client_e2e() -> None:
+    """Test AsyncUdpServer with AsyncUdpTransport."""
+    device = ModbusDevice()
+    router = setup_router(device)
+    server = AsyncUdpServer(host="127.0.0.1", port=0, handler=router)
+    await server.start()
+    port = get_server_port(server)
+
+    transport = AsyncUdpTransport("127.0.0.1", port)
+    client = AsyncModbusClient(transport=transport, unit_id=1)
+
+    async with client:
+        await run_full_pdu_test_suite(client)
+
+    await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_rtu_over_tcp_server_and_client_e2e() -> None:
+    """Test AsyncRtuOverTcpServer with AsyncRtuOverTcpTransport."""
+    device = ModbusDevice()
+    router = setup_router(device)
+    server = AsyncRtuOverTcpServer(host="127.0.0.1", port=0, handler=router)
+    await server.start()
+    port = get_server_port(server)
+
+    transport = AsyncRtuOverTcpTransport("127.0.0.1", port)
+    client = AsyncModbusClient(transport=transport, unit_id=1)
+
+    async with client:
+        await run_full_pdu_test_suite(client)
+
+    await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_rtu_serial_server_and_client_e2e(virtual_serial_ports: tuple[Path, Path]) -> None:
+    """Test AsyncRtuServer with AsyncRtuTransport over virtual serial link."""
+    server_port, client_port = virtual_serial_ports
+    device = ModbusDevice()
+    router = setup_router(device)
+
+    server = AsyncRtuServer(port=str(server_port), handler=router, baudrate=19200)
+    await server.start()
+
+    transport = AsyncRtuTransport(str(client_port), baudrate=19200, timeout=3.0)
+    client = AsyncModbusClient(transport=transport, unit_id=1)
+
+    async with client:
+        await run_full_pdu_test_suite(client)
+
+    await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_ascii_serial_server_and_client_e2e(virtual_serial_ports: tuple[Path, Path]) -> None:
+    """Test AsyncAsciiServer with AsyncAsciiTransport over virtual serial link."""
+    server_port, client_port = virtual_serial_ports
+    device = ModbusDevice()
+    router = setup_router(device)
+
+    server = AsyncAsciiServer(port=str(server_port), handler=router, baudrate=19200)
+    await server.start()
+
+    transport = AsyncAsciiTransport(str(client_port), baudrate=19200, timeout=3.0)
+    client = AsyncModbusClient(transport=transport, unit_id=1)
+
+    async with client:
+        await run_full_pdu_test_suite(client)
+
+    await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_smart_transport_e2e() -> None:
+    """Test AsyncSmartTransport wrapping AsyncTcpTransport."""
+    device = ModbusDevice()
+    router = setup_router(device)
+    server = AsyncTcpServer(host="127.0.0.1", port=0, handler=router)
+    await server.start()
+    port = get_server_port(server)
+
+    base_transport = AsyncTcpTransport("127.0.0.1", port)
+    smart_transport = AsyncSmartTransport(
+        base_transport,
+        wait_between_requests=0.001,
+        auto_reconnect=True,
+    )
+    client = AsyncModbusClient(transport=smart_transport, unit_id=1)
+
+    async with client:
+        await run_full_pdu_test_suite(client)
+
+    await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_tls_server_and_client_with_role_auth_e2e(tmp_path: Path) -> None:
+    """Test AsyncTcpServer with TLS, mutual authentication, and RequestContext client_role."""
+    now = datetime.datetime.now(datetime.UTC)
+    validity = datetime.timedelta(days=365)
+    modbus_oid = x509.ObjectIdentifier(MODBUS_ROLE_OID)
+
+    # Generate CA
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test CA")])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + validity)
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(ca_key.public_key()), critical=False)
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    # Generate Server Cert
+    srv_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    srv_cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")]))
+        .issuer_name(ca_cert.subject)
+        .public_key(srv_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + validity)
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(srv_key.public_key()), critical=False)
+        .add_extension(x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_key.public_key()), critical=False)
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [
+                    x509.DNSName("localhost"),
+                    x509.IPAddress(ipaddress.IPv4Address("127.0.0.1")),
+                ]
+            ),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    # Generate Client Cert with "operator" Role
+    cli_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    role_bytes = b"operator"
+    asn1_role = bytes([0x0C, len(role_bytes)]) + role_bytes
+    cli_cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Client")]))
+        .issuer_name(ca_cert.subject)
+        .public_key(cli_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + validity)
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(cli_key.public_key()), critical=False)
+        .add_extension(x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_key.public_key()), critical=False)
+        .add_extension(x509.UnrecognizedExtension(modbus_oid, asn1_role), critical=False)
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    # Write PEM files
+    ca_pem = tmp_path / "ca.crt"
+    ca_pem.write_bytes(ca_cert.public_bytes(serialization.Encoding.PEM))
+
+    srv_pem = tmp_path / "srv.crt"
+    srv_pem.write_bytes(srv_cert.public_bytes(serialization.Encoding.PEM))
+    srv_key_pem = tmp_path / "srv.key"
+    srv_key_pem.write_bytes(
+        srv_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+
+    cli_pem = tmp_path / "cli.crt"
+    cli_pem.write_bytes(cli_cert.public_bytes(serialization.Encoding.PEM))
+    cli_key_pem = tmp_path / "cli.key"
+    cli_key_pem.write_bytes(
+        cli_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+
+    # Setup SSL Contexts
+    server_ssl = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_ssl.load_cert_chain(srv_pem, srv_key_pem)
+    server_ssl.load_verify_locations(cafile=ca_pem)
+    server_ssl.verify_mode = ssl.CERT_REQUIRED
+
+    client_ssl = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    client_ssl.check_hostname = False
+    client_ssl.verify_mode = ssl.CERT_REQUIRED
+    client_ssl.load_cert_chain(cli_pem, cli_key_pem)
+    client_ssl.load_verify_locations(cafile=ca_pem)
+
+    device = ModbusDevice()
+    router = setup_router(device)
+    server = AsyncTcpServer(host="127.0.0.1", port=0, handler=router, ssl_context=server_ssl)
+    await server.start()
+    port = get_server_port(server)
+
+    transport = AsyncTcpTransport("127.0.0.1", port, ssl=client_ssl, server_hostname="localhost")
+    client = AsyncModbusClient(transport=transport, unit_id=1)
+
+    async with client:
+        await run_full_pdu_test_suite(client)
+
+    await server.stop()

--- a/integration_tests/tokio/test_tokio_client.py
+++ b/integration_tests/tokio/test_tokio_client.py
@@ -87,6 +87,25 @@ async def test_client(transport: AsyncBaseTransport) -> None:
         2: b"1.0",
     }
 
+    # Struct / Typed helpers
+    await client.write_int16(0, -1234)
+    assert await client.read_int16(0) == -1234
+
+    await client.write_uint16(0, 65000)
+    assert await client.read_uint16(0) == 65000
+
+    await client.write_int32(0, -12345678)
+    assert await client.read_int32(0) == -12345678
+
+    await client.write_uint32(0, 3000000000)
+    assert await client.read_uint32(0) == 3000000000
+
+    await client.write_float(0, 3.141592)
+    assert pytest.approx(await client.read_float(0), rel=1e-5) == 3.141592
+
+    await client.write_string(0, "TMod", number_of_registers=2)
+    assert (await client.read_string(0, number_of_registers=2)).rstrip("\x00") == "TMod"
+
     await client.disconnect()
 
 


### PR DESCRIPTION
1. **Shared Mock Device & Router (integration_test_server.py)**:
   - Added support and state tracking for **FC 0x07** (Read Exception Status), **FC 0x08** (Diagnostics Subfunctions), **FC 0x0B/0x0C** (Comm Event Counter & Log), **FC 0x11** (Report Server ID), **FC 0x14/0x15** (Read & Write File Records), **FC 0x16** (Mask Write Register), **FC 0x17** (Read/Write Multiple Registers), **FC 0x18** (Read FIFO Queue), and **FC 0x2B/0x0E** (Read Device Identification).

2. **External Simulators**:
   - **FieldTalk Diagslave**: Tested FC 0x07, FC 0x08 Query Data, FC 0x2B Device ID, and all struct helpers (`read_int16`/`write_int16`, `read_uint16`/`write_uint16`, `read_int32`/`write_int32`, `read_uint32`/`write_uint32`, `read_float`/`write_float`, `read_double`/`write_double`, `read_string`/`write_string`) across TCP, UDP, RTU over TCP, RTU serial, and ASCII serial.
   - **Rust `rmodbus`**: Expanded with coils, discrete inputs, and struct helpers across TCP, RTU, and ASCII.
   - **Rust `tokio-modbus`**: Expanded with Device Identification and struct helpers across TCP, RTU, and RTU-over-TCP.
   - **Go `simonvetter/modbus`**: Expanded with struct helpers.

3. **End-to-End Test Suite (test_tmodbus_end_to_end.py)**:
   - Full matrix testing all standard Modbus function codes, diagnostics subfunctions, endianness combinations (`big`/`big`, `big`/`little`, `little`/`big`, `little`/`little`), and unit switching via `client.for_unit_id(uid)` against: - `AsyncTcpServer` + `AsyncTcpTransport` - `AsyncUdpServer` + `AsyncUdpTransport` - `AsyncRtuOverTcpServer` + `AsyncRtuOverTcpTransport` - `AsyncRtuServer` + `AsyncRtuTransport` - `AsyncAsciiServer` + `AsyncAsciiTransport` - `AsyncSmartTransport` - TLS server/client with mutual certificate validation and Modbus role authorization.
