### PR TITLE
fix(server): never transmit a response to a broadcast request

### DIFF
--- a/src/tmodbus/server/async_ascii.py
+++ b/src/tmodbus/server/async_ascii.py
@@ -213,7 +213,9 @@ class AsyncAsciiServer(AsyncBaseServer):
         else:
             response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)
 
-        if response_pdu_bytes and (is_error or (unit_id != BROADCAST_UNIT_ID and request_pdu.expects_response)):
+        # Broadcast requests must never be answered: on a shared bus every
+        # listening server would transmit at once and collide.
+        if response_pdu_bytes and unit_id != BROADCAST_UNIT_ID and (is_error or request_pdu.expects_response):
             out_bin = bytearray([unit_id]) + response_pdu_bytes
             lrc = calculate_lrc(bytes(out_bin))
             out_bin.append(lrc)

--- a/src/tmodbus/server/async_rtu.py
+++ b/src/tmodbus/server/async_rtu.py
@@ -183,7 +183,9 @@ class AsyncRtuServer(AsyncBaseServer):
         else:
             response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)
 
-        if response_pdu_bytes and (is_error or (unit_id != BROADCAST_UNIT_ID and request_pdu.expects_response)):
+        # Broadcast requests must never be answered: on a shared bus every
+        # listening server would transmit at once and collide.
+        if response_pdu_bytes and unit_id != BROADCAST_UNIT_ID and (is_error or request_pdu.expects_response):
             out_frame = bytearray([unit_id]) + response_pdu_bytes
             crc = calculate_crc16(bytes(out_frame))
             out_frame.extend(crc)

--- a/src/tmodbus/server/async_rtu_over_tcp.py
+++ b/src/tmodbus/server/async_rtu_over_tcp.py
@@ -166,7 +166,9 @@ class AsyncRtuOverTcpServer(AsyncBaseServer):
             else:
                 response_pdu_bytes = await handle_modbus_request(unit_id, request_pdu, self.handler)
 
-        if response_pdu_bytes and (is_error or (unit_id != BROADCAST_UNIT_ID and request_pdu.expects_response)):
+        # Broadcast requests must never be answered, including the unregistered
+        # unit ID and decode error paths above.
+        if response_pdu_bytes and unit_id != BROADCAST_UNIT_ID and (is_error or request_pdu.expects_response):
             out_frame = bytearray([unit_id]) + response_pdu_bytes
             crc = calculate_crc16(bytes(out_frame))
             out_frame.extend(crc)

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -316,3 +316,88 @@ async def test_rtu_over_tcp_server_broadcast_response_suppressed() -> None:
     assert status is True
     assert len(executed) == 1
     assert len(mock_writer.written) == 0
+
+
+def _build_broadcast_decode_error_pdu() -> bytes:
+    """Return PDU bytes that fail decoding: ReadHoldingRegisters (FC 0x03) with quantity 0."""
+    return bytes([0x03, 0x00, 0x00, 0x00, 0x00])
+
+
+def _make_router() -> ModbusRequestRouter:
+    """Return a router that supports all unit IDs."""
+    router = ModbusRequestRouter()
+
+    @router.register(ReadHoldingRegistersPDU)
+    async def handle_read(_unit_id: int, request: ReadHoldingRegistersPDU) -> list[int]:
+        return [0] * request.quantity
+
+    return router
+
+
+@pytest.mark.asyncio
+async def test_rtu_server_broadcast_decode_error_suppressed() -> None:
+    """Test AsyncRtuServer does not send an exception response for a malformed broadcast frame."""
+    server = AsyncRtuServer(port="dummy", handler=_make_router())
+    server._inter_frame_silence = 0.0
+
+    frame = bytearray([0x00]) + _build_broadcast_decode_error_pdu()
+    frame.extend(calculate_crc16(bytes(frame)))
+
+    mock_writer = MockWriteTransport()
+    server._writer = mock_writer  # type: ignore[assignment]
+
+    status = await server._handle_frame(bytes(frame))
+    assert status == "error"
+    assert len(mock_writer.written) == 0
+
+
+@pytest.mark.asyncio
+async def test_ascii_server_broadcast_decode_error_suppressed() -> None:
+    """Test AsyncAsciiServer does not send an exception response for a malformed broadcast frame."""
+    server = AsyncAsciiServer(port="dummy", handler=_make_router())
+
+    bin_data = bytes([0x00]) + _build_broadcast_decode_error_pdu()
+    ascii_hex = (bin_data + bytes([calculate_lrc(bin_data)])).hex().upper().encode("ascii")
+    ascii_frame = b":" + ascii_hex + b"\r\n"
+
+    mock_writer = MockWriteTransport()
+    server._writer = mock_writer  # type: ignore[assignment]
+
+    status = await server._process_next_frame(ascii_frame)
+    assert status == "error"
+    assert len(mock_writer.written) == 0
+
+
+@pytest.mark.asyncio
+async def test_rtu_over_tcp_server_broadcast_decode_error_suppressed() -> None:
+    """Test AsyncRtuOverTcpServer does not send an exception response for a malformed broadcast frame."""
+    server = AsyncRtuOverTcpServer(host="localhost", port=502, handler=_make_router())
+
+    frame = bytearray([0x00]) + _build_broadcast_decode_error_pdu()
+    frame.extend(calculate_crc16(bytes(frame)))
+
+    mock_writer = MockStreamWriter()
+    status = await server._handle_frame(bytes(frame), ("127.0.0.1", 12345), mock_writer)  # type: ignore[arg-type]
+    assert status is False
+    assert len(mock_writer.written) == 0
+
+
+@pytest.mark.asyncio
+async def test_rtu_over_tcp_server_broadcast_unregistered_unit_suppressed() -> None:
+    """Test AsyncRtuOverTcpServer does not answer a broadcast frame when unit ID 0 is not registered."""
+    router = ModbusRequestRouter()
+
+    @router.register(WriteSingleRegisterPDU, unit_id=5)
+    async def handle_write(_unit_id: int, request: WriteSingleRegisterPDU) -> int:
+        return request.value
+
+    server = AsyncRtuOverTcpServer(host="localhost", port=502, handler=router)
+
+    pdu_bytes = bytes([0x06, 0x00, 0x01, 0x00, 0x02])
+    frame = bytearray([0x00]) + pdu_bytes
+    frame.extend(calculate_crc16(bytes(frame)))
+
+    mock_writer = MockStreamWriter()
+    status = await server._handle_frame(bytes(frame), ("127.0.0.1", 12345), mock_writer)  # type: ignore[arg-type]
+    assert status is False
+    assert len(mock_writer.written) == 0


### PR DESCRIPTION
# Proposed Changes

The serial servers' send guard let `is_error` short-circuit the broadcast check, so a malformed broadcast frame got an exception response written onto the bus — the spec forbids any response to broadcast, and on shared RS-485 every listening server transmits it at once. RTU-over-TCP also answered broadcast frames for unregistered unit IDs.

The guard now checks `unit_id != BROADCAST_UNIT_ID` first in all three serial servers, so broadcast never produces a transmitted response. Handlers still run, so broadcast write side effects are unchanged. TCP/UDP untouched (no broadcast in MBAP).

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
