### PR TITLE
fix(transport): bound and linearize receive-buffer resynchronization

### DIFF
--- a/src/tmodbus/transport/async_rtu.py
+++ b/src/tmodbus/transport/async_rtu.py
@@ -100,6 +100,11 @@ class SerialXOptions(TypedDict):
 
 MAX_RTU_FRAME_SIZE = 256  # Maximum RTU frame size in bytes
 
+# The buffer never legitimately holds more than a frame in progress plus a few
+# delayed responses, so cap it at a small multiple of the maximum frame size and
+# trim the oldest bytes beyond it (mirroring the ASCII transport's frame cap).
+MAX_RTU_BUFFER_SIZE = 8 * MAX_RTU_FRAME_SIZE
+
 MIN_RTU_RESPONSE_LENGTH = 4  # a minimal response is: address + function code + CRC
 
 BITS_PER_CHAR = 11  # start + 8 data + parity/stop
@@ -339,6 +344,9 @@ class ModbusRtuProtocol(asyncio.Protocol):
     _last_frame_ended_at: float
     _pending_request: _PendingRequest | None
     _timed_out_requests: dict[int, BaseClientPDU[Any]]
+    _find_cache: dict[bytes, int]
+    _resync_discarded_bytes: int
+    _resync_discard_steps: int
 
     def __init__(
         self,
@@ -359,6 +367,9 @@ class ModbusRtuProtocol(asyncio.Protocol):
         self._last_frame_ended_at = 0.0
         self._pending_request = None
         self._timed_out_requests = {}
+        self._find_cache = {}
+        self._resync_discarded_bytes = 0
+        self._resync_discard_steps = 0
 
         self.connection_made_event = asyncio.Event()
 
@@ -483,16 +494,38 @@ class ModbusRtuProtocol(asyncio.Protocol):
         return headers
 
     def _find_next_frame_start(self, start: int, headers: set[bytes]) -> int:
-        """Find the index of the next plausible frame start starting from `start`."""
-        positions = [pos for h in headers if (pos := self._buffer.find(h, start)) != -1]
+        """Find the index of the next plausible frame start starting from `start`.
+
+        Header positions are cached as distances from the buffer end, which survive
+        front discards, so within one data_received call each header is searched at
+        most once past any byte instead of rescanning after every discard.
+        The cache stays valid because the buffer only shrinks from the front between
+        cache resets, and successive searches never start earlier in the stream.
+        """
+        buffer_length = len(self._buffer)
+        positions = []
+        for h in headers:
+            cached = self._find_cache.get(h)
+            if cached is not None:
+                if cached == 0:
+                    continue  # known absent from the rest of the buffer
+                pos = buffer_length - cached
+                if pos >= start:
+                    positions.append(pos)
+                    continue
+                # The cached match was discarded; fall through and search again.
+            pos = self._buffer.find(h, start)
+            self._find_cache[h] = 0 if pos == -1 else buffer_length - pos
+            if pos != -1:
+                positions.append(pos)
         if positions:
             return min(positions)
 
         # Check if the very last byte could be the unit_id of a frame whose FC hasn't arrived
-        if len(self._buffer) > start and any(h[0] == self._buffer[-1] for h in headers):
-            return len(self._buffer) - 1
+        if buffer_length > start and any(h[0] == self._buffer[-1] for h in headers):
+            return buffer_length - 1
 
-        return len(self._buffer)
+        return buffer_length
 
     def _discard_garbage_data(self) -> None:
         """Discard garbage data from the buffer."""
@@ -510,11 +543,13 @@ class ModbusRtuProtocol(asyncio.Protocol):
         discard_count = self._find_next_frame_start(0, headers)
         if discard_count > 0:
             discarded = bytes(self._buffer[:discard_count])
-            logger.warning(
+            logger.debug(
                 "Discarding %d byte(s): %s",
                 discard_count,
                 discarded.hex(" ").upper(),
             )
+            self._resync_discarded_bytes += discard_count
+            self._resync_discard_steps += 1
             del self._buffer[:discard_count]
 
     def _resync_discard_length(self) -> int:
@@ -594,9 +629,11 @@ class ModbusRtuProtocol(asyncio.Protocol):
                     msg = f"Cannot frame response with unsupported function code {function_code:#04x}"
                     raise RTUFrameError(msg, response_bytes=bytes(self._buffer)) from e
 
-            # memoryview avoids an intermediate bytearray copy on every incoming chunk
+            # memoryview avoids an intermediate bytearray copy on every incoming chunk.
+            # A valid frame never exceeds MAX_RTU_FRAME_SIZE, so cap the slice to keep
+            # the copy O(frame size) instead of O(buffer size) per pass.
             expected_response_data_length = pdu_class.get_expected_response_data_length(
-                bytes(memoryview(self._buffer)[2:])
+                bytes(memoryview(self._buffer)[2:MAX_RTU_FRAME_SIZE])
             )
 
             if expected_response_data_length is None:
@@ -681,12 +718,14 @@ class ModbusRtuProtocol(asyncio.Protocol):
             return None
 
         discard_length = self._resync_discard_length()
-        logger.warning(
+        logger.debug(
             "CRC validation failed for candidate frame (%d bytes: %s). Discarding %d byte(s) to resynchronize.",
             len(candidate_frame),
             candidate_frame.hex(" ").upper(),
             discard_length,
         )
+        self._resync_discarded_bytes += discard_length
+        self._resync_discard_steps += 1
         del self._buffer[:discard_length]
         return CRCError(response_bytes=candidate_frame)
 
@@ -750,6 +789,36 @@ class ModbusRtuProtocol(asyncio.Protocol):
         # next request keeps the inter-frame delay from the end of a received frame.
         self._last_frame_ended_at = time.monotonic()
 
+        # Cached header positions are measured from the buffer end, so new data voids them.
+        self._find_cache.clear()
+
+        # Nothing else bounds the buffer while the frame length stays undetermined, and a
+        # buffer this size cannot start with a framable response anyway, so keep only the
+        # newest bytes. This also bounds the resynchronization work for one hostile chunk.
+        if len(self._buffer) > MAX_RTU_BUFFER_SIZE:
+            trim_count = len(self._buffer) - MAX_RTU_BUFFER_SIZE
+            logger.warning(
+                "Receive buffer exceeded %d bytes; discarding the %d oldest byte(s).",
+                MAX_RTU_BUFFER_SIZE,
+                trim_count,
+            )
+            del self._buffer[:trim_count]
+
+        self._resync_discarded_bytes = 0
+        self._resync_discard_steps = 0
+        try:
+            self._process_buffer()
+        finally:
+            if self._resync_discarded_bytes:
+                # One summary per chunk: per-step details are logged at debug level.
+                logger.warning(
+                    "Discarding %d byte(s) in %d step(s) to resynchronize.",
+                    self._resync_discarded_bytes,
+                    self._resync_discard_steps,
+                )
+
+    def _process_buffer(self) -> None:
+        """Frame and deliver as many complete responses as the buffer holds."""
         last_error: Exception | None = None
 
         # Try to process complete frames
@@ -779,12 +848,14 @@ class ModbusRtuProtocol(asyncio.Protocol):
                 expected_total_frame_length = self._determine_expected_frame_length(pending.pdu)
             except (RTUFrameError, FunctionCodeError) as e:
                 discard_length = self._resync_discard_length()
-                logger.warning(
+                logger.debug(
                     "Framing error for unit %d: %s. Discarding %d byte(s) to resynchronize.",
                     unit_id,
                     e,
                     discard_length,
                 )
+                self._resync_discarded_bytes += discard_length
+                self._resync_discard_steps += 1
                 last_error = e
                 del self._buffer[:discard_length]
                 continue

--- a/src/tmodbus/transport/async_tcp.py
+++ b/src/tmodbus/transport/async_tcp.py
@@ -294,6 +294,32 @@ class ModbusTcpProtocol(asyncio.Protocol):
 
         return pdu.decode_response(response.pdu_bytes)
 
+    def _resync_discard_count(self) -> int:
+        """Get the number of leading bytes to discard to resynchronize on a bad MBAP header.
+
+        Looks for the next occurrence of 0x0000 (a candidate protocol id) whose length
+        field is also in range, starting past the current position so a bogus length
+        cannot loop on the same bytes. Checking the length here skips an unmatchable
+        run in one step instead of one byte per pass through the receive loop.
+        """
+        search_start = 3
+        while (next_protocol_id_pos := self._buffer.find(b"\x00\x00", search_start)) != -1:
+            if next_protocol_id_pos + 4 > len(self._buffer):
+                # The candidate's length field is not buffered yet: discard up to the
+                # potential start of the next message (the 2 transaction ID bytes
+                # before the found occurrence) and wait for more data.
+                break
+            (length,) = struct.unpack_from(">H", self._buffer, next_protocol_id_pos + 2)
+            if 1 <= length <= MODBUS_TCP_MAX_LENGTH:
+                break
+            search_start = next_protocol_id_pos + 1
+
+        if next_protocol_id_pos == -1:
+            # No occurrence found: discard everything except the last byte (in case it's part of a valid header)
+            return len(self._buffer) - 1
+
+        return next_protocol_id_pos - 2
+
     def data_received(self, data: bytes) -> None:
         """Handle data received event."""
         self._buffer.extend(data)
@@ -314,19 +340,9 @@ class ModbusTcpProtocol(asyncio.Protocol):
             # a bad protocol id, and trusting it would stall the parser forever waiting for
             # bytes that never come, so resync in that case too.
             if protocol_id != 0x0000 or not (1 <= length <= MODBUS_TCP_MAX_LENGTH):
-                # Look for the next occurrence of 0x0000 (a candidate protocol id), starting
-                # past the current position so a bogus length cannot loop on the same bytes.
-                next_protocol_id_pos = self._buffer.find(b"\x00\x00", 3)
-                if next_protocol_id_pos == -1:
-                    # No occurrence found: discard everything except the last byte (in case it's part of a valid header)
-                    logger.debug("Discarding garbage bytes: %s", self._buffer[:-1].hex(" ").upper())
-                    del self._buffer[:-1]
-                    return  # buffer is exhausted, wait for more data
-
-                # Discard bytes up to the potential start of the next message,
-                # keeping the 2 bytes before the found occurrence as the transaction ID.
-                logger.debug("Discarding garbage bytes: %s", self._buffer[: next_protocol_id_pos - 2].hex(" ").upper())
-                del self._buffer[: next_protocol_id_pos - 2]
+                discard_count = self._resync_discard_count()
+                logger.debug("Discarding garbage bytes: %s", self._buffer[:discard_count].hex(" ").upper())
+                del self._buffer[:discard_count]
                 continue  # Re-evaluate the buffer from the start
 
             # we have a valid protocol ID, now check if we have the full message

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -22,6 +22,7 @@ from tmodbus.exceptions import (
 from tmodbus.pdu.base import BaseClientPDU
 from tmodbus.pdu.serial_line import DiagnosticsQueryDataPDU
 from tmodbus.transport.async_rtu import (
+    MAX_RTU_BUFFER_SIZE,
     MAX_RTU_FRAME_SIZE,
     AsyncRtuTransport,
     ModbusRtuProtocol,
@@ -1454,6 +1455,76 @@ async def test_large_garbage_burst_resynchronizes(
 
     assert result == ("decoded", b"\x03\x05")
     assert len(protocol._buffer) == 0
+
+
+async def test_large_hostile_garbage_burst_is_bounded(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 64 KiB burst of expected-header false starts must not stall the event loop."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()  # FC 0x03
+    unit_id = 1
+
+    class DummyPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> int:
+            return 1
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: DummyPduClass)
+    protocol._last_frame_ended_at = time.monotonic() - 10
+
+    good_payload = bytes([unit_id, pdu.function_code, 0x05])
+    good_frame = good_payload + calculate_crc16(good_payload)
+
+    # False starts with the expected header (01 03) plus embedded exception headers
+    # (01 83), so every candidate frames but fails CRC.
+    garbage = (b"\x01\x03" * 100 + b"\x01\x83\x00\x00") * 320  # ~64 KiB
+
+    result_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu))
+    await asyncio.sleep(0.01)
+
+    started_at = time.monotonic()
+    protocol.data_received(garbage)
+    elapsed = time.monotonic() - started_at
+    # Generous ceiling: the quadratic resync took tens of seconds for this burst.
+    assert elapsed < 2.0
+
+    # A real response arriving after the burst must still be delivered.
+    protocol.data_received(good_frame)
+    result = await result_task
+    assert result == ("decoded", b"\x03\x05")
+
+
+async def test_receive_buffer_is_capped(
+    mock_transport: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The buffer must be trimmed to MAX_RTU_BUFFER_SIZE while the frame length stays undetermined."""
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None)
+    protocol.connection_made(mock_transport)
+
+    pdu = _DummyPDU()
+    unit_id = 1
+    fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+    protocol._pending_request = _PendingRequest(unit_id=unit_id, future=fut, pdu=pdu)
+
+    class UndecidedPduClass:
+        @staticmethod
+        def get_expected_response_data_length(_begin_bytes: bytes) -> None:
+            return None  # length never determinable: the buffer would otherwise grow forever
+
+    monkeypatch.setattr("tmodbus.transport.async_rtu.get_pdu_class", lambda _: UndecidedPduClass)
+
+    with caplog.at_level(logging.WARNING, logger="tmodbus.transport.async_rtu"):
+        protocol.data_received(bytes([unit_id, pdu.function_code]) * 1500)
+
+    assert len(protocol._buffer) == MAX_RTU_BUFFER_SIZE
+    assert any("Receive buffer exceeded" in record.message for record in caplog.records)
+    assert not fut.done()
 
 
 async def test_determine_expected_frame_length_subfunction_pdu(

--- a/tests/transport/test_async_tcp.py
+++ b/tests/transport/test_async_tcp.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import struct
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -211,6 +212,34 @@ async def test_protocol_data_received_out_of_range_length_resyncs() -> None:
 
     # A real response for the same transaction id must still be parsed.
     protocol.data_received(struct.pack(">HHHB", 1, 0x0000, 3, 1) + b"\x03\x99")
+    await asyncio.sleep(0.01)
+
+    assert future.done()
+    assert future.result().pdu_bytes == b"\x03\x99"
+
+
+async def test_protocol_data_received_zeros_flood_is_bounded() -> None:
+    """A 64 KiB flood of zero bytes must be discarded in one pass, not one byte per pass.
+
+    Every offset in an all-zeros buffer looks like a candidate protocol id, but its
+    length field (zero) can never be valid, so the resync must skip past the whole
+    run instead of re-parsing it one byte at a time.
+    """
+    protocol = ModbusTcpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
+    protocol.connection_made(MagicMock(spec=asyncio.WriteTransport))
+
+    future: asyncio.Future[_ModbusMessage] = asyncio.get_event_loop().create_future()
+    protocol._pending_requests[1] = future
+
+    started_at = time.monotonic()
+    protocol.data_received(b"\x00" * (64 * 1024))
+    elapsed = time.monotonic() - started_at
+    assert elapsed < 2.0  # generous ceiling to catch quadratic regressions
+    assert len(protocol._buffer) < 7  # the flood is discarded, not retained
+
+    # A real response after the flood (preceded by line noise that flushes the
+    # leftover zero bytes) must still be parsed.
+    protocol.data_received(b"\xff" * 7 + struct.pack(">HHHB", 1, 0x0000, 3, 1) + b"\x03\x99")
     await asyncio.sleep(0.01)
 
     assert future.done()


### PR DESCRIPTION
# Proposed Changes

A garbage burst freezes the event loop: the RTU resync rescanned the buffer from the front after every discarded candidate (quadratic) and logged one warning per step, and the RTU buffer had no size cap. Remotely reachable via RTU-over-TCP when a bridge delivers a large chunk in one read. TCP had a milder one-byte-per-pass variant on unmatchable runs.

Three changes:

1. Linear RTU resync — header search results are cached as distances from the buffer end, and the slice handed to the length hook is capped at one max frame. Framing behavior unchanged; existing tests pass unmodified.
2. `MAX_RTU_BUFFER_SIZE = 8 * MAX_RTU_FRAME_SIZE` (2048): oldest bytes are trimmed with a warning, mirroring the ASCII cap. A buffer this size can never start with a framable response, so only garbage or already-stalled data is dropped.
3. TCP resync validates the candidate length field while scanning, so an unmatchable run is discarded in one step.

Logging is now one summary warning per `data_received` call; per-step detail moved to debug.

Measured (single hostile chunk, mock transport): RTU 16 KiB `01 03` repeats 4.4 s → 7 ms; RTU 64 KiB 35 s → 5 ms; TCP 64 KiB zeros 0.86 s → 0.22 s.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
