### PR TITLE
fix(transport): reject no-response PDUs in the TCP and UDP clients

### DIFF
--- a/src/tmodbus/transport/async_tcp.py
+++ b/src/tmodbus/transport/async_tcp.py
@@ -9,11 +9,12 @@ import struct
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 
 from tmodbus.const import EXCEPTION_RESPONSE_BIT, FUNCTION_CODE_MASK
 from tmodbus.exceptions import (
     HeaderMismatchError,
+    InvalidRequestError,
     ModbusConnectionError,
     UnknownModbusResponseError,
     error_code_to_exception_map,
@@ -258,10 +259,10 @@ class ModbusTcpProtocol(asyncio.Protocol):
 
         # 3. Async send request
         if not pdu.expects_response:
-            # No response expected from server, so send and return immediately
-            self.transport.write(request_frame)
-            log_raw_traffic("sent", request_frame)
-            return cast("RT", None)
+            # PDUs without a response are a serial-line concept; there is no
+            # way to confirm delivery over Modbus TCP, so reject them.
+            msg = f"{type(pdu).__name__} does not expect a response and is only supported on serial transports."
+            raise InvalidRequestError(msg)
 
         read_future: asyncio.Future[_ModbusMessage] = asyncio.get_running_loop().create_future()
         self._pending_requests[current_transaction_id] = read_future

--- a/src/tmodbus/transport/async_tcp.py
+++ b/src/tmodbus/transport/async_tcp.py
@@ -9,7 +9,7 @@ import struct
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from tmodbus.const import EXCEPTION_RESPONSE_BIT, FUNCTION_CODE_MASK
 from tmodbus.exceptions import (
@@ -257,6 +257,12 @@ class ModbusTcpProtocol(asyncio.Protocol):
         request_frame = mbap_header + request_pdu_bytes
 
         # 3. Async send request
+        if not pdu.expects_response:
+            # No response expected from server, so send and return immediately
+            self.transport.write(request_frame)
+            log_raw_traffic("sent", request_frame)
+            return cast("RT", None)
+
         read_future: asyncio.Future[_ModbusMessage] = asyncio.get_running_loop().create_future()
         self._pending_requests[current_transaction_id] = read_future
 

--- a/src/tmodbus/transport/async_udp.py
+++ b/src/tmodbus/transport/async_udp.py
@@ -9,7 +9,7 @@ import struct
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from tmodbus.const import EXCEPTION_RESPONSE_BIT, FUNCTION_CODE_MASK
 from tmodbus.exceptions import (
@@ -235,6 +235,12 @@ class ModbusUdpProtocol(asyncio.DatagramProtocol):
         )
 
         request_frame = mbap_header + request_pdu_bytes
+
+        if not pdu.expects_response:
+            # No response expected from server, so send and return immediately
+            self.transport.sendto(request_frame)
+            log_raw_traffic("sent", request_frame)
+            return cast("RT", None)
 
         read_future: asyncio.Future[_ModbusMessage] = asyncio.get_running_loop().create_future()
         self._pending_requests[current_transaction_id] = read_future

--- a/src/tmodbus/transport/async_udp.py
+++ b/src/tmodbus/transport/async_udp.py
@@ -9,11 +9,12 @@ import struct
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 
 from tmodbus.const import EXCEPTION_RESPONSE_BIT, FUNCTION_CODE_MASK
 from tmodbus.exceptions import (
     HeaderMismatchError,
+    InvalidRequestError,
     ModbusConnectionError,
     UnknownModbusResponseError,
     error_code_to_exception_map,
@@ -237,10 +238,10 @@ class ModbusUdpProtocol(asyncio.DatagramProtocol):
         request_frame = mbap_header + request_pdu_bytes
 
         if not pdu.expects_response:
-            # No response expected from server, so send and return immediately
-            self.transport.sendto(request_frame)
-            log_raw_traffic("sent", request_frame)
-            return cast("RT", None)
+            # PDUs without a response are a serial-line concept; there is no
+            # way to confirm delivery over Modbus UDP, so reject them.
+            msg = f"{type(pdu).__name__} does not expect a response and is only supported on serial transports."
+            raise InvalidRequestError(msg)
 
         read_future: asyncio.Future[_ModbusMessage] = asyncio.get_running_loop().create_future()
         self._pending_requests[current_transaction_id] = read_future

--- a/tests/transport/test_async_tcp.py
+++ b/tests/transport/test_async_tcp.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from tmodbus.exceptions import InvalidResponseError, ModbusConnectionError, ModbusResponseError
 from tmodbus.pdu.base import BaseClientPDU
+from tmodbus.pdu.serial_line import DiagnosticsForceListenOnlyModePDU
 from tmodbus.transport.async_tcp import AsyncTcpTransport, ModbusTcpProtocol, _ModbusMessage
 
 
@@ -297,6 +298,26 @@ async def test_protocol_send_and_receive_timeout() -> None:
     # Should timeout since no response is sent
     with pytest.raises(TimeoutError, match="Response timeout"):
         await protocol.send_and_receive(1, pdu)
+
+
+async def test_protocol_send_and_receive_no_response_pdu() -> None:
+    """Test send_and_receive when PDU expects_response is False."""
+    protocol = ModbusTcpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
+    mock_transport = MagicMock(spec=asyncio.WriteTransport)
+    mock_transport.is_closing.return_value = False
+    protocol.connection_made(mock_transport)
+
+    pdu = DiagnosticsForceListenOnlyModePDU()
+
+    # Returns immediately without waiting for a response
+    result = await asyncio.wait_for(protocol.send_and_receive(1, pdu), timeout=1.0)
+
+    assert result is None
+    # MBAP: tid=1, pid=0, len=6, uid=1 + PDU: fc=0x08, sub-func=0x0004, data=0x0000
+    expected_request = struct.pack(">HHHB", 1, 0, 6, 1) + b"\x08\x00\x04\x00\x00"
+    mock_transport.write.assert_called_once_with(expected_request)
+    # No pending future left behind
+    assert not protocol._pending_requests
 
 
 async def test_protocol_send_and_receive_invalid_protocol_id(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/transport/test_async_tcp.py
+++ b/tests/transport/test_async_tcp.py
@@ -6,7 +6,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tmodbus.exceptions import InvalidResponseError, ModbusConnectionError, ModbusResponseError
+from tmodbus.exceptions import InvalidRequestError, InvalidResponseError, ModbusConnectionError, ModbusResponseError
 from tmodbus.pdu.base import BaseClientPDU
 from tmodbus.pdu.serial_line import DiagnosticsForceListenOnlyModePDU
 from tmodbus.transport.async_tcp import AsyncTcpTransport, ModbusTcpProtocol, _ModbusMessage
@@ -330,7 +330,7 @@ async def test_protocol_send_and_receive_timeout() -> None:
 
 
 async def test_protocol_send_and_receive_no_response_pdu() -> None:
-    """Test send_and_receive when PDU expects_response is False."""
+    """Test send_and_receive rejects a PDU that expects no response."""
     protocol = ModbusTcpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
     mock_transport = MagicMock(spec=asyncio.WriteTransport)
     mock_transport.is_closing.return_value = False
@@ -338,14 +338,11 @@ async def test_protocol_send_and_receive_no_response_pdu() -> None:
 
     pdu = DiagnosticsForceListenOnlyModePDU()
 
-    # Returns immediately without waiting for a response
-    result = await asyncio.wait_for(protocol.send_and_receive(1, pdu), timeout=1.0)
+    with pytest.raises(InvalidRequestError, match="only supported on serial transports"):
+        await protocol.send_and_receive(1, pdu)
 
-    assert result is None
-    # MBAP: tid=1, pid=0, len=6, uid=1 + PDU: fc=0x08, sub-func=0x0004, data=0x0000
-    expected_request = struct.pack(">HHHB", 1, 0, 6, 1) + b"\x08\x00\x04\x00\x00"
-    mock_transport.write.assert_called_once_with(expected_request)
-    # No pending future left behind
+    # Nothing sent, no pending future left behind
+    mock_transport.write.assert_not_called()
     assert not protocol._pending_requests
 
 

--- a/tests/transport/test_async_udp.py
+++ b/tests/transport/test_async_udp.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from tmodbus.exceptions import (
+    InvalidRequestError,
     InvalidResponseError,
     ModbusConnectionError,
     ModbusResponseError,
@@ -208,7 +209,7 @@ async def test_protocol_send_and_receive_timeout() -> None:
 
 
 async def test_protocol_send_and_receive_no_response_pdu() -> None:
-    """Test send_and_receive when PDU expects_response is False."""
+    """Test send_and_receive rejects a PDU that expects no response."""
     protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
     mock_transport = MagicMock(spec=asyncio.DatagramTransport)
     mock_transport.is_closing.return_value = False
@@ -216,14 +217,11 @@ async def test_protocol_send_and_receive_no_response_pdu() -> None:
 
     pdu = DiagnosticsForceListenOnlyModePDU()
 
-    # Returns immediately without waiting for a response
-    result = await asyncio.wait_for(protocol.send_and_receive(unit_id=1, pdu=pdu), timeout=1.0)
+    with pytest.raises(InvalidRequestError, match="only supported on serial transports"):
+        await protocol.send_and_receive(unit_id=1, pdu=pdu)
 
-    assert result is None
-    # MBAP: tid=1, pid=0, len=6, uid=1 + PDU: fc=0x08, sub-func=0x0004, data=0x0000
-    expected_request = struct.pack(">HHHB", 1, 0, 6, 1) + b"\x08\x00\x04\x00\x00"
-    mock_transport.sendto.assert_called_once_with(expected_request)
-    # No pending future left behind
+    # Nothing sent, no pending future left behind
+    mock_transport.sendto.assert_not_called()
     assert not protocol._pending_requests
 
 

--- a/tests/transport/test_async_udp.py
+++ b/tests/transport/test_async_udp.py
@@ -13,6 +13,7 @@ from tmodbus.exceptions import (
     UnknownModbusResponseError,
 )
 from tmodbus.pdu.base import BaseClientPDU
+from tmodbus.pdu.serial_line import DiagnosticsForceListenOnlyModePDU
 from tmodbus.transport.async_udp import AsyncUdpTransport, ModbusUdpProtocol
 
 
@@ -204,6 +205,26 @@ async def test_protocol_send_and_receive_timeout() -> None:
     pdu = _DummyPDU()
     with pytest.raises(TimeoutError, match=r"Response timeout after .*"):
         await protocol.send_and_receive(unit_id=1, pdu=pdu)
+
+
+async def test_protocol_send_and_receive_no_response_pdu() -> None:
+    """Test send_and_receive when PDU expects_response is False."""
+    protocol = ModbusUdpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+    mock_transport.is_closing.return_value = False
+    protocol.connection_made(mock_transport)
+
+    pdu = DiagnosticsForceListenOnlyModePDU()
+
+    # Returns immediately without waiting for a response
+    result = await asyncio.wait_for(protocol.send_and_receive(unit_id=1, pdu=pdu), timeout=1.0)
+
+    assert result is None
+    # MBAP: tid=1, pid=0, len=6, uid=1 + PDU: fc=0x08, sub-func=0x0004, data=0x0000
+    expected_request = struct.pack(">HHHB", 1, 0, 6, 1) + b"\x08\x00\x04\x00\x00"
+    mock_transport.sendto.assert_called_once_with(expected_request)
+    # No pending future left behind
+    assert not protocol._pending_requests
 
 
 async def test_protocol_datagram_received_invalid_length() -> None:


### PR DESCRIPTION
# Proposed Changes

The TCP and UDP client transports ignored `pdu.expects_response` (added in #112), so a no-response PDU like Force Listen Only Mode always burned the full timeout and raised `TimeoutError`.

Per review feedback: these PDUs are serial-line only, so the TCP and UDP transports now reject them explicitly with `InvalidRequestError` instead of sending them.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
