### PR TITLE
fix(pdu): validate serial-line and file record PDU edge cases

### DIFF
--- a/src/tmodbus/pdu/device.py
+++ b/src/tmodbus/pdu/device.py
@@ -136,6 +136,14 @@ class ReadDeviceIdentificationPDU(BaseSubFunctionPDU[ReadDeviceIdentificationRes
             ValueError: If a field is out of range or the object count does not match
 
         """
+        if value.device_id_code not in (0x01, 0x02, 0x03, 0x04):
+            msg = f"Invalid device ID code: {value.device_id_code:#04x}"
+            raise ValueError(msg)
+
+        if value.conformity_level not in ConformityLevel:
+            msg = f"Invalid conformity level: {value.conformity_level:#04x}"
+            raise ValueError(msg)
+
         if not (0x00 <= value.next_object_id <= 0xFF):
             msg = "Next object ID must be between 0x00 and 0xFF."
             raise ValueError(msg)

--- a/src/tmodbus/pdu/file.py
+++ b/src/tmodbus/pdu/file.py
@@ -71,6 +71,15 @@ class ReadFileRecordPDU(BasePDU[list[bytes]]):
             )
             raise ValueError(msg)
 
+        # Each requested record costs 2 header bytes plus 2 bytes per register in the response.
+        response_byte_count = sum(2 + 2 * request.record_length for request in requests)
+        if response_byte_count > MAX_READ_FILE_RECORD_BYTE_COUNT:
+            msg = (
+                f"Read File Record response byte count {response_byte_count} exceeds the "
+                f"maximum of {MAX_READ_FILE_RECORD_BYTE_COUNT}."
+            )
+            raise ValueError(msg)
+
         self.requests = requests
 
     def encode_request(self) -> bytes:
@@ -251,8 +260,10 @@ class ReadFileRecordPDU(BasePDU[list[bytes]]):
             raise InvalidRequestError(str(e), request_bytes=request) from e
 
     @classmethod
-    def get_expected_request_data_length(cls, data: bytes) -> int:
+    def get_expected_request_data_length(cls, data: bytes) -> int | None:
         """Get the expected number of bytes for the data part of the request PDU."""
+        if not data:
+            return None  # length byte not received yet
         return 1 + data[0]
 
 
@@ -511,6 +522,8 @@ class WriteFileRecordPDU(BasePDU[list[FileRecord]]):
             raise InvalidRequestError(str(e), request_bytes=request) from e
 
     @classmethod
-    def get_expected_request_data_length(cls, data: bytes) -> int:
+    def get_expected_request_data_length(cls, data: bytes) -> int | None:
         """Get the expected number of bytes for the data part of the request PDU."""
+        if not data:
+            return None  # length byte not received yet
         return 1 + data[0]

--- a/src/tmodbus/pdu/serial_line.py
+++ b/src/tmodbus/pdu/serial_line.py
@@ -83,8 +83,9 @@ class DiagnosticsQueryDataPDU(BaseDiagnosticsSubFunctionPDU[bytes]):
 
     def encode_response(self, value: bytes) -> bytes:
         """Encode response PDU."""
-        if len(value) % 2 != 0:
-            msg = "Diagnostics query data must be an even number of bytes"
+        # Return Query Data must echo the request data exactly.
+        if len(value) != len(self.data):
+            msg = f"Diagnostics query data response length {len(value)} does not match request length {len(self.data)}"
             raise ValueError(msg)
         return struct.pack(">BH", self.function_code, self.sub_function_code) + value
 
@@ -540,6 +541,12 @@ class GetCommEventCounterPDU(BasePDU[CommEventCounterResponse]):
 
     def encode_response(self, value: CommEventCounterResponse) -> bytes:
         """Encode the response PDU."""
+        if value.status not in (0x0000, 0xFFFF):
+            msg = f"Status {value.status:#06x} invalid, expected 0x0000 or 0xFFFF"
+            raise ValueError(msg)
+        if not (0 <= value.event_count <= 0xFFFF):
+            msg = f"Event count {value.event_count} out of range (0-65535)"
+            raise ValueError(msg)
         return struct.pack(">BHH", self.function_code, value.status, value.event_count)
 
     def decode_response(self, response: bytes) -> CommEventCounterResponse:
@@ -558,6 +565,9 @@ class GetCommEventCounterPDU(BasePDU[CommEventCounterResponse]):
 
 # Alias matching const FunctionCode naming convention
 GetComEventCounterPDU = GetCommEventCounterPDU
+
+
+MAX_COMM_EVENT_LOG_EVENTS = 64
 
 
 @dataclass(frozen=True)
@@ -598,6 +608,10 @@ class GetCommEventLogPDU(BasePDU[CommEventLogResponse]):
 
     def encode_response(self, value: CommEventLogResponse) -> bytes:
         """Encode the response PDU."""
+        # The specification caps the event log at 64 single-byte events.
+        if len(value.events) > MAX_COMM_EVENT_LOG_EVENTS:
+            msg = f"Comm event log length {len(value.events)} exceeds the maximum of {MAX_COMM_EVENT_LOG_EVENTS}."
+            raise ValueError(msg)
         byte_count = 6 + len(value.events)
         return (
             struct.pack(">BBHHH", self.function_code, byte_count, value.status, value.event_count, value.message_count)
@@ -676,6 +690,12 @@ class ReportServerIdPDU(BasePDU[ServerIdResponse]):
             InvalidResponseError: If the response is invalid.
             FunctionCodeError: If function code is incorrect.
 
+        Note:
+            The specification does not delimit the server ID: this method treats the first
+            0x00/0xFF byte after the byte count as the run indicator status. A server ID that
+            itself contains 0x00 or 0xFF is therefore mis-split into server_id/run
+            indicator/additional_data.
+
         """
         # response format: function code (1 byte) + byte count (1 byte) + server ID + status (1 byte)
 
@@ -748,9 +768,14 @@ class ReportServerIdPDU(BasePDU[ServerIdResponse]):
             Encoded bytes of the response PDU.
 
         Raises:
-            ValueError: If the byte count is out of range.
+            ValueError: If the byte count is out of range, or the server ID contains 0x00 or 0xFF.
 
         """
+        # decode_response locates the run indicator status as the first 0x00/0xFF byte after
+        # the byte count, so those values inside the server ID would corrupt the round-trip.
+        if ID_ON in value.server_id or ID_OFF in value.server_id:
+            msg = "Server ID must not contain 0x00 or 0xFF bytes"
+            raise ValueError(msg)
         byte_count = len(value.server_id) + 1 + len(value.additional_data)  # +1 for run indicator status
         if byte_count > 0xFF:
             msg = f"Server ID response byte count {byte_count} exceeds the maximum of 255."

--- a/tests/pdu/test_device.py
+++ b/tests/pdu/test_device.py
@@ -593,3 +593,31 @@ class TestReadDeviceIdentificationPDUServer:
         )
         with pytest.raises(ValueError, match="Object 0x00 value length 256 exceeds the maximum of 255"):
             pdu.encode_response(response)
+
+    def test_encode_response_invalid_device_id_code(self) -> None:
+        """Test encode_response raises on an invalid device ID code."""
+        pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)
+        response = ReadDeviceIdentificationResponse(
+            device_id_code=0x05,  # type: ignore[arg-type]
+            conformity_level=ConformityLevel.BASIC,
+            more=False,
+            next_object_id=0x00,
+            number_of_objects=1,
+            objects={0x00: b"Vendor"},
+        )
+        with pytest.raises(ValueError, match="Invalid device ID code: 0x05"):
+            pdu.encode_response(response)
+
+    def test_encode_response_invalid_conformity_level(self) -> None:
+        """Test encode_response raises on an invalid conformity level."""
+        pdu = ReadDeviceIdentificationPDU(read_device_id_code=0x01, object_id=0x00)
+        response = ReadDeviceIdentificationResponse(
+            device_id_code=0x01,
+            conformity_level=0x42,  # type: ignore[arg-type]
+            more=False,
+            next_object_id=0x00,
+            number_of_objects=1,
+            objects={0x00: b"Vendor"},
+        )
+        with pytest.raises(ValueError, match="Invalid conformity level: 0x42"):
+            pdu.encode_response(response)

--- a/tests/pdu/test_file.py
+++ b/tests/pdu/test_file.py
@@ -24,6 +24,7 @@ class TestReadFileRecordPDU:
     def test_get_expected_request_data_length(self) -> None:
         """Test get_expected_request_data_length."""
         assert ReadFileRecordPDU.get_expected_request_data_length(b"\x0a") == 11
+        assert ReadFileRecordPDU.get_expected_request_data_length(b"") is None
 
     def test_encode_request_single_record(self) -> None:
         """Test encoding a single file record request."""
@@ -125,6 +126,27 @@ class TestReadFileRecordPDU:
         with pytest.raises(ValueError, match="exceeds the maximum"):
             ReadFileRecordPDU(requests)
         ReadFileRecordPDU(requests[:35])  # the maximum is accepted
+
+    def test_validation_response_too_large(self) -> None:
+        """Requests whose implied response exceeds the one-byte byte count are rejected."""
+        # A single record of 122 registers implies a 2 + 244 = 246 byte response, over the 0xF5 (245) maximum.
+        with pytest.raises(ValueError, match="Read File Record response byte count 246 exceeds the maximum of 245"):
+            ReadFileRecordPDU([FileRecordRequest(file_number=1, record_number=0, record_length=122)])
+        with pytest.raises(ValueError, match="response byte count"):
+            ReadFileRecordPDU([FileRecordRequest(file_number=1, record_number=0, record_length=0x7FFF)])
+        # 121 registers (244 response bytes) is the single-record maximum.
+        ReadFileRecordPDU([FileRecordRequest(file_number=1, record_number=0, record_length=121)])
+        # The cap applies to the records combined: two records of 61 registers imply 2 * (2 + 122) = 248 bytes.
+        requests = [FileRecordRequest(file_number=1, record_number=0, record_length=61)] * 2
+        with pytest.raises(ValueError, match="Read File Record response byte count 248 exceeds the maximum of 245"):
+            ReadFileRecordPDU(requests)
+
+    def test_decode_request_response_too_large(self) -> None:
+        """A request whose implied response is too large is rejected with InvalidRequestError."""
+        # Server-side request: a single record of 0x7FFF registers cannot fit in any legal response.
+        request = b"\x14\x07\x06\x00\x01\x00\x00\x7f\xff"
+        with pytest.raises(InvalidRequestError, match="response byte count"):
+            ReadFileRecordPDU.decode_request(request)
 
     def test_decode_request_invalid_record_number(self) -> None:
         """A malformed request is rejected with InvalidRequestError, even when constructor validation fails."""
@@ -295,10 +317,11 @@ class TestReadFileRecordPDU:
 
     def test_encode_response_byte_count_too_high(self) -> None:
         """Test encode_response raises when the byte count exceeds the maximum."""
-        requests = [FileRecordRequest(file_number=4, record_number=1, record_length=122)]
+        requests = [FileRecordRequest(file_number=4, record_number=1, record_length=121)]
         pdu = ReadFileRecordPDU(requests)
 
-        record = b"\x00" * 244  # byte count = 2 + 244 = 246, above the 245 maximum
+        # A handler can return more data than requested: byte count = 2 + 244 = 246, above the 245 maximum.
+        record = b"\x00" * 244
         with pytest.raises(ValueError, match="Read File Record response byte count 246 exceeds the maximum of 245"):
             pdu.encode_response([record])
 
@@ -439,6 +462,7 @@ class TestWriteFileRecordPDU:
     def test_get_expected_request_data_length(self) -> None:
         """Test get_expected_request_data_length."""
         assert WriteFileRecordPDU.get_expected_request_data_length(b"\x0b") == 12
+        assert WriteFileRecordPDU.get_expected_request_data_length(b"") is None
 
     def test_encode_request_single_record(self) -> None:
         """Test encoding a single file record write request."""

--- a/tests/pdu/test_serial_line.py
+++ b/tests/pdu/test_serial_line.py
@@ -175,6 +175,15 @@ def test_encode_response_byte_count_too_high() -> None:
         pdu.encode_response(value)
 
 
+def test_encode_response_server_id_with_status_bytes_rejected() -> None:
+    """Test encode_response rejects a server ID containing 0x00 or 0xFF bytes."""
+    pdu = ReportServerIdPDU()
+    for server_id in (b"a\x00b", b"a\xffb"):
+        value = ServerIdResponse(server_id=server_id, run_indicator_status=True, additional_data=b"")
+        with pytest.raises(ValueError, match="Server ID must not contain 0x00 or 0xFF bytes"):
+            pdu.encode_response(value)
+
+
 # --- Diagnostics Sub-Function PDU Tests ---
 def test_diagnostics_query_data_encode_decode() -> None:
     """Test DiagnosticsQueryDataPDU encoding and decoding."""
@@ -317,8 +326,10 @@ def test_diagnostics_query_and_restart_error_paths() -> None:
     with pytest.raises(ValueError, match="even number of bytes"):
         DiagnosticsQueryDataPDU(b"\x01")
     q_pdu = DiagnosticsQueryDataPDU()
-    with pytest.raises(ValueError, match="even number of bytes"):
+    with pytest.raises(ValueError, match="does not match request length"):
         q_pdu.encode_response(b"\x01")
+    with pytest.raises(ValueError, match="response length 4 does not match request length 2"):
+        q_pdu.encode_response(b"\x12\x34\x56\x78")
     with pytest.raises(InvalidRequestError, match="too short"):
         DiagnosticsQueryDataPDU.decode_request(b"\x08\x00")
     with pytest.raises(InvalidRequestError, match="Invalid function/sub-function"):
@@ -437,6 +448,18 @@ def test_get_comm_event_counter_encode_decode() -> None:
     with pytest.raises(FunctionCodeError, match="Invalid function code"):
         pdu.decode_response(b"\x8b\xff\xff\x01\x08")
 
+    assert pdu.encode_response(CommEventCounterResponse(status=0x0000, event_count=0)) == b"\x0b\x00\x00\x00\x00"
+
+    with pytest.raises(ValueError, match="Status 0x1234 invalid, expected 0x0000 or 0xFFFF"):
+        pdu.encode_response(CommEventCounterResponse(status=0x1234, event_count=0))
+    with pytest.raises(ValueError, match=r"Event count -1 out of range \(0-65535\)"):
+        pdu.encode_response(CommEventCounterResponse(status=0x0000, event_count=-1))
+    with pytest.raises(ValueError, match=r"Event count 65536 out of range \(0-65535\)"):
+        pdu.encode_response(CommEventCounterResponse(status=0x0000, event_count=0x10000))
+
+    # Decoding stays lenient: devices in the wild send other status values.
+    assert pdu.decode_response(b"\x0b\x12\x34\x00\x01") == CommEventCounterResponse(status=0x1234, event_count=1)
+
 
 # --- GetCommEventLogPDU (FC0C) Tests ---
 
@@ -473,3 +496,15 @@ def test_get_comm_event_log_encode_decode() -> None:
     # Invalid function code
     with pytest.raises(FunctionCodeError, match="Invalid function code"):
         pdu.decode_response(b"\x8c\x08\x00\x00\x01\x08\x01\x21\x20\x00")
+
+    # The 64-event maximum is accepted; one more is rejected.
+    max_events = CommEventLogResponse(status=0, event_count=0, message_count=0, events=b"\x20" * 64)
+    assert pdu.decode_response(pdu.encode_response(max_events)) == max_events
+
+    too_many = CommEventLogResponse(status=0, event_count=0, message_count=0, events=b"\x20" * 65)
+    with pytest.raises(ValueError, match="Comm event log length 65 exceeds the maximum of 64"):
+        pdu.encode_response(too_many)
+
+    # Decoding stays lenient for devices that report more than 64 events.
+    lenient = b"\x0c\x47\x00\x00\x00\x00\x00\x00" + b"\x20" * 65
+    assert pdu.decode_response(lenient).events == b"\x20" * 65


### PR DESCRIPTION
# Proposed Changes

Closes validation gaps in the serial-line, file record, and device identification PDUs where invalid values escaped as `struct.error`, `IndexError`, or silent wire corruption instead of a clear `ValueError`:

- `DiagnosticsQueryDataPDU.encode_response` now requires the response to echo the request length (a mismatch previously surfaced as a client CRC error).
- `ReportServerIdPDU.encode_response` rejects server IDs containing 0x00/0xFF — the decode heuristic treats the first such byte as the run indicator, so these round-tripped corrupted. The heuristic is now documented.
- `ReadFileRecordPDU.__init__` rejects requests whose implied response exceeds the 0xF5 byte cap (previously accepted, then failed server-side as SERVER_DEVICE_FAILURE).
- Both file PDUs' `get_expected_request_data_length` return `None` on empty data per the #128 contract, instead of `IndexError`.
- `GetCommEventLogPDU` enforces the spec's 64-event cap on encode; `GetCommEventCounterPDU` validates status (0x0000/0xFFFF) and count; `ReadDeviceIdentificationPDU.encode_response` validates device ID code and conformity level. Decode stays lenient for non-spec devices.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
