### PR TITLE
test: remove wall-clock races from transport protocol tests

### DIFF
--- a/tests/transport/test_async_ascii.py
+++ b/tests/transport/test_async_ascii.py
@@ -545,7 +545,10 @@ async def test_protocol_interframe_gap(mock_transport: MagicMock) -> None:
     protocol.data_received(response_frame)
     await task1
 
-    # Send second request - should wait for gap
+    # Send second request - should wait for gap.
+    # Re-prime the gap timer so the remaining-gap assertion below does not
+    # depend on real elapsed time since the response above.
+    protocol._last_frame_ended_at = time.monotonic()
     orig_sleep = asyncio.sleep
     with patch("asyncio.sleep", wraps=asyncio.sleep) as mock_sleep:
         asyncio.create_task(protocol.send_and_receive(1, pdu))  # noqa: RUF006
@@ -618,7 +621,7 @@ async def test_protocol_invalid_frame(mock_transport: MagicMock) -> None:
     """Test handling invalid frame (bad LRC) for pending request."""
     protocol = ModbusAsciiProtocol(
         on_connection_lost=lambda _exc: None,
-        timeout=0.1,
+        timeout=10.0,
     )
     protocol.connection_made(mock_transport)
 
@@ -799,18 +802,23 @@ async def test_protocol_multiple_frames(mock_transport: MagicMock) -> None:
 
     assert protocol._timed_out_requests[unit_id] is pdu1
 
+    # The tight timeout was only needed to make request 1 time out; request 2
+    # must not race the wall clock, so give it a generous timeout.
+    protocol.timeout = 10.0
+
     # Build delayed response for request 1 and valid response for request 2
     frame1 = build_ascii_frame(unit_id, b"\x03\x02\xaa\xbb")
     frame2 = build_ascii_frame(unit_id, b"\x06\x00\x01\x11\x22")
 
-    async def deliver_both_frames() -> None:
-        await asyncio.sleep(0.01)
-        # Send both frames at once in single data_received call
-        protocol.data_received(frame1 + frame2)
+    req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
+    while protocol._pending_request is None:
+        assert not req2_task.done()
+        await asyncio.sleep(0)
 
-    deliv_task = asyncio.create_task(deliver_both_frames())
-    res2 = await protocol.send_and_receive(unit_id, pdu2)
-    await deliv_task
+    # Send both frames at once in single data_received call
+    protocol.data_received(frame1 + frame2)
+
+    res2 = await req2_task
 
     assert res2 == ("decoded", b"\x06\x00\x01\x11\x22")
     assert len(protocol._buffer) == 0
@@ -1274,27 +1282,29 @@ async def test_delayed_response_during_active_request_same_unit(
     assert protocol._timed_out_requests[unit_id] is pdu1
 
     # Step 2: Request 2 (FC 0x06) is sent and active
+    # The tight timeout was only needed to make request 1 time out; request 2
+    # must not race the wall clock, so give it a generous timeout.
+    protocol.timeout = 10.0
+
     delayed_frame_1 = build_ascii_frame(unit_id, b"\x03\x02\xaa\xbb")
     real_frame_2 = build_ascii_frame(unit_id, b"\x06\x00\x01\x11\x22")
 
-    async def deliver_delayed_then_real() -> None:
-        await asyncio.sleep(0.01)
-        # Deliver late response for request 1
-        protocol.data_received(delayed_frame_1)
-        # Active request should still be pending and not failed
-        assert protocol._pending_request is not None
-        assert not protocol._pending_request.future.done()
-        assert unit_id not in protocol._timed_out_requests
-
-        # Deliver real response for request 2
-        await asyncio.sleep(0.01)
-        protocol.data_received(real_frame_2)
-
     req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
-    deliv_task = asyncio.create_task(deliver_delayed_then_real())
+    while protocol._pending_request is None:
+        assert not req2_task.done()
+        await asyncio.sleep(0)
+
+    # Deliver late response for request 1
+    protocol.data_received(delayed_frame_1)
+    # Active request should still be pending and not failed
+    assert protocol._pending_request is not None
+    assert not protocol._pending_request.future.done()
+    assert unit_id not in protocol._timed_out_requests
+
+    # Deliver real response for request 2
+    protocol.data_received(real_frame_2)
 
     result = await req2_task
-    await deliv_task
 
     assert result == ("decoded", b"\x06\x00\x01\x11\x22")
     assert len(protocol._buffer) == 0
@@ -1371,17 +1381,20 @@ async def test_active_request_succeeds_and_clears_stale_timed_out_request(
     assert protocol._timed_out_requests[unit_id] is pdu1
 
     # Request 2 is sent and succeeds
+    # The tight timeout was only needed to make request 1 time out; request 2
+    # must not race the wall clock, so give it a generous timeout.
+    protocol.timeout = 10.0
+
     response = build_ascii_frame(unit_id, b"\x03\x02\x00\x55")
 
-    async def deliver_response() -> None:
-        await asyncio.sleep(0.01)
-        protocol.data_received(response)
-
     req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
-    deliv_task = asyncio.create_task(deliver_response())
+    while protocol._pending_request is None:
+        assert not req2_task.done()
+        await asyncio.sleep(0)
+
+    protocol.data_received(response)
 
     result = await req2_task
-    await deliv_task
 
     assert result == ("decoded", b"\x03\x02\x00\x55")
     assert unit_id not in protocol._timed_out_requests
@@ -1527,32 +1540,34 @@ async def test_corrupt_delayed_frame_during_active_request_keeps_tracking(
     assert protocol._timed_out_requests[unit_id] is pdu1
 
     # Step 2: Request 2 (FC 0x06) is sent and active
+    # The tight timeout was only needed to make request 1 time out; request 2
+    # must not race the wall clock, so give it a generous timeout.
+    protocol.timeout = 10.0
+
     good_delayed_1 = build_ascii_frame(unit_id, b"\x03\x02\xaa\xbb")
     corrupt_delayed_1 = good_delayed_1.replace(b"AABB", b"AABC")  # data changed, LRC now invalid
     real_frame_2 = build_ascii_frame(unit_id, b"\x06\x00\x01\x11\x22")
 
-    async def deliver_frames() -> None:
-        await asyncio.sleep(0.01)
-        # Corrupt delayed frame: discarded, tracking retained, active request unaffected
-        protocol.data_received(corrupt_delayed_1)
-        assert protocol._pending_request is not None
-        assert not protocol._pending_request.future.done()
-        assert protocol._timed_out_requests[unit_id] is pdu1
-
-        # Real delayed frame clears the tracking
-        protocol.data_received(good_delayed_1)
-        assert unit_id not in protocol._timed_out_requests
-        assert not protocol._pending_request.future.done()
-
-        # Deliver real response for request 2
-        await asyncio.sleep(0.01)
-        protocol.data_received(real_frame_2)
-
     req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
-    deliv_task = asyncio.create_task(deliver_frames())
+    while protocol._pending_request is None:
+        assert not req2_task.done()
+        await asyncio.sleep(0)
+
+    # Corrupt delayed frame: discarded, tracking retained, active request unaffected
+    protocol.data_received(corrupt_delayed_1)
+    assert protocol._pending_request is not None
+    assert not protocol._pending_request.future.done()
+    assert protocol._timed_out_requests[unit_id] is pdu1
+
+    # Real delayed frame clears the tracking
+    protocol.data_received(good_delayed_1)
+    assert unit_id not in protocol._timed_out_requests
+    assert not protocol._pending_request.future.done()
+
+    # Deliver real response for request 2
+    protocol.data_received(real_frame_2)
 
     result = await req2_task
-    await deliv_task
 
     assert result == ("decoded", b"\x06\x00\x01\x11\x22")
     assert len(protocol._buffer) == 0

--- a/tests/transport/test_async_rtu.py
+++ b/tests/transport/test_async_rtu.py
@@ -567,16 +567,21 @@ async def test_protocol_per_unit_request_tracking(
     assert protocol._timed_out_requests[unit_id_1] is pdu1
 
     # Request 2 succeeds -> stored in _timed_out_requests[unit_id_2] (if timed out), but unit 1 is kept
+    # The tight timeout was only needed to make request 1 time out; request 2
+    # must not race the wall clock, so give it a generous timeout.
+    protocol.timeout = 10.0
+
     resp2_payload = bytes([unit_id_2, pdu2.function_code, 0x05])
     resp2_frame = resp2_payload + calculate_crc16(resp2_payload)
 
-    async def deliver_resp2() -> None:
-        await asyncio.sleep(0.01)
-        protocol.data_received(resp2_frame)
+    req2_task = asyncio.create_task(protocol.send_and_receive(unit_id_2, pdu2))
+    while protocol._pending_request is None:
+        assert not req2_task.done()
+        await asyncio.sleep(0)
 
-    deliv_task = asyncio.create_task(deliver_resp2())
-    res2 = await protocol.send_and_receive(unit_id_2, pdu2)
-    await deliv_task
+    protocol.data_received(resp2_frame)
+
+    res2 = await req2_task
 
     assert res2[0] == "decoded"
     # Unit 1 timed-out request is still tracked safely!
@@ -918,7 +923,7 @@ async def test_frame_exceeds_max_size(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that frame size exceeding max raises RTUFrameError."""
-    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=0.02)
+    protocol = ModbusRtuProtocol(on_connection_lost=lambda _: None, timeout=10.0)
     protocol.connection_made(mock_transport)
 
     pdu = _DummyPDU()
@@ -1597,19 +1602,22 @@ async def test_delayed_response_after_timeout_is_cleanly_discarded_using_old_pdu
     assert unit_id not in protocol._timed_out_requests
 
     # Step 3: Subsequent request should work cleanly without any stale interference
+    # The tight timeout was only needed to make request 1 time out; request 2
+    # must not race the wall clock, so give it a generous timeout.
+    protocol.timeout = 10.0
+
     pdu2 = _DummyPDU()
     new_payload = bytes([unit_id, pdu2.function_code, 0x09])
     new_response = new_payload + calculate_crc16(new_payload)
 
-    async def simulate_new_response() -> None:
-        await asyncio.sleep(0.01)
-        protocol.data_received(new_response)
-
     task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
-    resp_task = asyncio.create_task(simulate_new_response())
+    while protocol._pending_request is None:
+        assert not task.done()
+        await asyncio.sleep(0)
+
+    protocol.data_received(new_response)
 
     result = await task
-    await resp_task
 
     assert result == ("decoded", b"\x03\x09")
 
@@ -1726,30 +1734,32 @@ async def test_delayed_response_arriving_during_active_request_different_fc(
     assert protocol._timed_out_requests[unit_id] is pdu1
 
     # Step 2: Request 2 is dispatched (FC 0x06) and is active
+    # The tight timeout was only needed to make request 1 time out; request 2
+    # must not race the wall clock, so give it a generous timeout.
+    protocol.timeout = 10.0
+
     delayed_payload_1 = bytes([unit_id, 0x03, 0xAA])
     delayed_response_1 = delayed_payload_1 + calculate_crc16(delayed_payload_1)
 
     resp_payload_2 = bytes([unit_id, 0x06, 0x11, 0x22])
     response_2 = resp_payload_2 + calculate_crc16(resp_payload_2)
 
-    async def deliver_delayed_then_real_response() -> None:
-        await asyncio.sleep(0.01)
-        # Deliver late response for request 1 first
-        protocol.data_received(delayed_response_1)
-        # Active request should still be pending and not failed
-        assert protocol._pending_request is not None
-        assert not protocol._pending_request.future.done()
-        assert unit_id not in protocol._timed_out_requests
-
-        # Now deliver real response for request 2
-        await asyncio.sleep(0.01)
-        protocol.data_received(response_2)
-
     req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
-    deliv_task = asyncio.create_task(deliver_delayed_then_real_response())
+    while protocol._pending_request is None:
+        assert not req2_task.done()
+        await asyncio.sleep(0)
+
+    # Deliver late response for request 1 first
+    protocol.data_received(delayed_response_1)
+    # Active request should still be pending and not failed
+    assert protocol._pending_request is not None
+    assert not protocol._pending_request.future.done()
+    assert unit_id not in protocol._timed_out_requests
+
+    # Now deliver real response for request 2
+    protocol.data_received(response_2)
 
     result = await req2_task
-    await deliv_task
 
     assert result == ("decoded", b"\x06\x11\x22")
     assert len(protocol._buffer) == 0
@@ -1782,18 +1792,21 @@ async def test_active_request_succeeds_and_clears_stale_timed_out_request(
     assert protocol._timed_out_requests[unit_id] is pdu1
 
     # Request 2 is sent, and its response arrives directly
+    # The tight timeout was only needed to make request 1 time out; request 2
+    # must not race the wall clock, so give it a generous timeout.
+    protocol.timeout = 10.0
+
     resp_payload = bytes([unit_id, pdu2.function_code, 0x55])
     response = resp_payload + calculate_crc16(resp_payload)
 
-    async def deliver_response() -> None:
-        await asyncio.sleep(0.01)
-        protocol.data_received(response)
-
     req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
-    deliv_task = asyncio.create_task(deliver_response())
+    while protocol._pending_request is None:
+        assert not req2_task.done()
+        await asyncio.sleep(0)
+
+    protocol.data_received(response)
 
     result = await req2_task
-    await deliv_task
 
     assert result == ("decoded", b"\x03\x55")
     # Verify stale timed-out request tracking was cleared upon successful delivery
@@ -1831,6 +1844,10 @@ async def test_delayed_exception_response_arriving_during_active_request(
     assert protocol._timed_out_requests[unit_id] is pdu1
 
     # Step 2: Request 2 (FC 0x06) is sent and active
+    # The tight timeout was only needed to make request 1 time out; request 2
+    # must not race the wall clock, so give it a generous timeout.
+    protocol.timeout = 10.0
+
     # Late response for Request 1 is an Exception Response (FC 0x83, Exception Code 0x02)
     delayed_exc_payload = bytes([unit_id, 0x83, 0x02])
     delayed_exc_response = delayed_exc_payload + calculate_crc16(delayed_exc_payload)
@@ -1838,24 +1855,22 @@ async def test_delayed_exception_response_arriving_during_active_request(
     resp_payload_2 = bytes([unit_id, 0x06, 0x11, 0x22])
     response_2 = resp_payload_2 + calculate_crc16(resp_payload_2)
 
-    async def deliver_delayed_exc_then_real_response() -> None:
-        await asyncio.sleep(0.01)
-        # Deliver late exception response for request 1
-        protocol.data_received(delayed_exc_response)
-        # Active request should still be pending (not failed by the delayed exception!)
-        assert protocol._pending_request is not None
-        assert not protocol._pending_request.future.done()
-        assert unit_id not in protocol._timed_out_requests
-
-        # Now deliver real response for request 2
-        await asyncio.sleep(0.01)
-        protocol.data_received(response_2)
-
     req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
-    deliv_task = asyncio.create_task(deliver_delayed_exc_then_real_response())
+    while protocol._pending_request is None:
+        assert not req2_task.done()
+        await asyncio.sleep(0)
+
+    # Deliver late exception response for request 1
+    protocol.data_received(delayed_exc_response)
+    # Active request should still be pending (not failed by the delayed exception!)
+    assert protocol._pending_request is not None
+    assert not protocol._pending_request.future.done()
+    assert unit_id not in protocol._timed_out_requests
+
+    # Now deliver real response for request 2
+    protocol.data_received(response_2)
 
     result = await req2_task
-    await deliv_task
 
     assert result == ("decoded", b"\x06\x11\x22")
     assert len(protocol._buffer) == 0
@@ -1905,39 +1920,41 @@ async def test_delayed_response_in_chunks_during_active_request(
     assert protocol._timed_out_requests[unit_id] is pdu1
 
     # Step 2: Request 2 (FC 0x06) is sent and active
+    # The tight timeout was only needed to make request 1 time out; request 2
+    # must not race the wall clock, so give it a generous timeout.
+    protocol.timeout = 10.0
+
     delayed_payload_1 = bytes([unit_id, 0x03, 0xAA, 0xBB])
     delayed_response_1 = delayed_payload_1 + calculate_crc16(delayed_payload_1)  # 6 bytes
 
     resp_payload_2 = bytes([unit_id, 0x06, 0x11, 0x22])
     response_2 = resp_payload_2 + calculate_crc16(resp_payload_2)
 
-    async def deliver_chunks_then_real_response() -> None:
-        await asyncio.sleep(0.01)
-        # Deliver chunk 1 of late response (first 4 bytes of 6-byte frame)
-        protocol.data_received(delayed_response_1[:4])
-        # Buffer has 4 bytes (>= MIN_RTU_RESPONSE_LENGTH), protocol determines frame length is 6 and waits
-        assert len(protocol._buffer) == 4
-        assert protocol._pending_request is not None
-        assert not protocol._pending_request.future.done()
-        assert unit_id in protocol._timed_out_requests
-
-        # Deliver chunk 2 of late response (remaining 2 bytes)
-        protocol.data_received(delayed_response_1[4:])
-        # Now late response is complete and drained
-        assert len(protocol._buffer) == 0
-        assert protocol._pending_request is not None
-        assert not protocol._pending_request.future.done()
-        assert unit_id not in protocol._timed_out_requests
-
-        # Now deliver real response for request 2
-        await asyncio.sleep(0.01)
-        protocol.data_received(response_2)
-
     req2_task = asyncio.create_task(protocol.send_and_receive(unit_id, pdu2))
-    deliv_task = asyncio.create_task(deliver_chunks_then_real_response())
+    while protocol._pending_request is None:
+        assert not req2_task.done()
+        await asyncio.sleep(0)
+
+    # Deliver chunk 1 of late response (first 4 bytes of 6-byte frame)
+    protocol.data_received(delayed_response_1[:4])
+    # Buffer has 4 bytes (>= MIN_RTU_RESPONSE_LENGTH), protocol determines frame length is 6 and waits
+    assert len(protocol._buffer) == 4
+    assert protocol._pending_request is not None
+    assert not protocol._pending_request.future.done()
+    assert unit_id in protocol._timed_out_requests
+
+    # Deliver chunk 2 of late response (remaining 2 bytes)
+    protocol.data_received(delayed_response_1[4:])
+    # Now late response is complete and drained
+    assert len(protocol._buffer) == 0
+    assert protocol._pending_request is not None
+    assert not protocol._pending_request.future.done()
+    assert unit_id not in protocol._timed_out_requests
+
+    # Now deliver real response for request 2
+    protocol.data_received(response_2)
 
     result = await req2_task
-    await deliv_task
 
     assert result == ("decoded", b"\x06\x11\x22")
     assert len(protocol._buffer) == 0

--- a/tests/transport/test_async_tcp.py
+++ b/tests/transport/test_async_tcp.py
@@ -330,7 +330,7 @@ async def test_protocol_send_and_receive_invalid_protocol_id_followed_by_correct
 ) -> None:
     """Test protocol validates protocol ID."""
     caplog.set_level("DEBUG", logger="tmodbus.transport.async_tcp")
-    protocol = ModbusTcpProtocol(on_connection_lost=lambda _: None, timeout=0.02)
+    protocol = ModbusTcpProtocol(on_connection_lost=lambda _: None, timeout=10.0)
     mock_transport = MagicMock(spec=asyncio.WriteTransport)
     mock_transport.is_closing.return_value = False
     protocol.connection_made(mock_transport)


### PR DESCRIPTION
# Proposed Changes

Removes the remaining wall-clock races in the transport tests (~50% failure rate per `test_async_ascii.py` run on a loaded machine). The mechanism: a tight `wait_for` timeout races a deliver task's real `asyncio.sleep` — after an event-loop stall, the timeout callback runs before the rescheduled deliver task and cancels the future.

Applies #124's recipe to the 10 remaining tests with that construction (4 ASCII, 6 RTU): generous timeout for the request under test, deliver synchronously after registration. Three more tests get a one-line timeout bump, and the ASCII interframe-gap test re-primes its clock. Every test still drives the same code path; only scheduling changed.

Stability: 10/10 clean loops on both serial test files after the change.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
