### PR TITLE
fix(server): bind handler return types to the PDU payload type

### DIFF
--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -22,10 +22,12 @@ The recommended way to structure your server's request handling is using the
 :class:`~tmodbus.server.ModbusRequestRouter` class.
 
 `ModbusRequestRouter` maps incoming Modbus function codes/PDU types to specific handler
-functions. The key advantage of the router is **full static type safety**: Python type
+functions. The key advantage of the router is **static return type safety**: Python type
 checkers (like mypy and pyright) will check and enforce that each registered handler
 returns the correct response payload type for its specific request PDU (e.g. returning a
-list of integers `list[int]` for a `ReadHoldingRegistersPDU`).
+list of integers `list[int]` for a `ReadHoldingRegistersPDU`). Handler parameter types
+are not checked statically; the router inspects them at runtime to detect context-aware
+handlers.
 
 Here is a complete example of setting up a TCP server using `ModbusRequestRouter`:
 

--- a/src/tmodbus/server/handler.py
+++ b/src/tmodbus/server/handler.py
@@ -190,9 +190,9 @@ class ModbusRequestRouter(ModbusHandler):
         """Check if the handler supports the given unit ID."""
         return None in self._handlers or unit_id in self._handlers
 
-    def register[T, PDU: BasePDU[Any]](
+    def register[T](
         self,
-        pdu_class: type[PDU],
+        pdu_class: type[BasePDU[T]],
         *,
         unit_id: int | Iterable[int] | None = None,
     ) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:


### PR DESCRIPTION
# Proposed Changes

The docs claim type checkers validate handler return types against the registered PDU's payload, but `register[T, PDU: BasePDU[Any]]` never linked `T` to the payload type — a `str`-returning handler for `ReadHoldingRegistersPDU` passed `mypy --strict` and pyright with zero errors.

Changed to `register[T](pdu_class: type[BasePDU[T]], ...)`, binding `T` to the payload. Verified with both checkers: the wrong-return handlers now error, correct handlers (both arities, all `unit_id` variants) still pass, and no new errors appear anywhere in the repo. `server.rst`'s "full static type safety" is tightened to return-type safety (parameters stay gradual).

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
