### PR TITLE
fix(server): don't emit zero-length-PDU frames for suppressed responses

### DIFF
--- a/src/tmodbus/server/async_tcp.py
+++ b/src/tmodbus/server/async_tcp.py
@@ -233,6 +233,22 @@ class AsyncTcpServer(AsyncBaseServer):
 
         log_raw_traffic("recv", mbap_header + pdu_bytes, is_error=is_error)
 
+        await self._send_response(writer, transaction_id, protocol_id, unit_id, response_pdu_bytes)
+        return True
+
+    @staticmethod
+    async def _send_response(
+        writer: asyncio.StreamWriter,
+        transaction_id: int,
+        protocol_id: int,
+        unit_id: int,
+        response_pdu_bytes: bytes,
+    ) -> None:
+        """Send an MBAP-framed response, or nothing when the response is suppressed."""
+        if not response_pdu_bytes:
+            logger.debug("Response suppressed. Not sending response bytes.")
+            return
+
         # Build MBAP header for response
         resp_length = len(response_pdu_bytes) + 1
         resp_mbap = struct.pack(">HHHB", transaction_id, protocol_id, resp_length, unit_id)
@@ -241,7 +257,6 @@ class AsyncTcpServer(AsyncBaseServer):
         writer.write(out_bytes)
         log_raw_traffic("sent", out_bytes)
         await writer.drain()
-        return True
 
     async def handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         """Handle a single client connection."""

--- a/src/tmodbus/server/async_udp.py
+++ b/src/tmodbus/server/async_udp.py
@@ -172,13 +172,28 @@ class ModbusUdpServerProtocol(asyncio.DatagramProtocol):
 
             log_raw_traffic("recv", data, is_error=is_error)
 
-            # Build MBAP header for response
-            resp_length = len(response_pdu_bytes) + 1
-            resp_mbap = struct.pack(">HHHB", transaction_id, protocol_id, resp_length, unit_id)
-
-            out_bytes = resp_mbap + response_pdu_bytes
-            if self.transport:
-                self.transport.sendto(out_bytes, addr)
-                log_raw_traffic("sent", out_bytes)
+            self._send_response(addr, transaction_id, protocol_id, unit_id, response_pdu_bytes)
         except Exception:
             logger.exception("Error processing UDP datagram from %s", addr)
+
+    def _send_response(
+        self,
+        addr: tuple[str, int],
+        transaction_id: int,
+        protocol_id: int,
+        unit_id: int,
+        response_pdu_bytes: bytes,
+    ) -> None:
+        """Send an MBAP-framed response datagram, or nothing when the response is suppressed."""
+        if not response_pdu_bytes:
+            logger.debug("Response suppressed. Not sending response bytes.")
+            return
+
+        # Build MBAP header for response
+        resp_length = len(response_pdu_bytes) + 1
+        resp_mbap = struct.pack(">HHHB", transaction_id, protocol_id, resp_length, unit_id)
+
+        out_bytes = resp_mbap + response_pdu_bytes
+        if self.transport:
+            self.transport.sendto(out_bytes, addr)
+            log_raw_traffic("sent", out_bytes)

--- a/tests/server/test_async_tcp.py
+++ b/tests/server/test_async_tcp.py
@@ -7,7 +7,8 @@ from collections.abc import AsyncIterator
 from unittest.mock import patch
 
 import pytest
-from tmodbus.pdu import ReadHoldingRegistersPDU
+from tmodbus.exceptions import SuppressResponseError
+from tmodbus.pdu import DiagnosticsForceListenOnlyModePDU, ReadHoldingRegistersPDU
 from tmodbus.pdu.base import BaseClientPDU
 from tmodbus.server import AsyncTcpServer, ModbusRequestRouter
 
@@ -493,5 +494,67 @@ async def test_tcp_server_configurable_exception_code() -> None:
             writer.close()
             await writer.wait_closed()
 
+    finally:
+        await server.stop()
+
+
+async def test_tcp_server_suppress_response_error() -> None:
+    """Test that TCP server sends no bytes when SuppressResponseError is raised by handler."""
+    router = ModbusRequestRouter()
+
+    @router.register(ReadHoldingRegistersPDU)
+    async def handle_read(_unit_id: int, _request: ReadHoldingRegistersPDU) -> list[int]:
+        raise SuppressResponseError
+
+    server = AsyncTcpServer(host="127.0.0.1", port=0, handler=router)
+    await server.start()
+
+    try:
+        port = get_server_port(server)
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+        try:
+            mbap = struct.pack(">HHHB", 1, 0, 6, 1)
+            pdu = b"\x03\x00\x00\x00\x02"
+            writer.write(mbap + pdu)
+            await writer.drain()
+
+            # No response frame at all: not even a bare MBAP header
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(reader.read(1), timeout=0.1)
+        finally:
+            writer.close()
+            await writer.wait_closed()
+    finally:
+        await server.stop()
+
+
+async def test_tcp_server_force_listen_only_no_response() -> None:
+    """Test that Force Listen Only Mode request gets no response frame on TCP."""
+    router = ModbusRequestRouter()
+
+    @router.register(DiagnosticsForceListenOnlyModePDU)
+    async def handle_force_listen_only(_unit_id: int, _request: DiagnosticsForceListenOnlyModePDU) -> None:
+        return
+
+    server = AsyncTcpServer(host="127.0.0.1", port=0, handler=router)
+    await server.start()
+
+    try:
+        port = get_server_port(server)
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+        try:
+            # Diagnostics (0x08) sub-function 0x0004: Force Listen Only Mode
+            mbap = struct.pack(">HHHB", 1, 0, 6, 1)
+            pdu = b"\x08\x00\x04\x00\x00"
+            writer.write(mbap + pdu)
+            await writer.drain()
+
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(reader.read(1), timeout=0.1)
+        finally:
+            writer.close()
+            await writer.wait_closed()
     finally:
         await server.stop()

--- a/tests/server/test_async_udp.py
+++ b/tests/server/test_async_udp.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from tmodbus.exceptions import SuppressResponseError
 from tmodbus.pdu import ReadHoldingRegistersPDU
 from tmodbus.server import AsyncUdpServer, ModbusRequestRouter
 from tmodbus.server.async_udp import ModbusUdpServerProtocol
@@ -338,3 +339,33 @@ async def test_server_protocol_process_datagram_exception() -> None:
 
         # Verify exception log was called
         mock_logger.exception.assert_called_with("Error processing UDP datagram from %s", ("127.0.0.1", 1234))
+
+
+async def test_udp_server_suppress_response_error() -> None:
+    """Test that UDP server sends no datagram when SuppressResponseError is raised by handler."""
+    router = ModbusRequestRouter()
+
+    @router.register(ReadHoldingRegistersPDU)
+    async def handle_read(_unit_id: int, _request: ReadHoldingRegistersPDU) -> list[int]:
+        raise SuppressResponseError
+
+    server = AsyncUdpServer(host="127.0.0.1", port=0, handler=router)
+    await server.start()
+
+    try:
+        port = get_server_port(server)
+        loop = asyncio.get_running_loop()
+        transport, protocol = await loop.create_datagram_endpoint(UdpClientProtocol, remote_addr=("127.0.0.1", port))
+
+        try:
+            mbap = struct.pack(">HHHB", 1, 0, 6, 1)
+            pdu = b"\x03\x00\x00\x00\x02"
+            transport.sendto(mbap + pdu)
+
+            # No response datagram at all: not even a bare MBAP header
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(protocol.future, timeout=0.1)
+        finally:
+            transport.close()
+    finally:
+        await server.stop()


### PR DESCRIPTION
# Proposed Changes

When a handler produced no response (`SuppressResponseError`, or Force Listen Only Mode's empty encode), the TCP and UDP servers still sent a bare MBAP header with zero PDU bytes — violating the 1-byte-minimum PDU rule and making the tmodbus client raise `InvalidResponseError`.

Both servers now send nothing when the response PDU is empty, matching the guard the serial servers already have.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
