### PR TITLE
feat(server): route diagnostics handlers by sub-function code

### DIFF
--- a/integration_tests/integration_test_server.py
+++ b/integration_tests/integration_test_server.py
@@ -272,6 +272,19 @@ def setup_router(device: ModbusDevice) -> ModbusRequestRouter:  # noqa: C901, PL
         return device.fifo_queues.get(request.address, [])
 
     @router.register(DiagnosticsQueryDataPDU)
+    @router.register(DiagnosticsRestartCommunicationsOptionPDU)
+    @router.register(DiagnosticsDiagnosticRegisterPDU)
+    @router.register(DiagnosticsChangeAsciiInputDelimiterPDU)
+    @router.register(DiagnosticsClearCountersAndRegisterPDU)
+    @router.register(DiagnosticsBusMessageCountPDU)
+    @router.register(DiagnosticsBusCommunicationErrorCountPDU)
+    @router.register(DiagnosticsBusExceptionErrorCountPDU)
+    @router.register(DiagnosticsServerMessageCountPDU)
+    @router.register(DiagnosticsServerNoResponseCountPDU)
+    @router.register(DiagnosticsServerNakCountPDU)
+    @router.register(DiagnosticsServerBusyCountPDU)
+    @router.register(DiagnosticsBusCharacterOverrunCountPDU)
+    @router.register(DiagnosticsClearOverrunCounterAndFlagPDU)
     async def handle_diagnostics(  # noqa: C901, PLR0911, PLR0912
         _unit_id: int, request: BaseDiagnosticsSubFunctionPDU[Any]
     ) -> Any:

--- a/src/tmodbus/server/handler.py
+++ b/src/tmodbus/server/handler.py
@@ -182,9 +182,12 @@ class ModbusRequestRouter(ModbusHandler):
         # Structure:
         #   Outer Key: `int | None` representing the unit ID (slave address).
         #              `None` acts as a wildcard fallback key for any unit ID.
-        #   Inner Key: `int` representing the Modbus function code (e.g. 0x03).
-        #   Value:     `RouterHandler` mapping the function code to the handler.
-        self._handlers: dict[int | None, dict[int, RouterHandler]] = {}
+        #   Inner Key: `(function_code, sub_function_code)` tuple. The sub-function
+        #              code is `None` for PDUs without one (e.g. 0x03), so PDUs that
+        #              share a function code (e.g. Diagnostics 0x08) route per
+        #              sub-function.
+        #   Value:     `RouterHandler` mapping that key to the handler.
+        self._handlers: dict[int | None, dict[tuple[int, int | None], RouterHandler]] = {}
 
     def supports_unit_id(self, unit_id: int, /) -> bool:
         """Check if the handler supports the given unit ID."""
@@ -201,6 +204,11 @@ class ModbusRequestRouter(ModbusHandler):
         The handler's signature is inspected dynamically on dispatch to determine
         whether to inject the :class:`RequestContext`.
 
+        PDU classes with a ``sub_function_code`` attribute (e.g. the Diagnostics
+        PDUs, which all share function code 0x08) are registered per sub-function,
+        so each sub-function gets its own handler. A request for a sub-function
+        without a handler is answered with an Illegal Function exception.
+
         Note:
             For Modbus RTU/ASCII (serial line), to handle broadcast requests, a handler
             must be explicitly registered for unit ID 0 (or register a default wildcard
@@ -211,6 +219,8 @@ class ModbusRequestRouter(ModbusHandler):
         def decorator(handler: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
             # Ensure pdu_class has function_code (since it should be a BasePDU subclass)
             func_code = pdu_class.function_code
+            sub_func_code: int | None = getattr(pdu_class, "sub_function_code", None)
+            key = (func_code, sub_func_code)
 
             unit_ids: list[int | None] = [unit_id] if unit_id is None or isinstance(unit_id, int) else list(unit_id)
 
@@ -218,13 +228,14 @@ class ModbusRequestRouter(ModbusHandler):
             # leaves the router unchanged.
             seen: set[int | None] = set()
             for uid in unit_ids:
-                if uid in seen or func_code in self._handlers.get(uid, {}):
-                    msg = f"Handler for function code {func_code} and unit ID {uid} already registered"
+                if uid in seen or key in self._handlers.get(uid, {}):
+                    sub_func = f" sub-function code {sub_func_code}" if sub_func_code is not None else ""
+                    msg = f"Handler for function code {func_code}{sub_func} and unit ID {uid} already registered"
                     raise ValueError(msg)
                 seen.add(uid)
 
             for uid in unit_ids:
-                self._handlers.setdefault(uid, {})[func_code] = handler
+                self._handlers.setdefault(uid, {})[key] = handler
             return handler
 
         return decorator
@@ -249,7 +260,7 @@ class ModbusRequestRouter(ModbusHandler):
 
         Raises:
             IllegalFunctionError: If no handler is registered for the function code
-                specified in the request PDU.
+                (and sub-function code, if any) specified in the request PDU.
 
         """
         # First, try to find handlers for the specific unit ID
@@ -261,7 +272,7 @@ class ModbusRequestRouter(ModbusHandler):
         if func_handlers is None:
             raise IllegalFunctionError(request.function_code)
 
-        handler = func_handlers.get(request.function_code)
+        handler = func_handlers.get((request.function_code, getattr(request, "sub_function_code", None)))
         if handler is None:
             raise IllegalFunctionError(request.function_code)
 

--- a/tests/server/test_async_tcp_security.py
+++ b/tests/server/test_async_tcp_security.py
@@ -394,7 +394,7 @@ def test_router_stores_wants_context_true() -> None:
         return []
 
     # Access internal structure to verify
-    entry = router._handlers[None][ReadHoldingRegistersPDU.function_code]
+    entry = router._handlers[None][(ReadHoldingRegistersPDU.function_code, None)]
     assert _handler_accepts_context(entry) is True
 
 
@@ -406,7 +406,7 @@ def test_router_stores_wants_context_false() -> None:
     async def handler(_unit_id: int, _request: ReadHoldingRegistersPDU) -> list[int]:
         return []
 
-    entry = router._handlers[None][ReadHoldingRegistersPDU.function_code]
+    entry = router._handlers[None][(ReadHoldingRegistersPDU.function_code, None)]
     assert _handler_accepts_context(entry) is False
 
 

--- a/tests/server/test_handler.py
+++ b/tests/server/test_handler.py
@@ -5,7 +5,13 @@ from typing import Any, cast
 
 import pytest
 from tmodbus.exceptions import IllegalDataAddressError, IllegalFunctionError, SuppressResponseError
-from tmodbus.pdu import BasePDU, ReadHoldingRegistersPDU, WriteSingleRegisterPDU
+from tmodbus.pdu import (
+    BasePDU,
+    DiagnosticsDiagnosticRegisterPDU,
+    DiagnosticsQueryDataPDU,
+    ReadHoldingRegistersPDU,
+    WriteSingleRegisterPDU,
+)
 from tmodbus.server import (
     AnyModbusHandler,
     ModbusHandler,
@@ -228,6 +234,59 @@ async def test_router_unit_id_routing() -> None:
     assert strict_router.supports_unit_id(2) is True
     assert strict_router.supports_unit_id(3) is False
     assert strict_router.supports_unit_id(0) is False
+
+
+async def test_router_sub_function_routing() -> None:
+    """Test that PDUs sharing a function code route per sub-function code."""
+    router = ModbusRequestRouter()
+
+    @router.register(DiagnosticsQueryDataPDU)
+    async def handle_query_data(_unit_id: int, request: DiagnosticsQueryDataPDU) -> bytes:
+        return request.data
+
+    # An unhandled sub-function under the same function code answers Illegal Function
+    with pytest.raises(IllegalFunctionError):
+        await router(1, DiagnosticsDiagnosticRegisterPDU())
+    response_bytes = await handle_modbus_request(1, DiagnosticsDiagnosticRegisterPDU(), router)
+    assert response_bytes == b"\x88\x01"
+
+    # A second sub-function under the same function code registers alongside the first
+    @router.register(DiagnosticsDiagnosticRegisterPDU)
+    async def handle_diagnostic_register(_unit_id: int, _request: DiagnosticsDiagnosticRegisterPDU) -> int:
+        return 0x1234
+
+    # Each handler receives only its own sub-function
+    assert await router(1, DiagnosticsQueryDataPDU(data=b"\xab\xcd")) == b"\xab\xcd"
+    assert await router(1, DiagnosticsDiagnosticRegisterPDU()) == 0x1234
+
+    # Duplicate registration of the same sub-function is still rejected
+    with pytest.raises(ValueError, match=r"sub-function code 2 .* already registered"):
+
+        @router.register(DiagnosticsDiagnosticRegisterPDU)
+        async def handle_duplicate(_unit_id: int, _request: DiagnosticsDiagnosticRegisterPDU) -> int:
+            return -1
+
+
+async def test_router_sub_function_unit_id_routing() -> None:
+    """Test sub-function routing combined with unit-scoped and wildcard handlers."""
+    router = ModbusRequestRouter()
+
+    @router.register(DiagnosticsQueryDataPDU, unit_id=1)
+    async def handle_unit_1(_unit_id: int, _request: DiagnosticsQueryDataPDU) -> bytes:
+        return b"\x11\x11"
+
+    @router.register(DiagnosticsQueryDataPDU)
+    async def handle_default(_unit_id: int, _request: DiagnosticsQueryDataPDU) -> bytes:
+        return b"\x99\x99"
+
+    req = DiagnosticsQueryDataPDU()
+    assert await router(1, req) == b"\x11\x11"
+    assert await router(2, req) == b"\x99\x99"
+
+    # A unit with registered handlers does not fall back to the wildcard
+    # for a sub-function it does not handle
+    with pytest.raises(IllegalFunctionError):
+        await router(1, DiagnosticsDiagnosticRegisterPDU())
 
 
 async def test_router_context_passing() -> None:


### PR DESCRIPTION
# Proposed Changes

The router keyed handlers on function code alone, so only one of the 15 diagnostics PDUs (all FC 0x08) could be registered, and that handler received every sub-function's request — crashing on the wrong PDU type and answering SERVER_DEVICE_FAILURE instead of ILLEGAL_FUNCTION.

The handler table key is now `(function_code, sub_function_code | None)`. Each handler receives only its own PDU type, and an unregistered sub-function answers ILLEGAL_FUNCTION per spec. PDUs without a sub-function are unaffected.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
