### PR TITLE
perf: fast paths for PDU validation, struct reuse, and CRC checks

### DIFF
--- a/src/tmodbus/pdu/holding_registers.py
+++ b/src/tmodbus/pdu/holding_registers.py
@@ -223,12 +223,16 @@ class ReadHoldingRegistersPDU(BasePDU[list[int]]):
             msg = f"Invalid number of read values: expected {self.quantity}, got {len(value)}"
             raise ValueError(msg)
 
-        for idx, val in enumerate(value):
-            if not (0 <= val < 65536):
-                msg = f"Invalid read value {val} on index {idx}: must be between 0 and 65535"
-                raise ValueError(msg)
+        try:
+            # 'H' rejects values outside 0..65535, so packing doubles as range validation.
+            data = struct.pack(f">{len(value)}H", *value)
+        except struct.error:
+            for idx, val in enumerate(value):
+                if not (0 <= val < 65536):
+                    msg = f"Invalid read value {val} on index {idx}: must be between 0 and 65535"
+                    raise ValueError(msg) from None
+            raise  # non-integer value: propagate struct.error as before
 
-        data = struct.pack(f">{len(value)}H", *value)
         return struct.pack(">BB", self.function_code, len(data)) + data
 
 
@@ -558,14 +562,28 @@ class WriteMultipleRegistersPDU(BasePDU[int]):
             msg = "Number of registers must be between 1 and 123."
             raise ValueError(msg)
 
-        for value in values:
-            if not (0 <= value < 65536):
-                msg = f"Value must be between 0 and 65535: {value}"
-                raise ValueError(msg)
+        try:
+            # 'H' rejects values outside 0..65535, so packing doubles as range validation.
+            content = struct.pack(f">{len(values)}H", *values)
+        except struct.error:
+            for value in values:
+                if not (0 <= value < 65536):
+                    msg = f"Value must be between 0 and 65535: {value}"
+                    raise ValueError(msg) from None
+            raise  # non-integer value: propagate struct.error as before
+
+        if start_address + len(values) > 65536:
+            msg = "Start address plus number of registers must not exceed 65536."
+            raise ValueError(msg)
 
         self.values = values
 
-        self.raw_pdu = RawWriteMultipleRegistersPDU(start_address, struct.pack(f">{len(values)}H", *values))
+        # Everything is validated above; skip RawWriteMultipleRegistersPDU.__init__
+        # so the same checks do not run a second time.
+        raw_pdu = RawWriteMultipleRegistersPDU.__new__(RawWriteMultipleRegistersPDU)
+        raw_pdu.start_address = start_address
+        raw_pdu.content = content
+        self.raw_pdu = raw_pdu
 
     def encode_request(self) -> bytes:
         """Convert PDU to bytes.
@@ -822,10 +840,15 @@ class ReadWriteMultipleRegistersPDU(BasePDU[list[int]]):
             msg = "Write starting address plus number of registers to write must not exceed 65536."
             raise ValueError(msg)
 
-        for idx, value in enumerate(self.write_values):
-            if not (0 <= value < 65536):
-                msg = f"Invalid write value {value} on index {idx}: must be between 0 and 65535"
-                raise ValueError(msg)
+        try:
+            # 'H' rejects values outside 0..65535, so packing doubles as range validation.
+            struct.pack(f">{len(self.write_values)}H", *self.write_values)
+        except struct.error:
+            for idx, value in enumerate(self.write_values):
+                if not (0 <= value < 65536):
+                    msg = f"Invalid write value {value} on index {idx}: must be between 0 and 65535"
+                    raise ValueError(msg) from None
+            raise  # non-integer value: propagate struct.error as before
 
     def encode_request(self) -> bytes:
         """Convert PDU to bytes.
@@ -951,9 +974,12 @@ class ReadWriteMultipleRegistersPDU(BasePDU[list[int]]):
             msg = f"Invalid number of read values: expected {self.read_quantity}, got {len(value)}"
             raise ValueError(msg)
 
-        for idx, val in enumerate(value):
-            if not (0 <= val < 65536):
-                msg = f"Invalid read value {val} on index {idx}: must be between 0 and 65535"
-                raise ValueError(msg)
-
-        return struct.pack(f">BB{len(value)}H", self.function_code, len(value) * 2, *value)
+        try:
+            # 'H' rejects values outside 0..65535, so packing doubles as range validation.
+            return struct.pack(f">BB{len(value)}H", self.function_code, len(value) * 2, *value)
+        except struct.error:
+            for idx, val in enumerate(value):
+                if not (0 <= val < 65536):
+                    msg = f"Invalid read value {val} on index {idx}: must be between 0 and 65535"
+                    raise ValueError(msg) from None
+            raise  # non-integer value: propagate struct.error as before

--- a/src/tmodbus/pdu/holding_registers_struct.py
+++ b/src/tmodbus/pdu/holding_registers_struct.py
@@ -1,5 +1,6 @@
 """Holding Registers utilities."""
 
+from functools import lru_cache
 from struct import Struct
 from typing import Any, Literal, Protocol, TypeVar, cast
 
@@ -9,6 +10,16 @@ from .base import BasePDU
 from .holding_registers import RawReadHoldingRegistersPDU, RawReadInputRegistersPDU, RawWriteMultipleRegistersPDU
 
 RT = TypeVar("RT")
+
+
+@lru_cache(maxsize=128)
+def _get_order_aware_struct(
+    fmt: str,
+    word_order: Literal["big", "little"],
+    byte_order: Literal["big", "little"],
+) -> OrderAwareStruct:
+    """Build (or reuse) an OrderAwareStruct: construction parses the format, a cache hit is ~100x cheaper."""
+    return OrderAwareStruct(fmt, word_order=word_order, byte_order=byte_order)
 
 
 class SupportsExecuteAsync(Protocol):
@@ -76,11 +87,9 @@ class HoldingRegisterReadMixin(SupportsExecuteAsync):
         # This way, it is possible for the user to override the word_order and/or byte_order
         # for this specific request, deviating from the instance defaults.
         if isinstance(format_struct, Struct) and not isinstance(format_struct, OrderAwareStruct):
-            format_struct = OrderAwareStruct(
-                format_struct.format, word_order=self.word_order, byte_order=self.byte_order
-            )
+            format_struct = _get_order_aware_struct(format_struct.format, self.word_order, self.byte_order)
         if isinstance(format_struct, str):
-            format_struct = OrderAwareStruct(format_struct, word_order=self.word_order, byte_order=self.byte_order)
+            format_struct = _get_order_aware_struct(format_struct, self.word_order, self.byte_order)
 
         response_bytes = await self.execute(
             pdu_class(
@@ -355,9 +364,7 @@ class HoldingRegisterReadMixin(SupportsExecuteAsync):
             Decoded string value.
 
         """
-        format_struct = OrderAwareStruct(
-            f">{number_of_registers * 2}s", word_order=self.word_order, byte_order=self.byte_order
-        )
+        format_struct = _get_order_aware_struct(f">{number_of_registers * 2}s", self.word_order, self.byte_order)
         string_bytes = cast(
             "bytes",
             await self.read_simple_struct_format(
@@ -422,11 +429,9 @@ class HoldingRegisterWriteMixin(SupportsExecuteAsync):
         """
         # Keep a user-provided OrderAwareStruct as-is: it already carries its own orders.
         if isinstance(format_struct, Struct) and not isinstance(format_struct, OrderAwareStruct):
-            format_struct = OrderAwareStruct(
-                format_struct.format, word_order=self.word_order, byte_order=self.byte_order
-            )
+            format_struct = _get_order_aware_struct(format_struct.format, self.word_order, self.byte_order)
         if isinstance(format_struct, str):
-            format_struct = OrderAwareStruct(format_struct, word_order=self.word_order, byte_order=self.byte_order)
+            format_struct = _get_order_aware_struct(format_struct, self.word_order, self.byte_order)
 
         return await self.execute(
             RawWriteMultipleRegistersPDU(
@@ -693,9 +698,7 @@ class HoldingRegisterWriteMixin(SupportsExecuteAsync):
             msg = f"String length exceeds maximum size of {max_length} bytes."
             raise ValueError(msg)
 
-        format_struct = OrderAwareStruct(
-            f">{number_of_registers * 2}s", word_order=self.word_order, byte_order=self.byte_order
-        )
+        format_struct = _get_order_aware_struct(f">{number_of_registers * 2}s", self.word_order, self.byte_order)
         # Pad with null bytes if necessary
         value_bytes = value_bytes.ljust(format_struct.size, b"\x00")
 

--- a/src/tmodbus/utils/crc.py
+++ b/src/tmodbus/utils/crc.py
@@ -66,11 +66,11 @@ def validate_crc16(frame_with_crc: bytes) -> bool:
     if len(frame_with_crc) < 3:  #  At least 1 byte data + 2 bytes CRC required
         return False
 
-    #  Separate data and CRC
-    data, received_crc = frame_with_crc[:-2], frame_with_crc[-2:]
+    # Folding the frame's own little-endian CRC into the running CRC yields 0,
+    # so the whole frame can be checked in one pass without slicing.
+    crc = 0xFFFF
 
-    # Calculate expected CRC
-    expected_crc = calculate_crc16(data)
+    for byte in frame_with_crc:
+        crc = (crc >> 8) ^ _CRC16_TABLE[(crc ^ byte) & 0xFF]
 
-    # Compare CRC
-    return received_crc == expected_crc
+    return crc == 0

--- a/src/tmodbus/utils/order_aware_struct.py
+++ b/src/tmodbus/utils/order_aware_struct.py
@@ -148,10 +148,11 @@ class OrderAwareStruct(struct.Struct):
         return lengths
 
     def _swap_word_order(self, data: "ReadableBuffer") -> bytes:
-        """Swap the word/byte order of each multi-register value based on the settings."""
-        if not self._value_lengths:
-            # ABCD byte order (standard), no need to swap
-            return bytes(data)
+        """Swap the word/byte order of each multi-register value based on the settings.
+
+        Callers only get here when reordering is configured (``_value_lengths`` is set).
+        """
+        assert self._value_lengths is not None  # callers guarantee this
 
         # Apply byte order transformation per value; single-register and sub-register
         # values are never reordered. The constructor guarantees every multi-byte value
@@ -218,10 +219,18 @@ class OrderAwareStruct(struct.Struct):
 
     def unpack(self, buffer: "ReadableBuffer") -> tuple[Any, ...]:
         """Unpack buffer with word order consideration."""
+        if not self._value_lengths:
+            # No reordering configured: skip the copy and use the C implementation directly.
+            return super().unpack(buffer)
         return super().unpack(self._swap_word_order(buffer))
 
     def unpack_from(self, buffer: "ReadableBuffer", offset: int = 0) -> tuple[Any, ...]:
         """Unpack from buffer with word order consideration."""
+        if not self._value_lengths:
+            # No reordering configured: the C implementation handles negative offsets
+            # itself, with the same error messages as the checks below.
+            return super().unpack_from(buffer, offset)
+
         # Handle negative offsets correctly
         if offset < 0:
             buf_len = len(memoryview(buffer))
@@ -255,10 +264,19 @@ class OrderAwareStruct(struct.Struct):
 
     def pack(self, *args: Any) -> bytes:
         """Pack values into bytes with word order consideration."""
+        if not self._value_lengths:
+            # No reordering configured: skip the copy and use the C implementation directly.
+            return super().pack(*args)
         return self._swap_word_order(super().pack(*args))
 
     def pack_into(self, buffer: "WriteableBuffer", offset: int, *args: Any) -> None:
         """Pack values into buffer with word order consideration."""
+        if not self._value_lengths:
+            # No reordering configured: the C implementation handles negative offsets and
+            # bounds checks itself, with the same error messages as the checks below.
+            super().pack_into(buffer, offset, *args)
+            return
+
         view = memoryview(buffer)
         # Mirror struct.Struct.pack_into: bounds-check instead of resizing the buffer,
         # and resolve negative offsets from the buffer end.

--- a/tests/pdu/test_holding_registers.py
+++ b/tests/pdu/test_holding_registers.py
@@ -1,5 +1,7 @@
 """Tests for tmodbus/pdu/holding_registers.py ."""
 
+import struct
+
 import pytest
 from tmodbus.exceptions import InvalidRequestError, InvalidResponseError
 from tmodbus.pdu import ReadHoldingRegistersPDU, WriteMultipleRegistersPDU, WriteSingleRegisterPDU
@@ -355,6 +357,12 @@ class TestReadInputRegistersPDU:
         with pytest.raises(ValueError, match=r"Invalid read value 65536 on index 1: must be between 0 and 65535"):
             pdu.encode_response([100, 65536])
 
+    def test_encode_response_non_integer_value(self) -> None:
+        """Test encode_response raises struct.error on a non-integer value, like struct.pack."""
+        pdu = ReadInputRegistersPDU(start_address=100, quantity=2)
+        with pytest.raises(struct.error):
+            pdu.encode_response([100, 1.5])  # type: ignore[list-item]
+
 
 # ============================================================================
 # WriteSingleRegisterPDU Additional Tests
@@ -672,6 +680,16 @@ class TestWriteMultipleRegistersPDU:
 
         with pytest.raises(ValueError, match=r"Value must be between 0 and 65535: 70000"):
             WriteMultipleRegistersPDU(start_address=1, values=[70000])
+
+    def test_write_multiple_registers_invalid_value_after_valid_value(self) -> None:
+        """Test the out-of-range error reports the offending value, not an earlier valid one."""
+        with pytest.raises(ValueError, match=r"Value must be between 0 and 65535: 70000"):
+            WriteMultipleRegistersPDU(start_address=1, values=[123, 70000])
+
+    def test_write_multiple_registers_non_integer_value(self) -> None:
+        """Test a non-integer value raises struct.error, like struct.pack."""
+        with pytest.raises(struct.error):
+            WriteMultipleRegistersPDU(start_address=1, values=[1.5])  # type: ignore[list-item]
 
     def test_write_multiple_registers_address_overflow_validation(self) -> None:
         """The written range must stay within the 16-bit address space."""
@@ -1025,6 +1043,26 @@ class TestReadWriteMultipleRegistersPDU:
                 write_values=write_vals,
             )
 
+    def test_initialization_invalid_write_value_after_valid_value(self) -> None:
+        """Test the out-of-range error reports the offending index, not an earlier valid one."""
+        with pytest.raises(ValueError, match=r"Invalid write value 65536 on index 1: must be between 0 and 65535"):
+            ReadWriteMultipleRegistersPDU(
+                read_start_address=100,
+                read_quantity=10,
+                write_start_address=100,
+                write_values=[1, 65536],
+            )
+
+    def test_initialization_non_integer_write_value(self) -> None:
+        """Test a non-integer write value raises struct.error, like struct.pack."""
+        with pytest.raises(struct.error):
+            ReadWriteMultipleRegistersPDU(
+                read_start_address=100,
+                read_quantity=10,
+                write_start_address=100,
+                write_values=[1.5],  # type: ignore[list-item]
+            )
+
     def test_encode_request(self) -> None:
         """Test encoding request PDU."""
         pdu = ReadWriteMultipleRegistersPDU(
@@ -1338,6 +1376,18 @@ class TestReadWriteMultipleRegistersPDU:
 
         with pytest.raises(ValueError, match=r"Invalid read value -1 on index 0: must be between 0 and 65535"):
             pdu.encode_response([-1, 100])
+
+    def test_encode_response_non_integer_value(self) -> None:
+        """Test encode_response raises struct.error on a non-integer value, like struct.pack."""
+        pdu = ReadWriteMultipleRegistersPDU(
+            read_start_address=0,
+            read_quantity=2,
+            write_start_address=10,
+            write_values=[1, 2],
+        )
+
+        with pytest.raises(struct.error):
+            pdu.encode_response([100, 1.5])  # type: ignore[list-item]
 
     def test_round_trip_encode_decode(self) -> None:
         """Test that encoding and decoding produces the same values."""

--- a/tests/utils/test_order_aware_struct.py
+++ b/tests/utils/test_order_aware_struct.py
@@ -238,6 +238,30 @@ def test_unpack_from_negative_offset_out_of_range() -> None:
         s.unpack_from(data, offset=-5)
 
 
+def test_unpack_from_negative_offset_success_with_reordering() -> None:
+    """Test unpack_from resolves valid negative offsets when reordering is configured."""
+    s = OrderAwareStruct(">I", word_order="little")
+    data = b"\xaa\xbb" + s.pack(0x0A0B0C0D)
+    result = s.unpack_from(data, offset=-4)
+    assert result == (0x0A0B0C0D,)
+
+
+def test_unpack_from_negative_offset_not_enough_data_with_reordering() -> None:
+    """Test unpack_from raises on trailing partial value when reordering is configured."""
+    s = OrderAwareStruct(">I", word_order="little")
+    data = b"\x00\x01\x02\x03"
+    with pytest.raises(struct.error, match="not enough data to unpack 4 bytes at offset -2"):
+        s.unpack_from(data, offset=-2)
+
+
+def test_unpack_from_negative_offset_out_of_range_with_reordering() -> None:
+    """Test unpack_from raises on out-of-range negative offset when reordering is configured."""
+    s = OrderAwareStruct(">I", word_order="little")
+    data = b"\x00\x01\x02\x03"
+    with pytest.raises(struct.error, match="offset -5 out of range for 4-byte buffer"):
+        s.unpack_from(data, offset=-5)
+
+
 @pytest.mark.parametrize(
     ("word_order", "byte_order"),
     [("big", "big"), ("little", "big"), ("big", "little"), ("little", "little")],
@@ -261,6 +285,14 @@ def test_pack_into() -> None:
     buffer = bytearray(8)
     s.pack_into(buffer, 2, 0x0A0B0C0D)
     assert buffer == b"\x00\x00\x0c\x0d\x0a\x0b\x00\x00"
+
+
+def test_pack_into_no_reordering() -> None:
+    """Test pack_into delegates to the plain struct implementation when no reordering applies."""
+    s = OrderAwareStruct(">I", word_order="big")
+    buffer = bytearray(8)
+    s.pack_into(buffer, 2, 0x0A0B0C0D)
+    assert buffer == b"\x00\x00\x0a\x0b\x0c\x0d\x00\x00"
 
 
 def test_pack_into_too_small_buffer_raises() -> None:


### PR DESCRIPTION
# Proposed Changes

Four measured hot-path optimizations. Wire bytes, return values, and error messages are identical; the full suite passes unchanged. Numbers are interleaved A/B `timeit` runs.

1. Let `struct.pack('>{n}H')` do register range validation instead of a Python loop; the loop runs only in the error path to reproduce the exact messages. Also drops the wrapper→Raw double validation in `WriteMultipleRegistersPDU` (via `__new__`; happy to restructure if you'd rather not skip Raw's `__init__`). Init 10 values −44%, 123 values −64%; `ReadHoldingRegistersPDU.encode_response` −50%.
2. `lru_cache(maxsize=128)` for `OrderAwareStruct` construction in the struct mixins (construction 14–23 µs vs 0.1–0.3 µs cache hit; single-float CDAB read ~46 → ~17 µs). Keyed on the orders at call time, so post-construction reassignment still works.
3. `OrderAwareStruct` delegates straight to C `struct.Struct` when no reordering applies (default big/big): pack −47%, unpack −28%.
4. `validate_crc16` uses the CRC(frame‖crc) == 0 property — one pass, no slicing: −50% on short frames.

One deliberate shift: `ReadWriteMultipleRegistersPDU` rejects non-integer write values at construction instead of later in `encode_request`.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
