### PR TITLE
docs: fix examples and complete reference lists

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -93,7 +93,9 @@ When the server responds with an error, tModbus will raise the corresponding sub
 - 0x0A Gateway path unavailable:
   :class:`~tmodbus.exceptions.GatewayPathUnavailableError`
 - 0x0B Gateway target device failed to respond:
-  :class:`~tmodbus.exceptions.GatewayTargetDeviceFailedToRespondError`.
+  :class:`~tmodbus.exceptions.GatewayTargetDeviceFailedToRespondError`
+- 0xAB Abnormal device description:
+  :class:`~tmodbus.exceptions.AbnormalDeviceDescriptionError`.
 
 If an unknown exception code is returned, an
 :class:`~tmodbus.exceptions.UnknownModbusResponseError` will be raised.
@@ -102,6 +104,7 @@ When the server responds with an invalid response, tModbus will raise the corres
 subclass of :class:`~tmodbus.exceptions.InvalidResponseError`:
 
 - RTU Frame Error: :class:`~tmodbus.exceptions.RTUFrameError`
+- ASCII Frame Error: :class:`~tmodbus.exceptions.ASCIIFrameError`
 - Invalid CRC: :class:`~tmodbus.exceptions.CRCError`
 - Invalid LRC: :class:`~tmodbus.exceptions.LRCError`
 - Header mismatch: :class:`~tmodbus.exceptions.HeaderMismatchError`

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -11,7 +11,7 @@ The library consists of the following layers:
   communication. Users can act as a **client** using convenience interfaces to read and
   write data, or run a **server** to listen for and process incoming requests.
 - **Transport layer**: This layer handles communication over underlying protocols (e.g.,
-  TCP, RTU, ASCII) for both clients and servers, abstracting the stream/packet
+  TCP, UDP, RTU, ASCII) for both clients and servers, abstracting the stream/packet
   transmission.
 - **PDU layer**: This layer is responsible for constructing, parsing, encoding, and
   decoding Modbus Protocol Data Units (PDUs), ensuring conformity to the Modbus
@@ -78,6 +78,7 @@ interface for transport implementations.
 The specific transport protocols are implemented in the following classes:
 
 - :class:`tmodbus.transport.AsyncTcpTransport`: Implements Modbus over TCP.
+- :class:`tmodbus.transport.AsyncUdpTransport`: Implements Modbus over UDP.
 - :class:`tmodbus.transport.AsyncRtuTransport`: Implements Modbus over RTU.
 - :class:`tmodbus.transport.AsyncAsciiTransport`: Implements Modbus over ASCII.
 - :class:`tmodbus.transport.AsyncRtuOverTcpTransport`: Implements Modbus RTU over TCP.

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -80,6 +80,18 @@ Here is a complete example of setting up a TCP server using `ModbusRequestRouter
     if __name__ == "__main__":
         asyncio.run(main())
 
+Handlers can also be registered for one or more specific unit IDs by passing the
+``unit_id`` parameter to ``register()``. Handlers registered without a ``unit_id`` act
+as a wildcard fallback for all unit IDs.
+
+.. note::
+
+   The wildcard fallback applies per unit ID, not per function code. As soon as any
+   handler is registered for a specific unit ID, wildcard handlers no longer apply to
+   that unit ID: requests to that unit for other function codes raise
+   :exc:`~tmodbus.exceptions.IllegalFunctionError` instead of falling back to a
+   wildcard handler.
+
 *************************************
  Implementing ModbusHandler Directly
 *************************************
@@ -370,8 +382,8 @@ Listen-Only mode:
             # 2. Handle Restart Communications Option (FC08 sub 1)
             if isinstance(request, DiagnosticsRestartCommunicationsOptionPDU):
                 self.listen_only_mode = False
-                # Echo data (0x0000 or 0xFF00) back to client
-                return cast(T, request.data)
+                # Echo the clear-event-log flag back to the client
+                return cast(T, request.clear_event_log)
 
             # 3. Delegate to standard request router
             response = await self.inner_router(unit_id, request)

--- a/examples/async_tcp_tls_server.py
+++ b/examples/async_tcp_tls_server.py
@@ -77,7 +77,7 @@ async def run():
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     ctx.load_verify_locations('examples/certs/ca.cert.pem')
     ctx.load_cert_chain('examples/certs/operator-client.cert.pem', 'examples/certs/operator-client.key.pem')
-    async with create_async_tcp_client('127.0.0.1', 8020, ssl=ctx) as client:
+    async with create_async_tcp_client('127.0.0.1', 8020, unit_id=1, ssl=ctx) as client:
         print('Registers:', await client.read_holding_registers(0, 2))
 
 asyncio.run(run())
@@ -93,7 +93,7 @@ async def run():
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     ctx.load_verify_locations('examples/certs/ca.cert.pem')
     ctx.load_cert_chain('examples/certs/user-client.cert.pem', 'examples/certs/user-client.key.pem')
-    async with create_async_tcp_client('127.0.0.1', 8020, ssl=ctx) as client:
+    async with create_async_tcp_client('127.0.0.1', 8020, unit_id=1, ssl=ctx) as client:
         try:
             await client.read_holding_registers(0, 2)
         except ModbusResponseError as e:


### PR DESCRIPTION
# Proposed Changes

Documentation fixes:

- `server.rst`: the listen-only example returned `cast(T, request.data)` — that attribute doesn't exist; now `request.clear_event_log`. Also documents that a unit-specific registration stops wildcard fallback for that unit ID.
- `examples/async_tcp_tls_server.py`: the docstring's client snippets omitted the required `unit_id` argument.
- `architecture.rst`: added the missing `AsyncUdpTransport`.
- `api.rst`: added `AbnormalDeviceDescriptionError` and `ASCIIFrameError` to the curated exception lists.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
